### PR TITLE
Fix RDMA Zap Share message initialization

### DIFF
--- a/lib/src/zap/rdma/zap_rdma.c
+++ b/lib/src/zap/rdma/zap_rdma.c
@@ -2029,6 +2029,7 @@ static zap_err_t z_rdma_share(zap_ep_t ep, zap_map_t map,
 
 	sm = (struct z_rdma_share_msg *)rbuf->data;
 	sm->hdr.msg_type = htons(Z_RDMA_MSG_RENDEZVOUS);
+	sm->share = 1;
 	sm->rkey = rmap->mr->rkey;
 	sm->va = (unsigned long)rmap->map.addr;
 	sm->len = htonl(rmap->map.len);


### PR DESCRIPTION
The `share` field was forgotten to set as `1` in the rendezvous
message -- making it looks like `unshare` rendezvous message.