### PR TITLE
fix missing destdir in install rule of ldmsauth.conf

### DIFF
--- a/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ClusterSecrets/Makefile.am
+++ b/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ClusterSecrets/Makefile.am
@@ -7,6 +7,6 @@ README ldmsauth.conf
 endif
 
 install-data-hook:
-	if test -f $(docdir)/ldmsauth.conf; then \
-		chmod 600 $(docdir)/ldmsauth.conf; \
+	if test -f $(DESTDIR)$(docdir)/ldmsauth.conf; then \
+		chmod 600 $(DESTDIR)$(docdir)/ldmsauth.conf; \
 	fi


### PR DESCRIPTION
the build is broken for genders install in some scenarios and this fixes it.