### PR TITLE
Fix aggregator crash due to null `prdcr->xprt`

### DIFF
--- a/ldms/src/ldmsd/ldmsd_prdcr.c
+++ b/ldms/src/ldmsd/ldmsd_prdcr.c
@@ -160,6 +160,9 @@ static void prdcr_set_del(ldmsd_prdcr_set_t set)
 
 static void prdcr_reset_set(ldmsd_prdcr_t prdcr, ldmsd_prdcr_set_t prd_set)
 {
+	pthread_mutex_lock(&prd_set->lock);
+	prd_set->state = LDMSD_PRDCR_SET_STATE_ERROR;
+	pthread_mutex_unlock(&prd_set->lock);
 	EV_DATA(prd_set->state_ev, struct state_data)->start_n_stop = 0;
 	ldmsd_prdcr_set_ref_get(prd_set, "state_ev");
 	if (ev_post(producer, updater, prd_set->state_ev, NULL)) {


### PR DESCRIPTION
On the delivery of LDMS_XPRT_EVENT_DISCONNECTED event,
`prdcr_connect_cb()` resets `prdcr->prd_sets`. The prd_set resetting
procedure only set `start_n_stop` flag to 0 to notify the updtr worker
to not further schedule future updates. After resetting all prd_sets,
`prdcr_connect_cb()` set `prdcr->xprt` to NULL. Because the state of the
prd_set has not changed, the update events that were scheduled before
the disconnected then tried to update (or lookup) on the prd_set which
direcly uses prdcr->xprt (NULL), leading to SIGSEGV. By changing the
state of the prd_set to ERROR before setting `prdcr->xprt` to NULL, the
update events will just wakes up, do nothing, and put the prd_set
reference back. Note that the update event will just get a synchronous
error when it tries to issue update/lookup on the disconnected
transport.