### PR TITLE
Add reserved field to the metric meta data

### DIFF
--- a/ldms/src/core/ldms_core.h
+++ b/ldms/src/core/ldms_core.h
@@ -98,6 +98,7 @@ typedef struct ldms_value_desc {
 	uint64_t vd_user_data;	/*! User defined meta-data */
 	uint32_t vd_data_offset;/*! Value offset in data (metric) or meta-data (attr) */
 	uint32_t vd_array_count;/*! Number of elements in the array */
+	uint32_t vd_reserved[2];
 	uint8_t vd_type;	/*! The type of the value, enum ldms_value_type */
 	uint8_t vd_flags;	/*! Metric or Attribute */
 #ifdef SWIG


### PR DESCRIPTION
This will allow new features to be added to OVIS 4
without breaking compatability.