### PR TITLE
Markdown link fix

### DIFF
--- a/ldms/README.md
+++ b/ldms/README.md
@@ -27,11 +27,11 @@ For plugin developers, please see
 - [ldmsd-store-dev] for LDMSD Store Plugin
   development.
 
-See [mdtest](ldms/doc/mdtest.md) for a concise instruction on how to write
+See [mdtest](doc/mdtest.md) for a concise instruction on how to write
 a man-sturctured markdown document and add it in `ldms` project.
 
 [LDMS-API]: LDMS.html
-[ldmsd-sampler]: ldms/src/ldmsd/ldmsd-sampler.md
-[ldmsd-aggregator]: ldms/src/ldmsd/ldmsd-aggregator.md
-[ldmsd-sampler-dev]: ldms/src/ldmsd/ldmsd-sampler-dev.md
-[ldmsd-store-dev]: ldms/src/ldmsd/ldmsd-store-dev.md
+[ldmsd-sampler]: src/ldmsd/ldmsd-sampler.md
+[ldmsd-aggregator]: src/ldmsd/ldmsd-aggregator.md
+[ldmsd-sampler-dev]: src/ldmsd/ldmsd-sampler-dev.md
+[ldmsd-store-dev]: src/ldmsd/ldmsd-store-dev.md

--- a/ldms/doc/Doxyfile.in
+++ b/ldms/doc/Doxyfile.in
@@ -952,7 +952,7 @@ INPUT_FILTER           =
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
 # properly processed by doxygen.
 
-FILTER_PATTERNS        =
+FILTER_PATTERNS        = *.md=./ldms/doc/mdlinkfilter.py
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
 # INPUT_FILTER) will also be used to filter the input files that are used for

--- a/ldms/doc/mdlinkfilter.py
+++ b/ldms/doc/mdlinkfilter.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python
+
+import os
+import io
+import re
+import sys
+
+if __name__ != '__main__':
+    raise Exception("This is not a module")
+
+execfile(os.getenv('PYTHONSTARTUP', '/dev/null'))
+
+# inp = sys.stdin.read()
+path = sys.argv[1]
+DIR = os.path.realpath(os.path.dirname(path))
+TOP = os.path.realpath(sys.path[0] + '/../../')
+inp = open(path).read()
+INP = inp
+sio = io.StringIO()
+
+CODE = r'(?P<code>```)'
+LINK_INLINE = r'(?:\[(?P<link_inline>(?:[^]]|\\\])+)\]\((?P<link_inline_url>[^)]+)\))'
+LINK_REF = r'(?:\[(?P<link_ref>[^]]+)\]\[(?P<link_ref_target>[^]]+)\])'
+LINK_ITEM = r'(?:^\[(?P<link_item>[^]]+)\]: (?P<link_item_url>.*)$)'
+RE = CODE + '|' + LINK_INLINE + '|' + LINK_REF + '|' + LINK_ITEM
+
+def alter_link_url(url):
+    if re.match(r'^(?:(?:http|https|file)://|#)', url):
+        return url
+    # url path is relative to current file
+    global DIR, TOP
+    _full_path = os.path.realpath(DIR + '/' + url)
+    if _full_path.startswith(TOP):
+        return _full_path[len(TOP)+1:]
+    return url
+
+_re = re.compile(RE, flags = re.M)
+
+m = _re.search(inp)
+while m:
+    g = m.groupdict()
+    pos = m.start()
+    end = m.end()
+    sio.write(unicode(inp[:pos]))
+    inp = inp[end:]
+    if g['code']:
+        # a code block
+        sio.write(u'```')
+        m = re.search('```', inp, flags = re.M)
+        end = m.end()
+        sio.write(unicode(inp[:end]))
+        inp = inp[end:]
+    if g['link_inline']:
+        g['link_inline_url'] = alter_link_url(g['link_inline_url'])
+        sio.write(u'[{link_inline}]({link_inline_url})'.format(**g))
+    if g['link_ref']:
+        sio.write(u'[{link_ref}][{link_ref_target}]'.format(**g))
+    if g['link_item']:
+        g['link_item_url'] = alter_link_url(g['link_item_url'])
+        sio.write(u'[{link_item}]: {link_item_url}'.format(**g))
+    m = _re.search(inp)
+sio.write(unicode(inp))
+
+print sio.getvalue()

--- a/ldms/doc/mdtest.md
+++ b/ldms/doc/mdtest.md
@@ -84,7 +84,7 @@ Note that the doxygen-generated man output file name is `md_` and a path to the
 file that every `/` is replaced by `_`. For example `ldms/doc/mdtest.md` will be
 `md_ldms_doc_mdtest.3`.
 
-See [ldms/doc/Makefile.am](ldms/doc/Makefile.am) in the source tree for more
+See [ldms/doc/Makefile.am](Makefile.am) in the source tree for more
 information.
 
 
@@ -126,7 +126,7 @@ HTML. doxygen man does not work because doxygen turns `<i>...</i>` into
 `\fI...\fP` (requesting italic style ONLY then swich back to previous style),
 and `<b>...</b>` into `\fB...\fP` (requesting bold style ONLY and switch back to
 previous style). The bold-italic above works because of an relatively-easy fix
-by [ldms/doc/mddoxymanfix.sh](ldms/doc/mddoxymanfix.sh).
+by [ldms/doc/mddoxymanfix.sh](mddoxymanfix.sh).
 
 
 Section Link
@@ -136,9 +136,9 @@ See [SEE ALSO](#see-also). This works on gitlab.
 
 Doxygen HTML doesn't automatically generate the header anchors. Hence, the link
 won't work right away. It will display a link, but the link doesn't work. A work
-around is to add a `<div id="#see-also"></div>` right under [SEE
+around is to add a `<span id="#see-also"></span>` right under [SEE
 ALSO](#see-also) section. This doesn't seem to interfere with the automatically
-generated anchors by gitlab.
+generated anchors by gitlab and github.
 
 Doxygen MAN display the link in BOLD after a post-processing by
 `mddoxymanfix.sh`.
@@ -222,7 +222,7 @@ admin@ogc.us
 
 Refers to [H2](#h2)
 
-Refers to another page [ldmsd-sampler](ldms/src/ldmsd/ldmsd-sampler.md)(7)
+Refers to another page [ldmsd-sampler](../src/ldmsd/ldmsd-sampler.md)(7)
 
 
 HEADER TESTING (H1)
@@ -231,7 +231,7 @@ Under H1
 
 H2
 --
-<div id="h2"></div>
+<span id="h2"></span>
 Under H2
 
 H2 is a subsection in doxygen MAN output.
@@ -259,7 +259,7 @@ H6 is also a subsection in doxygen MAN output (same level as H2).
 
 SEE ALSO
 ========
-<div id="see-also"></div>
+<span id="see-also"></span>
 **ldmsd**(1)
-[ldmsd-sampler](ldms/src/ldmsd/ldmsd-sampler.md)(7)
-[ldmsd-aggregator](ldms/src/ldmsd/ldmsd-aggregator.md)(7)
+[ldmsd-sampler](../src/ldmsd/ldmsd-sampler.md)(7)
+[ldmsd-aggregator](../src/ldmsd/ldmsd-aggregator.md)(7)

--- a/ldms/src/ldmsd/ldmsd-aggregator.md
+++ b/ldms/src/ldmsd/ldmsd-aggregator.md
@@ -179,4 +179,4 @@ SEE ALSO
 ========
 
 **ldmsd**(1)
-[ldmsd-sampler](ldms/src/ldmsd/ldmsd-sampler.md)(7)
+[ldmsd-sampler](ldmsd-sampler.md)(7)

--- a/ldms/src/ldmsd/ldmsd-sampler-dev.md
+++ b/ldms/src/ldmsd/ldmsd-sampler-dev.md
@@ -119,7 +119,7 @@ implement an LDMSD sampler plugin in the following subsections:
 
 Preparation
 -----------
-<div id="preparation"></div>
+<span id="preparation"></span>
 
 This step is for developing a sampler plugin in ovis development tree
 (recommended). If you are developing a plugin outside of ovis development tree,
@@ -204,7 +204,7 @@ endif
 
 Conventions
 -----------
-<div id="conventions"></div>
+<span id="conventions"></span>
 
 **Functions** of the plugin are `static`, except for `new()` function. The name
 of the plugin functions are preferably prefixed with plugin name for
@@ -216,7 +216,7 @@ The name of the **extended instance** structure is preferably `struct
 
 Extending Plugin Instance
 -------------------------
-<div id="extending-plugin-instance"></div>
+<span id="extending-plugin-instance"></span>
 
 To extend a sample plugin instance, simply define a new structure with `struct
 ldmsd_plugin_inst_s` as the first member. It is conventional to name the element
@@ -238,7 +238,7 @@ struct thermal_inst_s {
 
 Creating an Instance
 --------------------
-<div id="creating-an-instance"></div>
+<span id="creating-an-instance"></span>
 
 The sampler plugin implementation must implement `ldmsd_plugin_inst_t new()`
 function. This function is called by `ldmsd` when it needs to create an instance
@@ -289,7 +289,7 @@ after `new()` returned.
 
 Help and Description
 --------------------
-<div id="help-and-description"></div>
+<span id="help-and-description"></span>
 
 The `ldmsd_plugin_inst_s.desc()` interface is for a short description of the
 plugin, and `ldmsd_plugin_inst_s.help()` interface is for a long help text
@@ -319,7 +319,7 @@ static const char *thermal_help(ldmsd_plugin_inst_t pi)
 
 Initialization
 --------------
-<div id="initialization"></div>
+<span id="initialization"></span>
 
 After the plugin instance is created by `new()`, and `ldmsd` successfully link
 it to a copy of `ldmsd_sampler_type_s`, `ldmsd_plugin_inst_s.init()` is called
@@ -349,7 +349,7 @@ static int thermal_init(ldmsd_plugin_inst_t pi)
 
 Sampler APIs
 ------------
-<div id="sampler-apis"></div>
+<span id="sampler-apis"></span>
 
 The APIs in `ldmsd_sampler_type_s` are for `ldmsd` to communicate to the sampler
 plugin instance (e.g. tell plugin instance to populate data set), and for
@@ -485,7 +485,7 @@ thermal_update_set(ldmsd_plugin_inst_t pi, ldms_set_t set, void *ctxt)
 
 Config
 ------
-<div id="config"></div>
+<span id="config"></span>
 
 After `new()` and `ldmsd_plugin_inst_s.init()` (corresponding to the user's
 `load` command), `ldmsd_plugin_inst_s.config()` is called when the user gave
@@ -568,7 +568,7 @@ thermal_config(ldmsd_plugin_inst_t pi, json_entity_t json,
 
 Createing a Schema and a Set
 ----------------------------
-<div id="creating-a-schema-and-a-set"></div>
+<span id="creating-a-schema-and-a-set"></span>
 
 An LDMS set of the sampler plugin should be created by
 `ldmsd_sampler_type_s.create_set()` API, with a schema created from
@@ -605,7 +605,7 @@ thermal_update_schema(ldmsd_plugin_inst_t pi, ldms_schema_t sch)
 
 Sample
 ------
-<div id="sample"></div>
+<span id="sample"></span>
 
 If a sampler policy (see `smplr` in [ldmsd-sampler][ldmsd-sampler]) is setup and
 associates with the sampler plugin instance, the `ldmsd_sampler_type_s.sample()`
@@ -646,7 +646,7 @@ thermal_update_set(ldmsd_plugin_inst_t pi, ldms_set_t set, void *ctxt)
 
 Deletion of Sampler Plugin Instance
 -----------------------------------
-<div id="delete"></div>
+<span id="delete"></span>
 
 A plugin instance can be deleted upon user request (`term` command). The
 `ldmsd_plugin_inst_s.del()` is called to let the plugin implementation clear
@@ -1020,6 +1020,6 @@ SEE ALSO
 [ldmsd-store-dev][ldmsd-store-dev](7)
 
 
-[ldmsd-sampler]: ldms/src/ldmsd/ldmsd-sampler.md
-[ldmsd-store-dev]: ldms/src/ldmsd/ldmsd-store-dev.md
-[json_util.h]: lib/src/json/json_util.h
+[ldmsd-sampler]: ldmsd-sampler.md
+[ldmsd-store-dev]: ldmsd-store-dev.md
+[json_util.h]: ../../../lib/src/json/json_util.h

--- a/ldms/src/ldmsd/ldmsd-sampler.md
+++ b/ldms/src/ldmsd/ldmsd-sampler.md
@@ -217,4 +217,4 @@ SEE ALSO
 
 **ldmsd**(1) [ldmsd-aggregator][ldmsd-aggregator](7)
 
-[ldmsd-aggregator]: ldms/src/ldmsd/ldmsd-aggregator.md
+[ldmsd-aggregator]: ldmsd-aggregator.md

--- a/ldms/src/ldmsd/ldmsd-store-dev.md
+++ b/ldms/src/ldmsd/ldmsd-store-dev.md
@@ -135,7 +135,7 @@ implement a storage plugin for LDMS in the following subsections.
 
 Preparation
 ------------
-<div id="preparation"></div>
+<span id="preparation"></span>
 
 This step is for developing a storage plugin in ovis development tree
 (recommended). If you are developing a plugin outside of ovis development tree,
@@ -221,7 +221,7 @@ development.
 
 Conventions
 -----------
-<div id="conventions"></div>
+<span id="conventions"></span>
 
 **Functions** of the plugin are `static`, except for `new()` function. The name
 of the plugin functions are preferably prefixed with plugin name for
@@ -233,7 +233,7 @@ The name of the **extended instance** structure is preferably `struct
 
 Extending Plugin Instance
 -------------------------
-<div id="extending-plugin-instance"></div>
+<span id="extending-plugin-instance"></span>
 
 To extend a sample plugin instance, simply define a new structure with `struct
 ldmsd_plugin_inst_s` as the first member. It is conventional to name the element
@@ -255,7 +255,7 @@ struct plaintext_inst_s {
 
 Creating an Instance
 --------------------
-<div id="creating-an-instance"></div>
+<span id="creating-an-instance"></span>
 
 The storage plugin implementation must implement `ldmsd_plugin_inst_t new()`
 function. This function is called by `ldmsd` when it needs to create an instance
@@ -303,7 +303,7 @@ after `new()` returned.
 
 Help and Description
 --------------------
-<div id="help-and-description"></div>
+<span id="help-and-description"></span>
 
 The `ldmsd_plugin_inst_s.desc()` interface is for a short description of the
 plugin, and `ldmsd_plugin_inst_s.help()` interface is for a long help text
@@ -335,7 +335,7 @@ static const char *plaintext_help(ldmsd_plugin_inst_t pi)
 
 Initialization
 --------------
-<div id="initialization"></div>
+<span id="initialization"></span>
 
 After the plugin instance is created by `new()`, and `ldmsd` successfully link
 it to a copy of `ldmsd_store_type_s`, `ldmsd_plugin_inst_s.init()` is called to
@@ -366,7 +366,7 @@ static int plaintext_init(ldmsd_plugin_inst_t pi)
 
 Config
 ------
-<div id="config"></div>
+<span id="config"></span>
 
 After `new()` and `ldmsd_plugin_inst_s.init()` (corresponding to the user's
 `load` command), `ldmsd_plugin_inst_s.config()` is called when the user gave
@@ -421,7 +421,7 @@ plaintext_config(ldmsd_plugin_inst_t pi, json_entity_t json,
 
 Store APIs
 ----------
-<div id="store-apis"></div>
+<span id="store-apis"></span>
 
 `ldmsd` handle data storage business with a storage plugin instance through the
 storage APIs as the following:
@@ -538,7 +538,7 @@ plaintext_store(ldmsd_plugin_inst_t pi, ldms_set_t set, ldmsd_strgp_t strgp)
 
 Deletion of Sampler Plugin Instance
 -----------------------------------
-<div id="delete"></div>
+<span id="delete"></span>
 
 A plugin instance can be deleted upon user request (`term` command, after the
 associated `strgp` has been stopped and removed). The
@@ -984,7 +984,7 @@ SEE ALSO
 [ldmsd-sampler][samp](7)
 
 
-[agg]: ldms/src/ldmsd/ldmsd-aggregator.md
-[samp]: ldms/src/ldmsd/ldmsd-sampler.md
-[samp-dev]: ldms/src/ldmsd/ldmsd-sampler-dev.md
-[json_util.h]: lib/src/json/json_util.h
+[agg]: ldmsd-aggregator.md
+[samp]: ldmsd-sampler.md
+[samp-dev]: ldmsd-sampler-dev.md
+[json_util.h]: ../../../lib/src/json/json_util.h


### PR DESCRIPTION
TLDR; Make internal hyper links in Markdown files work on GitHub, GitLab
and in Doxygen-genarated HTML.

Historically, Doxygen does not understand relative document location in
the Markdown source file. It understands only a path relative to the
doxygen program working directory (which is the top-dir of the project).
GitLab on the other hand understands both document relative paths and
top-dir relative paths. As such, all internal document links in the
Markdown files are relative to the top-dir.

Unfortunately, GitHub only understands relative paths, but not top-dir
relative paths. This breaks document browsing from `README.md` and
`ldms/README.md` on GitHub.

This patch address the problem as follows:
  - Change all internal hyperlink references to be relative to its
    current file.
  - Apply a Doxygen input filter script to expand the relative paths to
    top-dir relative paths.