### PR TITLE
Json util new uninit return in v4

### DIFF
--- a/lib/src/json/json_util.c
+++ b/lib/src/json/json_util.c
@@ -215,7 +215,7 @@ json_entity_t json_entity_new(enum json_value_e type, ...)
 	double d;
 	char *s;
 	va_list ap;
-	json_entity_t e, name, value;
+	json_entity_t e = NULL, name, value;
 
 	va_start(ap, type);
 	switch (type) {


### PR DESCRIPTION
This patch returns null instead of random stack, and handles the build with -DNDEBUG.

The same problems exist in master; this should be ported to master.