### PR TITLE
FIX EXTRA_DIST autogen warnings

### DIFF
--- a/ldms/src/contrib/sampler/tutorial/Makefile.am
+++ b/ldms/src/contrib/sampler/tutorial/Makefile.am
@@ -26,4 +26,4 @@ libtutorial_sampler_la_CFLAGS = $(AM_CFLAGS)
 pkglib_LTLIBRARIES += libtutorial_sampler.la
 dist_man7_MANS += Plugin_tutorial_sampler.man
 endif
-EXTRA_DIST = Plugin_tutorial_sampler.man
+EXTRA_DIST += Plugin_tutorial_sampler.man

--- a/ldms/src/sampler/filesingle/Makefile.am
+++ b/ldms/src/sampler/filesingle/Makefile.am
@@ -26,7 +26,7 @@ dist_man1_MANS += ldms-sensors-config.man
 TESTS = test_sensors test_lscpu
 endif
 
-EXTRA_DIST = \
+EXTRA_DIST += \
 	Plugin_filesingle.man \
 	ldms-sensors-config.man \
 	test_sensors \


### PR DESCRIPTION
Fix EXTRA_DIST  in filesingle and sampler tutorial for autogen warnings