### PR TITLE
Rename libsampler_base to libldmsd_sampler_base

### DIFF
--- a/ldms/src/sampler/Makefile.am
+++ b/ldms/src/sampler/Makefile.am
@@ -12,10 +12,10 @@ AM_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@
 CORE_LIBADD = $(CORE)/libldms.la @LDFLAGS_GETTIME@ -lovis_util
 
 BASE_SRC=sampler_base.c sampler_base.h
-libsampler_base_la_SOURCES = $(BASE_SRC)
-libsampler_base_la_LIBADD = $(CORE_LIBADD)
-lib_LTLIBRARIES += libsampler_base.la
-BASE_LIBLA = libsampler_base.la
+libldmsd_sampler_base_la_SOURCES = $(BASE_SRC)
+libldmsd_sampler_base_la_LIBADD = $(CORE_LIBADD)
+lib_LTLIBRARIES += libldmsd_sampler_base.la
+BASE_LIBLA = libldmsd_sampler_base.la
 
 COMMON_LIBADD = $(BASE_LIBLA) $(CORE_LIBADD)
 

--- a/ldms/src/sampler/appinfo_lib/Makefile.am
+++ b/ldms/src/sampler/appinfo_lib/Makefile.am
@@ -8,7 +8,7 @@ AM_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@
 
 COMMON_LIBADD = $(CORE)/libldms.la \
 		@LDFLAGS_GETTIME@ -lpthread -lovis_util -lcoll \
-		../libsampler_base.la
+		../libldmsd_sampler_base.la
 
 libappinfocl_la_SOURCES = ldms_appinfo.c ldms_appinfo.h ldms_appinfo_shm.h
 libappinfocl_la_LIBADD = $(COMMON_LIBADD)

--- a/ldms/src/sampler/aries_mmr/Makefile.am
+++ b/ldms/src/sampler/aries_mmr/Makefile.am
@@ -6,7 +6,7 @@ CORE = ../../core
 AM_CFLAGS = -I$(srcdir)/$(CORE) -I$(top_srcdir) -I../.. @OVIS_LIB_INCDIR_FLAG@ -I$(srcdir)/../../ldmsd
 AM_LDFLAGS = @OVIS_LIB_LIBDIR_FLAG@
 BASE_INC = $(srcdir)/../
-BASE_LIBADD = ../libsampler_base.la
+BASE_LIBADD = ../libldmsd_sampler_base.la
 
 if ENABLE_ARIES_MMR
 # ARIES_LIBGPCD_INCDIR=@ARIES_LIBGPCD_INCDIR@

--- a/ldms/src/sampler/cray_system_sampler/Makefile.am
+++ b/ldms/src/sampler/cray_system_sampler/Makefile.am
@@ -5,7 +5,7 @@ CORE = ../../core
 AM_CFLAGS = -I$(srcdir)/$(CORE) -I$(top_srcdir) -I../.. @OVIS_LIB_INCDIR_FLAG@ -I$(srcdir)/../../ldmsd
 AM_LDFLAGS = @OVIS_LIB_LIBDIR_FLAG@
 BASE_INC = $(srcdir)/../
-BASE_LIBADD = ../libsampler_base.la
+BASE_LIBADD = ../libldmsd_sampler_base.la
 
 COMMON_LIBADD = $(BASE_LIBADD) $(CORE)/libldms.la \
 		@LDFLAGS_GETTIME@ -lovis_util -lcoll

--- a/ldms/src/sampler/dstat/Makefile.am
+++ b/ldms/src/sampler/dstat/Makefile.am
@@ -9,7 +9,7 @@ AM_CFLAGS = -I$(srcdir)/$(CORE) -I$(top_srcdir) -I../.. @OVIS_LIB_INCDIR_FLAG@ \
 	    -I$(srcdir)/../../ldmsd
 AM_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@
 
-BASE_LIBADD = ../libsampler_base.la
+BASE_LIBADD = ../libldmsd_sampler_base.la
 COMMON_LIBADD = $(CORE)/libldms.la libparse_stat.la \
 	@LDFLAGS_GETTIME@ -lovis_util -lcoll
 

--- a/ldms/src/sampler/examples/array_example/Makefile.am
+++ b/ldms/src/sampler/examples/array_example/Makefile.am
@@ -9,7 +9,7 @@ AM_CFLAGS = -I$(srcdir)/$(CORE) -I$(top_srcdir) -I../../.. @OVIS_LIB_INCDIR_FLAG
 		-I$(srcdir)/../../../ldmsd
 AM_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@
 
-BASE_LIBADD = ../../libsampler_base.la
+BASE_LIBADD = ../../libldmsd_sampler_base.la
 COMMON_LIBADD = $(CORE)/libldms.la \
 	    @LDFLAGS_GETTIME@ -lovis_util -lcoll
 

--- a/ldms/src/sampler/examples/synthetic/Makefile.am
+++ b/ldms/src/sampler/examples/synthetic/Makefile.am
@@ -9,7 +9,7 @@ AM_CFLAGS = -I$(srcdir)/$(CORE) -I$(top_srcdir) -I../../.. @OVIS_LIB_INCDIR_FLAG
 		-I$(srcdir)/../../../ldmsd
 AM_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@
 
-BASE_LIBADD = ../../libsampler_base.la
+BASE_LIBADD = ../../libldmsd_sampler_base.la
 COMMON_LIBADD = $(CORE)/libldms.la \
 	    @LDFLAGS_GETTIME@ -lovis_util -lcoll
 

--- a/ldms/src/sampler/examples/test_sampler/Makefile.am
+++ b/ldms/src/sampler/examples/test_sampler/Makefile.am
@@ -9,7 +9,7 @@ AM_CFLAGS = -I$(srcdir)/$(CORE) -I$(top_srcdir) -I../../.. @OVIS_LIB_INCDIR_FLAG
 		-I$(srcdir)/../../../ldmsd
 AM_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@
 
-BASE_LIBADD = ../../libsampler_base.la
+BASE_LIBADD = ../../libldmsd_sampler_base.la
 COMMON_LIBADD = $(CORE)/libldms.la \
 	    @LDFLAGS_GETTIME@ -lovis_util -lcoll
 

--- a/ldms/src/sampler/filesingle/Makefile.am
+++ b/ldms/src/sampler/filesingle/Makefile.am
@@ -11,7 +11,7 @@ AM_CFLAGS = -I$(srcdir)/$(CORE) -I$(top_srcdir) -I../.. @OVIS_LIB_INCDIR_FLAG@ \
 	    -I$(srcdir)/../../ldmsd
 AM_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@
 
-BASE_LIBLA = ../libsampler_base.la
+BASE_LIBLA = ../libldmsd_sampler_base.la
 COMMON_LIBADD = $(CORE)/libldms.la @LDFLAGS_GETTIME@ -lovis_util -lcoll
 
 if ENABLE_FILESINGLE

--- a/ldms/src/sampler/kgnilnd/Makefile.am
+++ b/ldms/src/sampler/kgnilnd/Makefile.am
@@ -11,7 +11,7 @@ AM_CFLAGS = -I$(srcdir)/$(CORE) -I$(top_srcdir) -I../.. @OVIS_LIB_INCDIR_FLAG@ \
 	    -I$(srcdir)/../../ldmsd
 AM_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@
 
-BASE_LIBADD = ../libsampler_base.la
+BASE_LIBADD = ../libldmsd_sampler_base.la
 COMMON_LIBADD = $(CORE)/libldms.la \
             @LDFLAGS_GETTIME@ -lovis_util -lcoll
 

--- a/ldms/src/sampler/llnl/Makefile.am
+++ b/ldms/src/sampler/llnl/Makefile.am
@@ -8,7 +8,7 @@ AM_CFLAGS = -I$(srcdir)/$(CORE) -I$(top_srcdir) -I../.. @OVIS_LIB_INCDIR_FLAG@ \
 AM_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@
 
 # common libadd for llnl samplers
-BASE_LIBADD = ../libsampler_base.la
+BASE_LIBADD = ../libldmsd_sampler_base.la
 COMMON_LIBADD = $(CORE)/libldms.la \
 		@LDFLAGS_GETTIME@ -lovis_util -lcoll
 

--- a/ldms/src/sampler/lustre/Makefile.am
+++ b/ldms/src/sampler/lustre/Makefile.am
@@ -18,7 +18,7 @@ pkglib_LTLIBRARIES += liblustre_sampler.la
 # common libadd for all subclass of lustre_sampler
 COMMON_LIBADD = $(CORE)/libldms.la  liblustre_sampler.la \
 		@LDFLAGS_GETTIME@ -lovis_util -lcoll \
-		../libsampler_base.la
+		../libldmsd_sampler_base.la
 
 #liblustre2_mds
 liblustre2_mds_la_SOURCES = lustre2_mds.c

--- a/ldms/src/sampler/meminfo/Makefile.am
+++ b/ldms/src/sampler/meminfo/Makefile.am
@@ -10,7 +10,7 @@ AM_CFLAGS = -I$(srcdir)/$(CORE) -I$(top_srcdir) -I../.. @OVIS_LIB_INCDIR_FLAG@ \
 	    -I$(srcdir)/../../ldmsd
 AM_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@
 
-BASE_LIBADD = ../libsampler_base.la
+BASE_LIBADD = ../libldmsd_sampler_base.la
 COMMON_LIBADD = $(CORE)/libldms.la \
             @LDFLAGS_GETTIME@ -lovis_util -lcoll
 

--- a/ldms/src/sampler/procinterrupts/Makefile.am
+++ b/ldms/src/sampler/procinterrupts/Makefile.am
@@ -10,7 +10,7 @@ AM_CFLAGS = -I$(srcdir)/$(CORE) -I$(top_srcdir) -I../.. @OVIS_LIB_INCDIR_FLAG@ \
 	    -I$(srcdir)/../../ldmsd
 AM_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@
 
-BASE_LIBADD = ../libsampler_base.la
+BASE_LIBADD = ../libldmsd_sampler_base.la
 COMMON_LIBADD = $(CORE)/libldms.la \
             @LDFLAGS_GETTIME@ -lovis_util -lcoll
 

--- a/ldms/src/sampler/procstat/Makefile.am
+++ b/ldms/src/sampler/procstat/Makefile.am
@@ -10,7 +10,7 @@ AM_CFLAGS = -I$(srcdir)/$(CORE) -I$(top_srcdir) -I../.. @OVIS_LIB_INCDIR_FLAG@ \
 	    -I$(srcdir)/../../ldmsd
 AM_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@
 
-BASE_LIBADD = ../libsampler_base.la
+BASE_LIBADD = ../libldmsd_sampler_base.la
 COMMON_LIBADD = $(CORE)/libldms.la \
             @LDFLAGS_GETTIME@ -lovis_util -lcoll
 

--- a/ldms/src/sampler/vmstat/Makefile.am
+++ b/ldms/src/sampler/vmstat/Makefile.am
@@ -10,7 +10,7 @@ AM_CFLAGS = -I$(srcdir)/$(CORE) -I$(top_srcdir) -I../.. @OVIS_LIB_INCDIR_FLAG@ \
 	    -I$(srcdir)/../../ldmsd
 AM_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@
 
-BASE_LIBADD = ../libsampler_base.la
+BASE_LIBADD = ../libldmsd_sampler_base.la
 COMMON_LIBADD = $(CORE)/libldms.la \
             @LDFLAGS_GETTIME@ -lovis_util -lcoll
 


### PR DESCRIPTION
Rename libsampler_base to libldmsd_sampler_base to reduce installed namespace polution.

Part of issue #71.