### PR TITLE
Add version string in ldmsd for binary string dump check

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -116,6 +116,9 @@ pthread_mutex_t log_lock = PTHREAD_MUTEX_INITIALIZER;
 size_t max_mem_size;
 char *max_mem_sz_str;
 
+/* NOTE: For determining version by dumping binary string */
+char *_VERSION_STR_ = "LDMSD_VERSION " OVIS_LDMS_VERSION;
+
 mode_t inband_cfg_mask = LDMSD_PERM_FAILOVER_ALLOWED;
 	/* LDMSD_PERM_FAILOVER_INTERNAL will be added in `failover_start`
 	 * command.


### PR DESCRIPTION
`ldmsd -V` shows all the version numbers that we need, but `ldms-test`
has a use case that needs to determine the version of the binary in the
environment that could not execute that binary. This patch will make
"LDMSD_VERSION #.#.#" presents in `ldmsd` and could be check with
`strings /opt/ovis/sbin/ldmsd | grep LDMSD_VERSION`.