### PR TITLE
zap_ugni: two arguments instead of one given to a _set_sockbuf_sz call

### DIFF
--- a/lib/src/zap/ugni/zap_ugni.c
+++ b/lib/src/zap/ugni/zap_ugni.c
@@ -540,7 +540,7 @@ static zap_err_t z_ugni_connect(zap_ep_t ep,
 		goto out;
 	}
 
-	if (__set_sockbuf_sz(uep, uep->sock)) {
+	if (__set_sockbuf_sz(uep->sock)) {
 		zerr = ZAP_ERR_TRANSPORT;
 		LOG_(uep, "Error %d: fail to set the sockbuf sz in %s.\n",
 				errno, __func__);


### PR DESCRIPTION
…f_sz