### PR TITLE
fix missing ptr deref in string operation.

### DIFF
--- a/ldms/src/sampler/filesingle/filesingle.c
+++ b/ldms/src/sampler/filesingle/filesingle.c
@@ -151,7 +151,7 @@ int parse_single_conf(const char *conf) {
 			goto out; 
 		}
 		char *u = typestr;
-		while (u != '\0') {
+		while (*u != '\0') {
 			*u = toupper(*u);
 			u++;
 		}


### PR DESCRIPTION
fixes potential filesingle config parser array overrun.