### PR TITLE
Change the `samp->delete_set()` interface to use set name.

### DIFF
--- a/ldms/src/ldmsd-samplers/app_sampler/app_sampler.c
+++ b/ldms/src/ldmsd-samplers/app_sampler/app_sampler.c
@@ -1223,7 +1223,6 @@ int __handle_task_init(app_sampler_inst_t inst, json_entity_t data)
 int __handle_task_exit(app_sampler_inst_t inst, json_entity_t data)
 {
 	ldmsd_sampler_type_t samp = LDMSD_SAMPLER(inst);
-	ldms_set_t set;
 	int len;
 	json_entity_t job_id;
 	json_entity_t task_pid;
@@ -1240,12 +1239,8 @@ int __handle_task_exit(app_sampler_inst_t inst, json_entity_t data)
 			task_pid->value.int_);
 	if (len < 0)
 		return ENOMEM;
-	set = ldms_set_by_name(setname);
+	samp->delete_set(LDMSD_INST(inst), setname);
 	free(setname);
-	if (!set)
-		return errno;
-	samp->delete_set(LDMSD_INST(inst), set);
-	ldms_set_put(set); /* put ref from `ldms_set_by_name()` */
 	return 0;
 }
 

--- a/ldms/src/ldmsd-samplers/test-samplers/test_sampler.c
+++ b/ldms/src/ldmsd-samplers/test-samplers/test_sampler.c
@@ -388,7 +388,7 @@ static int test_sampler_set_del(test_sampler_inst_t inst,
 {
 	if (!ts_set->set)
 		return ENOENT;
-	LDMSD_SAMPLER(inst)->delete_set(&inst->base, ts_set->set);
+	LDMSD_SAMPLER(inst)->delete_set(&inst->base, ldms_set_name_get(ts_set->set));
 	ts_set->set = NULL;
 	return 0;
 }

--- a/ldms/src/ldmsd/ldmsd_sampler.c
+++ b/ldms/src/ldmsd/ldmsd_sampler.c
@@ -558,11 +558,10 @@ ldms_set_t samp_create_set_group(ldmsd_plugin_inst_t inst,
 	return NULL;
 }
 
-int samp_delete_set(ldmsd_plugin_inst_t inst, ldms_set_t set)
+int samp_delete_set(ldmsd_plugin_inst_t inst, const char *name)
 {
 	ldmsd_sampler_type_t samp = (void*)inst->base;
 	ldmsd_set_entry_t ent;
-	const char *name = ldms_set_name_get(set);
 	pthread_mutex_lock(&samp->lock);
 	/* make sure that it is from our list */
 	LIST_FOREACH(ent, &samp->set_list, entry) {

--- a/ldms/src/ldmsd/ldmsd_sampler.h
+++ b/ldms/src/ldmsd/ldmsd_sampler.h
@@ -203,13 +203,13 @@ struct ldmsd_sampler_type_s {
 	 *       instance is deleted.
 	 *
 	 * \param inst The plugin instance pointer.
-	 * \param set  The set handle.
+	 * \param name The set name.
 	 *
 	 * \retval 0      If succeeded.
 	 * \retval ENOENT If the set is not found in the set_list of this
 	 *                instance.
 	 */
-	int (*delete_set)(ldmsd_plugin_inst_t inst, ldms_set_t set);
+	int (*delete_set)(ldmsd_plugin_inst_t inst, const char *name);
 
 	/**
 	 * Sample function.


### PR DESCRIPTION
The sole real use case of `samp->delete_set()` is in `app_sampler`.
The way it did before the patch was that when it received a task exit
event, it constructed a set name associated with the task and obtained
the `ldms_set_t` handle by `ldms_set_by_name()` (as `samp->delete_set()`
requires a handle to delete). Since this handle is different than the
one in the `samp->set_list` (created by `samp->create_set()`),
`samp->delete_set()` already has to iteratively compare the name of the
given `ldms_set_t` against those in the `samp->set_list` (please see
commit-id: 0f9f9dcb4). So, `samp->delete_set()` with set name makes more
sense from this use case.

Also, with -D_REF_TRACK_ compilation flag to track the correct reference
usage, we found out that all `ldms_set_t` were automatically removed
from the `set->local_rbd_list` in `ldms_set_delete()`. Hence, the use
case of

```C
s = ldms_set_by_name(name);
ldms_set_delete(s);
ldms_set_put(s);
```

in app_sampler will remove `s` twice from the list (in ldms_set_delete()
and in ldmse_set_put()), leading to memory corruption.

This patch is a work around to the above mentioned problem and is a
short-term solution. A real solution regarding LDMS set reference will
be handled separately.