### PR TITLE
Multi-domain authentication from master branch

### DIFF
--- a/ldms/man/ldms_authentication.man
+++ b/ldms/man/ldms_authentication.man
@@ -33,6 +33,16 @@ Specifying options to the authentication plugin. This option can be given
 multiple times.
 
 .PP
+\fBauth\fR configuration object has been introduced in \fBldmsd\fR version
+4.3.4. It describes an authentication domain in the configuration file with
+\fBauth_add\fR command. \fBlisten\fR and \fBprdcr_add\fR config commands can
+refer to \fBauth\fR object created by \fBauth_add\fR command to specify the
+authentication domain a listening port or a producer connection belong to. If no
+\fBauth\fR option is specified, \fBlisten\fR and \fBprdcr_add\fR commands fall
+back to use the authentication method specified by \fB-a, -A\fR CLI options
+(which is default to \fBnone\fR).
+
+.PP
 Please consult the manual of the plugin for more details.
 
 
@@ -40,7 +50,7 @@ Please consult the manual of the plugin for more details.
 
 .TP
 .B none
-Authentication will NOT be used.
+Authentication will NOT be used (allow all connections)
 .RB "(see " ldms_auth_none (7)).
 
 .TP

--- a/ldms/man/ldmsd.man
+++ b/ldms/man/ldmsd.man
@@ -125,26 +125,30 @@ Display the usage for named plugin. Special names all, sampler, and store match 
 .SS
 Communication Options:
 .TP
-.BI -x " XPRT" [: PORT ]
+.BI -x " XPRT:PORT"
 .br
 Specifies the transport type to listen on. May be specified more than once for
 multiple transports. The XPRT string is one of 'rdma', 'sock', or 'ugni' (CRAY
-XE/XK/XC).  A transport specific port number is optionally specified following a
-\':', e.g. rdma:10000.
+XE/XK/XC). A transport specific port number must be specified following a \':',
+e.g. rdma:10000.
+
+The listening transports can also be specified in the configuration file using
+\fBlisten\fR command, e.g. `listen xprt=sock port=1234`. Please see
+\fBldmsd_controller\fR(8) section \fBLISTEN COMMAND SYNTAX\fR for more details.
 .TP
 .BI -a " AUTH"
-AUTH is the name of the LDMS Authentication plugin to be used for the
-LDMS connection. Please see
-.BR ldms_authentication (7)
-for more information. If this option is not given, the default is "none" (no
-authentication).
+Specify the default LDMS Authentication method for the LDMS connections in this
+daemon (when the connections do not specify authentication method/domain).
+Please see \fBldms_authentication\fR(7) for more information. If this option is
+not given, the default is "none" (no authentication). Also see
+\fBldmsd_controller\fR(8) section \fBAUTHENTICATION COMMAND SYNTAX\fR for how to
+define an authentication domain.
 .TP
 .BI -A " NAME" = VALUE
 Passing the \fINAME\fR=\fIVALUE\fR option to the LDMS Authentication plugin.
 This command line option can be given multiple times. Please see
-.BR ldms_authentication (7)
-for more information, and consult the plugin manual page for plugin-specific
-options.
+\fBldms_authentication\fR(7) for more information, and consult the plugin manual
+page for plugin-specific options.
 
 
 .SS

--- a/ldms/man/ldmsd_controller.man
+++ b/ldms/man/ldmsd_controller.man
@@ -177,6 +177,7 @@ collection will be synchronous; if the offset is not specified,
 collection will be asynchronous. Optional.
 .RE
 
+
 .SS Stop a sampler plugin
 .BR stop
 attr=<value>
@@ -187,6 +188,60 @@ attr=<value>
 The plugin name.
 .RE
 
+.SH AUTHENTICATION COMMAND SYNTAX
+.SS  Add an authentication domain
+.B auth_add
+\fBname\fR=\fINAME\fR
+\fBplugin\fR=\fIPLUGIN\fR
+[ ... \fIPLUGIN ATTRIBUTES\fR ... ]
+.RS
+.TP
+\fBname\fR=\fINAME\fR
+.br
+The name of the authentication domain. This is the name referred to by
+\fBlisten\fR and \fBprdcr_add\fR commands.
+.TP
+\fBplugin\fR=\fInone\fR|\fIovis\fR|\fImunge\fR
+.br
+The LDMS Authentication Plugin for this domain.
+.TP
+[ ... \fIPLUGIN ATTRIBUTES\fR ... ]
+.br
+Arbitrary plugin attributes. Please consult the manual of the authentication
+plugin for more information.
+.RE
+
+
+.SH LISTEN COMMAND SYNTAX
+.SS  Instruct ldmsd to listen to a port
+.B listen
+\fBport\fR=\fIPORT\fR
+\fBxprt\fR=\fIsock\fR|\fIrdma\fR|\fIugni\fR|\fIfabric\fR
+[\fBhost\fR=\fIHOST\fR]
+[\fBauth\fR=\fIAUTH_REF\fR]
+.RS
+.TP
+\fBport\fR=\fIPORT\fR
+.br
+The port to listen to. Also, please be sure not to use ephemeral port (ports in
+the range of \fB/proc/sys/net/ip4/ip_local_port_range\fR).
+.TP
+\fBxprt\fR=\fIsock\fR|\fIrdma\fR|\fIugni\fR|\fIfabric\fR
+.br
+The type of the transport.
+.TP
+\fBhost\fR=\fIHOST\fR
+.br
+An optional hostname or IP address to bind. If not given, listen to all
+addresses (0.0.0.0 or PORT).
+.TP
+\fBauth\fR=\fIAUTH_REF\fR
+.br
+Instruct \fBldmsd\fR to use \fIAUTH_REF\fR (a name reference to \fBauth\fR
+object created by \fBauth_add\fR command) to authenticate connections on this
+port. If not given, the port uses the default authentication method specified on
+the CLI options (see \fBldmsd\fR(8) option \fB-a\fR).
+.RE
 
 .SH PRODUCER COMMAND SYNTAX
 .SS  Add a producer to the aggregator
@@ -219,6 +274,13 @@ The connection retry interval
 .BI [perm " permission"]
 .br
 The permission to modify the producer in the future
+.TP
+.BI [auth " AUTH_REF"]
+.br
+Instruct \fBldmsd\fR to use \fIAUTH_REF\fR (a name reference to \fBauth\fR
+object created by \fBauth_add\fR command) with the connections to this
+producer. If not given, the default authentication method specified on
+the CLI options (see \fBldmsd\fR(8) option \fB-a\fR) is used.
 .RE
 
 .SS Delete a producer from the aggregator

--- a/ldms/src/core/ldms_xprt_auth.c
+++ b/ldms/src/core/ldms_xprt_auth.c
@@ -203,6 +203,9 @@ int ldms_access_check(ldms_t x, uint32_t acc, uid_t obj_uid, gid_t obj_gid,
 		      int obj_perm)
 {
 	int macc = acc & obj_perm;
+	/* root can do anything */
+	if (x->ruid == 0)
+		return 0;
 	/* other */
 	if (07 & macc) {
 		return 0;

--- a/ldms/src/ldmsd/Makefile.am
+++ b/ldms/src/ldmsd/Makefile.am
@@ -37,7 +37,7 @@ ldmsd_SOURCES = ldmsd.c ldmsd_config.c \
 	ldmsd_request.c \
 	ldmsd_request.h \
 	ldmsd_cfgobj.c ldmsd_prdcr.c ldmsd_updtr.c ldmsd_strgp.c \
-	ldmsd_failover.c ldmsd_group.c
+	ldmsd_failover.c ldmsd_group.c ldmsd_auth.c
 ldmsd_LDADD = -lldms libldmsd_request.la libldmsd_stream.la \
 	-lzap -lmmalloc -lovis_util -lcoll -ljson_util \
 	-lovis_event -lpthread -lovis_ctrl -lm -ldl

--- a/ldms/src/ldmsd/ldmsd_auth.c
+++ b/ldms/src/ldmsd/ldmsd_auth.c
@@ -1,0 +1,180 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2020 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ * Copyright (c) 2020 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+#include <netdb.h>
+#include "ldms.h"
+#include "ldmsd.h"
+#include "ldmsd_request.h"
+#include "config.h"
+
+static
+void __ldmsd_auth_del(struct ldmsd_cfgobj *obj)
+{
+	ldmsd_auth_t auth = (void*)obj;
+	if (auth->plugin)
+		free(auth->plugin);
+	if (auth->attrs)
+		av_free(auth->attrs);
+	ldmsd_cfgobj___del(obj);
+}
+
+ldmsd_auth_t
+ldmsd_auth_new_with_auth(const char *name, const char *plugin,
+			 struct attr_value_list *attrs,
+			 uid_t uid, gid_t gid, int perm)
+{
+	ldmsd_auth_t auth = NULL;
+
+	if (!plugin) {
+		errno = EINVAL;
+		goto err;
+	}
+
+	auth = (ldmsd_auth_t) ldmsd_cfgobj_new_with_auth(name,
+					LDMSD_CFGOBJ_AUTH,
+					sizeof(struct ldmsd_auth),
+					__ldmsd_auth_del, uid, gid, perm);
+	if (!auth)
+		goto err;
+	auth->plugin = strdup(plugin);
+	if (!auth->plugin)
+		goto err;
+	if (attrs) {
+		auth->attrs = av_copy(attrs);
+		if (!auth->attrs)
+			goto err;
+	}
+	ldmsd_cfgobj_unlock(&auth->obj);
+	return auth;
+
+ err:
+	if (auth) {
+		ldmsd_cfgobj_unlock(&auth->obj);
+		ldmsd_cfgobj_put(&auth->obj);
+	}
+	return NULL;
+}
+
+ldmsd_cfgobj_t __cfgobj_find(const char *name, ldmsd_cfgobj_type_t type);
+struct rbt **cfgobj_trees;
+
+int ldmsd_auth_del(const char *name, ldmsd_sec_ctxt_t ctxt)
+{
+	int rc = 0;
+	ldmsd_auth_t auth;
+	ldmsd_cfg_lock(LDMSD_CFGOBJ_AUTH);
+	auth = (ldmsd_auth_t)__cfgobj_find(name, LDMSD_CFGOBJ_AUTH); /* this increase ref */
+	if (!auth) {
+		rc = ENOENT;
+		goto out;
+	}
+	rc = ldmsd_cfgobj_access_check(&auth->obj, 0222, ctxt);
+	if (rc)
+		goto out;
+	/* remove from the tree */
+	rbt_del(cfgobj_trees[LDMSD_CFGOBJ_AUTH], &auth->obj.rbn);
+	ldmsd_cfgobj_put(&auth->obj); /* correspond to `new` */
+ out:
+	ldmsd_cfg_unlock(LDMSD_CFGOBJ_AUTH);
+	if (auth) /* put ref back from `find` */
+		ldmsd_cfgobj_put(&auth->obj);
+	return rc;
+}
+
+ldmsd_auth_t ldmsd_auth_default_get()
+{
+	return ldmsd_auth_find(DEFAULT_AUTH);
+}
+
+int ldmsd_auth_default_set(const char *plugin, struct attr_value_list *attrs)
+{
+	ldmsd_auth_t d = ldmsd_auth_default_get();
+	int rc;
+	if (!d) {
+		/* default auth domain has not been created yet */
+		d = ldmsd_auth_new_with_auth(DEFAULT_AUTH, plugin, attrs,
+				geteuid(), getegid(), 0600);
+		if (d)
+			return 0;
+		else
+			return errno;
+	}
+	if (d->plugin) {
+		free(d->plugin);
+		d->plugin = NULL;
+	}
+	if (d->attrs) {
+		av_free(d->attrs);
+		d->attrs = NULL;
+	}
+	d->plugin = strdup(plugin);
+	if (!d->plugin) {
+		rc = ENOMEM;
+		goto out;
+	}
+	if (attrs) {
+		d->attrs = av_copy(attrs);
+		if (!d->attrs) {
+			rc = ENOMEM;
+			goto out;
+		}
+	}
+	rc = 0;
+ out:
+	ldmsd_cfgobj_put(&d->obj);
+	return rc;
+}

--- a/ldms/src/ldmsd/ldmsd_cfgobj.c
+++ b/ldms/src/ldmsd/ldmsd_cfgobj.c
@@ -77,16 +77,26 @@ pthread_mutex_t updtr_tree_lock = PTHREAD_MUTEX_INITIALIZER;
 struct rbt strgp_tree = RBT_INITIALIZER(cfgobj_cmp);
 pthread_mutex_t strgp_tree_lock = PTHREAD_MUTEX_INITIALIZER;
 
+struct rbt listen_tree = RBT_INITIALIZER(cfgobj_cmp);
+pthread_mutex_t listen_tree_lock = PTHREAD_MUTEX_INITIALIZER;
+
+struct rbt auth_tree = RBT_INITIALIZER(cfgobj_cmp);
+pthread_mutex_t auth_tree_lock = PTHREAD_MUTEX_INITIALIZER;
+
 pthread_mutex_t *cfgobj_locks[] = {
 	[LDMSD_CFGOBJ_PRDCR] = &prdcr_tree_lock,
 	[LDMSD_CFGOBJ_UPDTR] = &updtr_tree_lock,
 	[LDMSD_CFGOBJ_STRGP] = &strgp_tree_lock,
+	[LDMSD_CFGOBJ_LISTEN] = &listen_tree_lock,
+	[LDMSD_CFGOBJ_AUTH]   = &auth_tree_lock,
 };
 
 struct rbt *cfgobj_trees[] = {
 	[LDMSD_CFGOBJ_PRDCR] = &prdcr_tree,
 	[LDMSD_CFGOBJ_UPDTR] = &updtr_tree,
 	[LDMSD_CFGOBJ_STRGP] = &strgp_tree,
+	[LDMSD_CFGOBJ_LISTEN] = &listen_tree,
+	[LDMSD_CFGOBJ_AUTH]   = &auth_tree,
 };
 
 void ldmsd_cfgobj_init(void)
@@ -94,6 +104,8 @@ void ldmsd_cfgobj_init(void)
 	rbt_init(&prdcr_tree, cfgobj_cmp);
 	rbt_init(&updtr_tree, cfgobj_cmp);
 	rbt_init(&strgp_tree, cfgobj_cmp);
+	rbt_init(&listen_tree, cfgobj_cmp);
+	rbt_init(&auth_tree,   cfgobj_cmp);
 }
 
 void ldmsd_cfgobj___del(ldmsd_cfgobj_t obj)

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -942,33 +942,20 @@ static void __listen_connect_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 extern const char *auth_name;
 extern struct attr_value_list *auth_opt;
 
-ldms_t listen_on_ldms_xprt(char *xprt_str, char *port_str)
+int listen_on_ldms_xprt(ldmsd_listen_t listen)
 {
-	unsigned short port_no;
-	int ptmp;
-	ldms_t l = NULL;
-	int ret;
+	int rc = 0;
 	struct sockaddr_in sin;
 
-	if (!port_str || port_str[0] == '\0') {
-		port_no = LDMS_DEFAULT_PORT;
-	} else {
-		ptmp = atoi(port_str);
-		if (ptmp < 1 || ptmp > USHRT_MAX) {
-			ldmsd_log(LDMSD_LERROR, "'%s' transport with invalid port"
-				"'%s'\n",xprt_str,port_str);
-			cleanup(6, "error specifying transport.");
-		}
-		port_no = (unsigned)ptmp;
-	}
-	l = ldms_xprt_new_with_auth(xprt_str, ldmsd_linfo, auth_name, auth_opt);
-	if (!l) {
+	listen->x = ldms_xprt_new_with_auth(listen->xprt, ldmsd_linfo,
+			listen->auth_name, listen->auth_attrs);
+	if (!listen->x) {
 		ldmsd_log(LDMSD_LERROR,
 			  "'%s' transport creation with auth '%s' "
 			  "failed, error: %s(%d). Please check transpot "
 			  "configuration, authentication configuration, "
 			  "ZAP_LIBPATH (env var), and LD_LIBRARY_PATH.\n",
-			  xprt_str,
+			  listen->xprt,
 			  auth_name,
 			  ovis_errno_abbvr(errno),
 			  errno);
@@ -976,17 +963,19 @@ ldms_t listen_on_ldms_xprt(char *xprt_str, char *port_str)
 	}
 	sin.sin_family = AF_INET;
 	sin.sin_addr.s_addr = 0;
-	sin.sin_port = htons(port_no);
-	ret = ldms_xprt_listen(l, (struct sockaddr *)&sin, sizeof(sin),
+	sin.sin_port = htons(listen->port_no);
+	rc = ldms_xprt_listen(listen->x, (struct sockaddr *)&sin, sizeof(sin),
 			       __listen_connect_cb, NULL);
-	if (ret) {
+	if (rc) {
 		ldmsd_log(LDMSD_LERROR, "Error %d listening on the '%s' "
-				"transport.\n", ret, xprt_str);
+				"transport.\n", rc, listen->xprt);
 		cleanup(7, "error listening on transport");
 	}
-	ldmsd_log(LDMSD_LINFO, "Listening on transport %s:%s\n",
-			xprt_str, port_str);
-	return l;
+	ldmsd_log(LDMSD_LINFO, "Listening on %s:%d using `%s` transport and "
+		  "`%s` authentication\n",
+		  listen->xprt, listen->port_no, listen->xprt,
+		  listen->auth_name);
+	return 0;
 }
 
 void ldmsd_cfg_ldms_init(ldmsd_cfg_xprt_t xprt, ldms_t ldms)

--- a/ldms/src/ldmsd/ldmsd_failover.c
+++ b/ldms/src/ldmsd/ldmsd_failover.c
@@ -1979,6 +1979,7 @@ int failover_cfgprdcr_handler(ldmsd_req_ctxt_t req)
 	char *uid = __req_attr_gets(req, LDMSD_ATTR_UID);
 	char *gid = __req_attr_gets(req, LDMSD_ATTR_GID);
 	char *perm = __req_attr_gets(req, LDMSD_ATTR_PERM);
+	char *auth = __req_attr_gets(req, LDMSD_ATTR_AUTH);
 
 	uid_t _uid;
 	gid_t _gid;
@@ -2028,7 +2029,7 @@ int failover_cfgprdcr_handler(ldmsd_req_ctxt_t req)
 		goto out;
 	}
 	p = ldmsd_prdcr_new_with_auth(name, xprt, host, atoi(port), ptype,
-			atoi(interval), _uid, _gid, _perm);
+			atoi(interval), auth, _uid, _gid, _perm);
 	if (!p) {
 		rc = errno;
 		str_rbn_free(srbn);

--- a/ldms/src/ldmsd/ldmsd_request.h
+++ b/ldms/src/ldmsd/ldmsd_request.h
@@ -116,6 +116,9 @@ enum ldmsd_request {
 	LDMSD_RECORD_LEN_ADVICE_REQ,
 	LDMSD_SET_ROUTE_REQ,
 
+	/* command-line options */
+	LDMSD_LISTEN_REQ,
+
 	/* failover requests by user */
 	LDMSD_FAILOVER_CONFIG_REQ = 0x700, /* "failover_config" user command */
 	LDMSD_FAILOVER_PEERCFG_START_REQ, /* "failover_peercfg_start" user command */
@@ -147,6 +150,9 @@ enum ldmsd_request {
 	LDMSD_STREAM_PUBLISH_REQ = 0x900, /* Publish data to a stream */
 	LDMSD_STREAM_SUBSCRIBE_REQ,	  /* Subscribe to a stream */
 
+	/* Auth */
+	LDMSD_AUTH_ADD_REQ = 0xa00, /* Add auth domain */
+	LDMSD_AUTH_DEL_REQ,         /* Delete auth domain */
 	LDMSD_NOTSUPPORT_REQ,
 };
 
@@ -187,6 +193,7 @@ enum ldmsd_request_attr {
 	LDMSD_ATTR_UID,
 	LDMSD_ATTR_GID,
 	LDMSD_ATTR_STREAM,
+	LDMSD_ATTR_AUTH,
 	LDMSD_ATTR_LAST,
 };
 


### PR DESCRIPTION
This is the multi-domain authentication feature from the master branch. It brought in `auth_add` and `listen` configuration commands. `auth_add` allows users to define authentication domain that will later be used in `prdcr_add` or `listen`. `listen` command allows users to instruct `ldmsd` to listen to a port from a configuration file (instead of CLI).