### PR TITLE
fix reversion of ldmsd lib prefix and merge induced naming

### DIFF
--- a/ldms/src/ldmsd/Makefile.am
+++ b/ldms/src/ldmsd/Makefile.am
@@ -52,7 +52,7 @@ endif
 ldmsctl_SOURCES = ldmsctl.c
 ldmsctl_LDADD = -lldms libldmsd_request.la \
 		-lovis_ctrl -lovis_util -lmmalloc -lcoll -lzap -ljson_util \
-		 -ljson_parser -lm -lpthread @LDFLAGS_GETTIME@ @LDFLAGS_READLINE@
+		-lm -lpthread @LDFLAGS_GETTIME@ @LDFLAGS_READLINE@
 
 ldmsd_sos_init_SOURCES = ldmsd_sos_init.c
 ldmsd_sos_init_CFLAGS = @SOS_INCDIR_FLAG@ $(AM_CFLAGS)

--- a/ldms/src/store/Makefile.am
+++ b/ldms/src/store/Makefile.am
@@ -6,7 +6,7 @@ AM_LDFLAGS = @OVIS_LIB_ABS@
 #COMMON_LIBADD = -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
 AM_CPPFLAGS = $(DBGFLAGS) @OVIS_INCLUDE_ABS@
 
-STORE_LIBADD = -lldms -lplugattr -lcoll -lovis_util
+STORE_LIBADD = -lldms -lldmsd_plugattr -lcoll -lovis_util
 
 ldmsstoreincludedir = $(includedir)/ldms
 ldmsstoreinclude_HEADERS = store_csv_common.h

--- a/ldms/src/store/store_flatfile/Makefile.am
+++ b/ldms/src/store/store_flatfile/Makefile.am
@@ -4,10 +4,10 @@ pkglib_LTLIBRARIES =
 dist_man7_MANS =
 
 AM_LDFLAGS = @OVIS_LIB_ABS@
-#COMMON_LIBADD = -lldms -lplugattr @LDFLAGS_GETTIME@ -lovis_util -lcoll
+#COMMON_LIBADD = -lldms -lldmsd_plugattr @LDFLAGS_GETTIME@ -lovis_util -lcoll
 AM_CPPFLAGS = $(DBGFLAGS) @OVIS_INCLUDE_ABS@
 
-STORE_LIBADD = -lldms -lplugattr -lcoll -lovis_util
+STORE_LIBADD = -lldms -lldmsd_plugattr -lcoll -lovis_util
 
 ldmsstoreincludedir = $(includedir)/ldms
 


### PR DESCRIPTION
This removes incorrect use of libjson_parser (-> libjson_util)
and reverted libldmsd_plugattr name libplugattr appearances.
The occurred in the one_configure change.