### PR TITLE
Fix type-punning/strict-aliasing gcc warning

### DIFF
--- a/ldms/src/ldmsd-stores/store_csv/store_csv_common.c
+++ b/ldms/src/ldmsd-stores/store_csv/store_csv_common.c
@@ -993,26 +993,30 @@ int mval_print_s64_array(FILE *f, ldms_mval_t mval, int i, int ietfcsv)
 
 int mval_print_f32(FILE *f, ldms_mval_t mval, int i, int ietfcsv)
 {
-	uint32_t tmp = __le32_to_cpu(*(uint32_t*)&mval->v_f);
-	return fprintf(f, ",%.9g", *(float*)&tmp);
+	union ldms_value v;
+	v.v_u32 = __le32_to_cpu(mval->v_u32);
+	return fprintf(f, ",%.9g", v.v_f);
 }
 
 int mval_print_f32_array(FILE *f, ldms_mval_t mval, int i, int ietfcsv)
 {
-	uint32_t tmp = __le32_to_cpu(*(uint32_t*)&mval->a_f[i]);
-	return fprintf(f, ",%.9g", *(float*)&tmp);
+	union ldms_value v;
+	v.v_u32 = __le32_to_cpu(mval->a_u32[i]);
+	return fprintf(f, ",%.9g", v.v_f);
 }
 
 int mval_print_d64(FILE *f, ldms_mval_t mval, int i, int ietfcsv)
 {
-	uint64_t tmp = __le64_to_cpu(*(uint64_t*)&mval->v_d);
-	return fprintf(f, ",%.17g", *(double*)&tmp);
+	union ldms_value v;
+	v.v_u64 = __le64_to_cpu(mval->v_u64);
+	return fprintf(f, ",%.17g", v.v_d);
 }
 
 int mval_print_d64_array(FILE *f, ldms_mval_t mval, int i, int ietfcsv)
 {
-	uint64_t tmp = __le64_to_cpu(*(uint64_t*)&mval->a_d[i]);
-	return fprintf(f, ",%.17g", *(double*)&tmp);
+	union ldms_value v;
+	v.v_u64 =  __le64_to_cpu(mval->a_u64[i]);
+	return fprintf(f, ",%.17g", v.v_d);
 }
 
 mval_print_fn mval_print_tbl[] = {

--- a/lib/src/ev/ev.h
+++ b/lib/src/ev/ev.h
@@ -210,7 +210,7 @@ void ev_sched_to(struct timespec *to, time_t secs, int nsecs);
  * \param _type_ The type to which the event data is cast
  * \retval The event data cast to _type_
  */
-#define EV_DATA(_ptr_, _type_) ((_type_ *)&(_ptr_)->e_data[0])
+#define EV_DATA(_ptr_, _type_) ((_type_ *)(_ptr_))
 
 /**
  * \brief Return an event type's internal event id.


### PR DESCRIPTION
When `-O3` is given, `-fstrict-aliasing` is assumed.