### PR TITLE
fix missing dependency in store makefile.am

### DIFF
--- a/ldms/src/store/Makefile.am
+++ b/ldms/src/store/Makefile.am
@@ -61,7 +61,7 @@ pkglib_LTLIBRARIES += libstore_rabbitkw.la
 endif
 
 if ENABLE_CSV
-CSV_COMMON_LIBFLAGS = -lldms_store_csv_common -lpthread
+CSV_COMMON_LIBFLAGS = libldms_store_csv_common.la -lpthread
 
 libldms_store_csv_common_la_SOURCES = store_csv_common.c store_csv_common.h
 libldms_store_csv_common_la_LIBADD = $(STORE_LIBADD) -lpthread


### PR DESCRIPTION
the -l form of lib flag on a directory local peer library breaks the dependency calculations of automake required for parallel build. Using the .la form works.