### PR TITLE
Move pedigree files

### DIFF
--- a/automake/pedigree.am
+++ b/automake/pedigree.am
@@ -1,24 +1,21 @@
-install-exec-local:
+install-pedigree:
 	mkdir -p `dirname $(PEDIGREE)` ; \
 	if [ -f $(PEDIGREE) ]; then \
 		rm -f $(PEDIGREE); \
 	fi ; \
-	echo '#!/bin/bash' > $(PEDIGREE) ; \
-	echo echo commit-id: "$(OVIS_GIT_LONG)" >> $(PEDIGREE) ; \
-	echo echo package: "$(PACKAGE_STRING)" >> $(PEDIGREE) ; \
-	echo echo questions to: "$(PACKAGE_BUGREPORT)" >> $(PEDIGREE) ; \
-	echo echo source location: "$(abs_top_srcdir)" >> $(PEDIGREE) ; \
-	echo echo build location: "$(abs_top_builddir)" >> $(PEDIGREE) ; \
-	echo echo compile hostname: "$$HOSTNAME" >> $(PEDIGREE) ; \
-	echo echo compile cpu: "`uname -p`" >> $(PEDIGREE) ; \
-	echo echo compile os: "`uname -o`" >> $(PEDIGREE) ; \
-	echo echo configure args: "\"$(ac_configure_args)\"" >> $(PEDIGREE) ; \
-	echo 'if [ "$$1" == "--stat" ] ; then ' >> $(PEDIGREE) ; \
-	echo echo "------ git status ------" >> $(PEDIGREE) ; \
-	echo echo "\"`cd $(abs_top_srcdir) && git status -suno .`\"" >> $(PEDIGREE) ; \
-	echo echo "------------------------" >> $(PEDIGREE) ; \
-	echo fi >> $(PEDIGREE); \
-	chmod 755 $(PEDIGREE) ;
+	echo commit-id: "$(OVIS_GIT_LONG)" >> $(PEDIGREE) ; \
+	echo package: "$(PACKAGE_STRING)" >> $(PEDIGREE) ; \
+	echo questions to: "$(PACKAGE_BUGREPORT)" >> $(PEDIGREE) ; \
+	echo source location: "$(abs_top_srcdir)" >> $(PEDIGREE) ; \
+	echo build location: "$(abs_top_builddir)" >> $(PEDIGREE) ; \
+	echo compile hostname: "$$HOSTNAME" >> $(PEDIGREE) ; \
+	echo compile cpu: "`uname -p`" >> $(PEDIGREE) ; \
+	echo compile os: "`uname -o`" >> $(PEDIGREE) ; \
+	echo configure args: "\"$(ac_configure_args)\"" >> $(PEDIGREE) ; \
+	echo "------ git status ------" >> $(PEDIGREE) ; \
+	cd $(abs_top_srcdir) && git status -suno . >> $(PEDIGREE) ; \
+	echo "------------------------" >> $(PEDIGREE) ; \
+	chmod 444 $(PEDIGREE) ;
 
 SHA.txt:
 	echo "$(OVIS_GIT_LONG)" > SHA.txt

--- a/ldms/Makefile.am
+++ b/ldms/Makefile.am
@@ -75,14 +75,14 @@ endif
 
 .PHONY: $(PHONY_doc) $(PHONY_dox)
 
-install-data-local: install-dox
+PEDIGREE = $(DESTDIR)$(docdir)$(OPV)/ldms-pedigree.txt
+include $(top_srcdir)/pedigree.am
+
+install-data-local: install-dox install-pedigree
 	$(MKDIR_P) $(DESTDIR)$(docdir)$(OPV)
 	for f in AUTHORS README COPYING ChangeLog ; do \
 		$(INSTALL_DATA) ${srcdir}/$$f $(DESTDIR)$(docdir)$(OPV); \
 	done
-
-PEDIGREE = $(DESTDIR)/$(bindir)/ldms-pedigree
-include $(top_srcdir)/pedigree.am
 
 uninstall-hook:
 	rm $(PEDIGREE)

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -13,11 +13,7 @@ OVIS_LIB = $(PACKAGE_NAME)-$(PACKAGE_VERSION)
 OVIS_LIB_TARBALL = $(OVIS_LIB).tar.gz
 OPV=-$(PACKAGE_VERSION)
 
-PHONY_doc = doxygen doc install-doc
-
-if ENABLE_DOC
-install-data-local: install-doc
-endif
+PHONY_doc = doxygen doc
 
 if ENABLE_DOC_HTML
 DOCDEPS = $(top_srcdir)/src/*/*.c \
@@ -46,14 +42,14 @@ else
 install-dox:
 endif
 
-install-doc: install-dox
+PEDIGREE = $(DESTDIR)$(docdir)$(OPV)/ovis-lib-pedigree.txt
+include $(srcdir)/pedigree.am
+
+install-data-local: install-dox install-pedigree
 	$(MKDIR_P) $(DESTDIR)$(docdir)$(OPV)
 	for f in README COPYING ChangeLog COPYING; do \
 		$(INSTALL_DATA) ${srcdir}/$$f $(DESTDIR)$(docdir)$(OPV); \
 	done
-
-PEDIGREE = $(DESTDIR)/$(bindir)/lib-pedigree
-include $(srcdir)/pedigree.am
 
 uninstall-hook:
 	rm $(PEDIGREE)


### PR DESCRIPTION
Change the pedigree scripts into text files.  Move the pedigree
files' locations to docdir rather than bindir.

It looks like ovis/lib's doc build was broken, so that is tweaked
as well to allow the ovis lib pedigree file to go in the ovis-lib
doc directory.

Part of issue #71.