### PR TITLE
Put `job_set` reference when deleting the sampler

### DIFF
--- a/ldms/src/ldmsd/ldmsd_sampler.c
+++ b/ldms/src/ldmsd/ldmsd_sampler.c
@@ -107,6 +107,9 @@ void samp_del(ldmsd_plugin_inst_t inst)
 		free(ent);
 	}
 
+	if (samp->job_set)
+		ldms_set_put(samp->job_set);
+
 	free(samp->producer_name);
 	free(samp->set_inst_name);
 	free(samp->schema_name);


### PR DESCRIPTION
The `job_set` handle was not properly put down when the sampler instance
is deleted.