### PR TITLE
Add ifdef check for new EHWPOISON errno

### DIFF
--- a/lib/src/ovis_util/util.c
+++ b/lib/src/ovis_util/util.c
@@ -932,7 +932,9 @@ const char* ovis_errno_abbvr(int e)
 		[EOWNERDEAD]       =  "EOWNERDEAD",
 		[ENOTRECOVERABLE]  =  "ENOTRECOVERABLE",
 		[ERFKILL]          =  "ERFKILL",
+#ifdef EHWPOISON
 		[EHWPOISON]        =  "EHWPOISON",
+#endif
 	};
 	if (e < sizeof(estr)/sizeof(*estr) && estr[e]) {
 		return estr[e];


### PR DESCRIPTION
The older errno.h header files do not have this errno. Protect this definition with an ifdef to support the build.