### PR TITLE
Fix wrong `ZAP_LIBPATH`

### DIFF
--- a/lib/etc/ovis/set-ovis-variables.sh.in
+++ b/lib/etc/ovis/set-ovis-variables.sh.in
@@ -14,7 +14,7 @@ _add PYTHONPATH @pythondir@
 export LDMS_AUTH_FILE=@sysconfdir@/ldms/ldmsauth.conf
 
 export LDMSD_PLUGIN_LIBPATH=@libdir@/ovis-ldms
-export ZAP_LIBPATH=@libdir@/ovis-lib
+export ZAP_LIBPATH=@libdir@/ovis-ldms
 
 # for uGNI transport
 # export ZAP_UGNI_PTAG=<your ptag>


### PR DESCRIPTION
`ZAP_LIBPATH` now should point to `<LIB>/ovis-ldms`, not
`<LIB>/ovis-lib`.