### PR TITLE
Fix error path in `handle_rendezvous_lookup()`

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2097,6 +2097,9 @@ out:
 	return rc;
 }
 
+
+void __ldms_set_delete(struct ldms_set *set);
+
 static void handle_rendezvous_lookup(zap_ep_t zep, zap_event_t ev,
 				     struct ldms_xprt *x,
 				     struct ldms_rendezvous_msg *lm)
@@ -2123,42 +2126,50 @@ static void handle_rendezvous_lookup(zap_ep_t zep, zap_event_t ev,
 	if (lset) {
 		ldms_name_t lschema = get_schema_name(lset->meta);
 		if (0 != strcmp(schema_name->name, lschema->name)) {
-			ref_put(&lset->ref, "__ldms_find_local_set");
 			/* Two sets have the same name but different schema */
 			rc = EINVAL;
-			goto unlock_out;
+			goto lset_done;
 		}
 
 		rbd = ldms_lookup_rbd(x, lset);
 		if (rbd) {
 			if (!(ctxt->lookup.flags & LDMS_LOOKUP_SET_INFO)) {
+				/* Do not allow re-lookup */
 				rc = EEXIST;
 			} else {
+				/* allow only re-lookup to update SET_INFO */
 				pthread_mutex_lock(&lset->lock);
 				rc = __process_lookup_set_info(lset,
 					&inst_name->name[inst_name->len]);
 				pthread_mutex_unlock(&lset->lock);
 			}
-			ref_put(&lset->ref, "__ldms_find_local_set");
-			goto unlock_out;
+		} else {
+			/* The set existed either by created locally or from
+			 * other transport. */
+			rc = EEXIST;
 		}
-	} else {
-		lset = __ldms_create_set(inst_name->name, schema_name->name,
-				       ntohl(lu->meta_len), ntohl(lu->data_len),
-				       ntohl(lu->card),
-				       ntohl(lu->array_card),
-				       LDMS_SET_F_REMOTE);
-		if (!lset) {
-			rc = errno;
-			goto unlock_out;
-		}
+	lset_done:
+		ref_put(&lset->ref, "__ldms_find_local_set");
+		goto unlock_out;
+	}
+
+	/* else, record new ldms_set */
+
+	lset = __ldms_create_set(inst_name->name, schema_name->name,
+			       ntohl(lu->meta_len), ntohl(lu->data_len),
+			       ntohl(lu->card),
+			       ntohl(lu->array_card),
+			       LDMS_SET_F_REMOTE);
+	if (!lset) {
+		rc = errno;
+		goto unlock_out;
 	}
 
 	pthread_mutex_lock(&lset->lock);
 	rc = __process_lookup_set_info(lset, &inst_name->name[inst_name->len]);
 	pthread_mutex_unlock(&lset->lock);
 	if (rc)
-		goto unlock_out;
+		goto out_1;
 
 	/* Bind this set to a new RBD. We will initiate RDMA_READ */
 	rbd = __ldms_alloc_rbd(x, lset, LDMS_RBD_INITIATOR);
@@ -2211,25 +2222,29 @@ static void handle_rendezvous_lookup(zap_ep_t zep, zap_event_t ev,
 	}
 	return;
 
+ out_2:
+	if (lu->more) {
+		pthread_mutex_lock(&x->lock);
+		__ldms_free_ctxt(x, rd_ctxt);
+		pthread_mutex_unlock(&x->lock);
+	}
+	/* let through */
+ out_1:
+	if (rbd) {
+		ldms_set_delete(rbd);
+		rbd = NULL;
+	} else if (lset) {
+		/* if rbd has successfully created, lset is destroyed together
+		 * with rbd in ldms_set_delete(rbd) */
+		__ldms_set_delete(lset);
+	}
+	/* let through */
  unlock_out:
 	if (rc || (rbd && rbd->rmap != ev->map)) {
 		/* unmap ev->map if it is not used */
 		zap_unmap(x->zap_ep, ev->map);
 	}
-	goto out;
- out_2:
-	if (lu->more) {
-		pthread_mutex_lock(&x->lock);
-		__ldms_free_ctxt(x, ctxt);
-		pthread_mutex_unlock(&x->lock);
-	}
 
- out_1:
-	if (rbd) {
-		ldms_set_delete(rbd);
-		rbd = NULL;
-	}
- out:
 #ifdef DEBUG
 	x->log("DEBUG: %s: lookup error while ldms_xprt is processing the rendezvous "
 			"with error %d. NOTE: error %d indicates that it is "

--- a/ldms/src/ldmsd/ldmsd_updtr.c
+++ b/ldms/src/ldmsd/ldmsd_updtr.c
@@ -388,16 +388,24 @@ static void prdcrset_lookup_cb(ldms_t xprt, enum ldms_lookup_status status,
 	pthread_mutex_lock(&prd_set->lock);
 	if (status != LDMS_LOOKUP_OK) {
 		status = ((int)status < 0 ? -status : status);
-		if ((int)status == ENOMEM) {
+		switch ((int)status) {
+		case ENOMEM:
 			ldmsd_log(LDMSD_LERROR,
-				"Error %d in lookup callback for set '%s' "
+				"Out of memory error (%d) in lookup callback "
+				"for set '%s'. "
 				"Consider changing the -m parameter on the "
 				"command line to a bigger value. "
 				"The current value is %s\n",
 				status, prd_set->inst_name,
 				ldmsd_get_max_mem_sz_str());
-
-		} else {
+			break;
+		case EEXIST:
+			ldmsd_log(LDMSD_LERROR,
+				  "Lookup error, set '%s' existed.\n",
+				  prd_set->inst_name
+				 );
+			break;
+		default:
 			ldmsd_log(LDMSD_LERROR,
 				  "Error %d in lookup callback for set '%s'\n",
 					  status, prd_set->inst_name);


### PR DESCRIPTION
- add `__ldms_set_delete(struct ldms_set *)` for deleting the newly
  recorded set that does not have rbd yet (requires to unwind the set
  create in `handle_rendezvous_lookup()` in the case of an error).
- correct error path in `handle_rendezvous_lookup()`. Previously, when
  multiple-source lookup is allowed (e.g. agg2 lookup `node1/meminfo`
  from both agg11 and agg12), a synchronous read on agg12 would delete
  the set along with all the rbds, including the good rbd from agg11.
  The prd_set associated with agg11 will hold on a stale rbd.
- Multiple-source lookup will now result in `EEXIST`.
- Update `ldmsd_prdcr` to also handle and report `EEXIST` lookup error.