### PR TITLE
Fix ldmsd default auth processing

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -1370,6 +1370,23 @@ void handle_pidfile_banner()
 	}
 }
 
+/* process default auth options */
+void try_process_default_auth()
+{
+	static int once = 0;
+	if (once)
+		return;
+	once = 1;
+	/*
+	 * No default authentication was specified.
+	 * Set the default authentication method to 'none'.
+	 */
+	if (!cmd_line_args.auth_name)
+		cmd_line_args.auth_name = strdup("none");
+	/* Set default authentication */
+	ldmsd_auth_default_set(cmd_line_args.auth_name, cmd_line_args.auth_attrs);
+}
+
 void ldmsd_init()
 {
 	int rc, i;
@@ -1401,14 +1418,7 @@ void ldmsd_init()
 		return;
 	}
 
-	/*
-	 * No default authentication was specified.
-	 * Set the default authentication method to 'none'.
-	 */
-	if (!cmd_line_args.auth_name)
-		cmd_line_args.auth_name = strdup("none");
-	/* Set default authentication */
-	ldmsd_auth_default_set(cmd_line_args.auth_name, cmd_line_args.auth_attrs);
+	try_process_default_auth();
 
 	if (cmd_line_args.myhostname[0] == '\0') {
 		rc = gethostname(cmd_line_args.myhostname,

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -385,6 +385,8 @@ int __req_filter(ldmsd_req_ctxt_t reqc, void *ctxt)
 	return rc;
 }
 
+void try_process_default_auth(); /* see ldmsd.c */
+
 int process_config_file(const char *path, int *lno, int trust)
 {
 	static uint16_t file_no = 0; /* Config file ID */
@@ -555,6 +557,8 @@ parse:
 				have_cfgcmd = 1;
 			}
 		}
+		if (have_cfgcmd) /* no more CLI options */
+			try_process_default_auth();
 		rc = ldmsd_process_config_request(&xprt, request, req_filter_fn);
 cleanup_record:
 		free(request);


### PR DESCRIPTION
The default authentication object was set up after the configuration
file has done processing, but `prdcr_add` in the config file that did
not specify `auth` needed the default auth object to create the `prdcr`.
Hence, the default auth object (and its attributes) should be set up
during config file processing, when we knew that `set CLI` options are
done. If no config file is given, the default auth is set up in the
`ldmsd_init()` as usual.