### PR TITLE
Add area to ldms_set_hdr for compatible updates

### DIFF
--- a/ldms/src/core/ldms_core.h
+++ b/ldms/src/core/ldms_core.h
@@ -201,6 +201,7 @@ struct ldms_set_hdr {
 	uint32_t gid;           /* GID */
 	uint32_t perm;          /* permission */
 	uint32_t array_card;    /* number of sets in the set array */
+	uint32_t reserved[8];	/* area reserved for compatible core updates */
 	uint32_t dict[OVIS_FLEX];/* The attr/metric dictionary */
 };
 


### PR DESCRIPTION
Reserve an area in the set hdr to accomodate changes
that may affect this structure but still support backward
compatability.