### PR TITLE
Fix build with `--disable-rpath`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -231,10 +231,6 @@ OPTION_WITH_OR_BUILD([gpcdlocal],[../gpcd-support],[gpcd],[gpcdlocal.sh], ,[gpcd
 OPTION_DEFAULT_DISABLE([sos], [ENABLE_SOS])
 OPTION_WITH_OR_BUILD([sos],[../sos],[sos/src sos/include ods/src ods/include])
 
-dnl Options for consumer
-OPTION_DEFAULT_DISABLE([me], [ENABLE_ME])
-OPTION_WITH([me], [ME], [/usr/local])
-
 dnl Options for sampler
 OPTION_DEFAULT_ENABLE([sampler], [ENABLE_SAMPLER])
 OPTION_DEFAULT_DISABLE([kgnilnd], [ENABLE_KGNILND])

--- a/ldms/src/Makefile.am
+++ b/ldms/src/Makefile.am
@@ -12,7 +12,7 @@ do_subst = @LDMS_SUBST_RULE@
 	$(do_subst) < $< > $@
 	chmod 755 $@
 
-SUBDIRS += third-plugins contrib
+SUBDIRS += third-plugins
 
 if ENABLE_CORE
 SUBDIRS += core
@@ -34,6 +34,8 @@ endif
 if ENABLE_LDMS_TEST
 SUBDIRS += test
 endif
+
+SUBDIRS += contrib
 
 ovis-ldms-configure-args: Makefile
 	for i in @ac_configure_args@; do \

--- a/ldms/src/auth/Makefile.am
+++ b/ldms/src/auth/Makefile.am
@@ -11,23 +11,26 @@ AM_CFLAGS += \
 
 
 libldms_auth_none_la_SOURCES = ldms_auth_none.c
-libldms_auth_none_la_LIBADD = -lldms
+libldms_auth_none_la_LIBADD = ../core/libldms.la
 lib_LTLIBRARIES += libldms_auth_none.la
 
 libldms_auth_naive_la_SOURCES = ldms_auth_naive.c
-libldms_auth_naive_la_LIBADD = -lldms -lovis_util
+libldms_auth_naive_la_LIBADD = ../core/libldms.la \
+			       $(top_builddir)/lib/src/ovis_util/libovis_util.la
 
 lib_LTLIBRARIES += libldms_auth_naive.la
 
 libldms_auth_ovis_la_SOURCES = ldms_auth_ovis.c
-libldms_auth_ovis_la_LIBADD = -lldms -lovis_util -lovis_auth
+libldms_auth_ovis_la_LIBADD = ../core/libldms.la \
+			      $(top_builddir)/lib/src/ovis_util/libovis_util.la \
+			      $(top_builddir)/lib/src/ovis_auth/libovis_auth.la
 lib_LTLIBRARIES += libldms_auth_ovis.la
 
 if ENABLE_MUNGE
 libldms_auth_munge_la_SOURCES = ldms_auth_munge.c
 libldms_auth_munge_la_CFLAGS = @MUNGE_INCDIR_FLAG@
-libldms_auth_munge_la_LIBADD = -lldms \
-			       -lovis_util \
+libldms_auth_munge_la_LIBADD = ../core/libldms.la \
+			       $(top_builddir)/lib/src/ovis_util/libovis_util.la \
 			       -lmunge \
 			       @MUNGE_LIB64DIR_FLAG@ \
 			       @MUNGE_LIBDIR_FLAG@

--- a/ldms/src/contrib/sampler/ipmireader/Makefile.am
+++ b/ldms/src/contrib/sampler/ipmireader/Makefile.am
@@ -8,7 +8,11 @@ EXTRA_DIST =
 
 AM_LDFLAGS = @OVIS_LIB_ABS@
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 if ENABLE_IPMIREADER
 libipmireader_la_SOURCES = ipmireader.c

--- a/ldms/src/contrib/sampler/tutorial/Makefile.am
+++ b/ldms/src/contrib/sampler/tutorial/Makefile.am
@@ -8,7 +8,11 @@ EXTRA_DIST =
 
 AM_LDFLAGS = @OVIS_LIB_ABS@
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 
 if ENABLE_TUTORIAL_SAMPLER

--- a/ldms/src/contrib/store/tutorial/Makefile.am
+++ b/ldms/src/contrib/store/tutorial/Makefile.am
@@ -6,7 +6,9 @@ dist_man1_MANS =
 
 AM_LDFLAGS = @OVIS_LIB_ABS@
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
-STORE_LIBADD = -lldms -lcoll -lovis_util
+STORE_LIBADD = $(top_builddir)/ldms/src/core/libldms.la \
+	       $(top_builddir)/lib/src/coll/libcoll.la \
+	       $(top_builddir)/lib/src/ovis_util/libovis_util.la
 
 ldmsstoreincludedir = $(includedir)/ldms
 ldmsstoreinclude_HEADERS = 

--- a/ldms/src/core/Makefile.am
+++ b/ldms/src/core/Makefile.am
@@ -14,8 +14,10 @@ ldmscoreinclude_HEADERS = ldms.h ldms_core.h ldms_xprt.h ldms_auth.h kldms_req.h
 
 libldms_la_SOURCES = ldms.c ldms_xprt.c ldms_private.h \
 		     ldms_auth.c ldms_xprt_auth.c
-libldms_la_LIBADD = -ldl -lpthread -lcoll -ljson_util \
-	-lmmalloc -lzap
+libldms_la_LIBADD = -ldl -lpthread $(top_builddir)/lib/src/coll/libcoll.la \
+		    $(top_builddir)/lib/src/json/libjson_util.la \
+		    $(top_builddir)/lib/src/mmalloc/libmmalloc.la \
+		    $(top_builddir)/lib/src/zap/libzap.la
 
 lib_LTLIBRARIES += libldms.la
 

--- a/ldms/src/ldmsd/Makefile.am
+++ b/ldms/src/ldmsd/Makefile.am
@@ -18,29 +18,37 @@ AM_CFLAGS = \
 ldmsdincludedir = $(includedir)/ldms
 ldmsdinclude_HEADERS = ldmsd.h ldmsd_stream.h
 
+LZAP = $(top_builddir)/lib/src/zap/libzap.la
+LMMALLOC = $(top_builddir)/lib/src/mmalloc/libmmalloc.la
+LOVIS_UTIL = $(top_builddir)/lib/src/ovis_util/libovis_util.la
+LCOLL = $(top_builddir)/lib/src/coll/libcoll.la
+LJSON_UTIL = $(top_builddir)/lib/src/json/libjson_util.la
+LOVIS_EVENT = $(top_builddir)/lib/src/ovis_event/libovis_event.la
+LOVIS_CTRL = $(top_builddir)/lib/src/ovis_ctrl/libovis_ctrl.la
+
 AM_CFLAGS += -DPLUGINDIR='"$(pkglibdir)"'
 
 ldms_ls_SOURCES = ldms_ls.c
-ldms_ls_LDADD = -lldms -lzap -lmmalloc -lovis_util -lcoll \
+ldms_ls_LDADD = ../core/libldms.la $(LZAP) $(LMMALLOC) $(LOVIS_UTIL) $(LCOLL) \
         -lpthread \
         @LDFLAGS_GETTIME@
 
 lib_LTLIBRARIES += libldmsd_stream.la
 libldmsd_stream_la_SOURCES = ldmsd_stream.c ldmsd_stream.h ldmsd_request_util.c
-libldmsd_stream_la_LIBADD = -lldms
+libldmsd_stream_la_LIBADD = ../core/libldms.la
 
 lib_LTLIBRARIES += libldmsd_request.la
 libldmsd_request_la_SOURCES = ldmsd_request_util.c
-libldmsd_request_la_LIBADD = -lldms
+libldmsd_request_la_LIBADD = ../core/libldms.la
 
 ldmsd_SOURCES = ldmsd.c ldmsd_config.c \
 	ldmsd_request.c \
 	ldmsd_request.h \
 	ldmsd_cfgobj.c ldmsd_prdcr.c ldmsd_updtr.c ldmsd_strgp.c \
 	ldmsd_failover.c ldmsd_group.c ldmsd_auth.c
-ldmsd_LDADD = -lldms libldmsd_request.la libldmsd_stream.la \
-	-lzap -lmmalloc -lovis_util -lcoll -ljson_util \
-	-lovis_event -lpthread -lovis_ctrl -lm -ldl
+ldmsd_LDADD = ../core/libldms.la libldmsd_request.la libldmsd_stream.la \
+	$(LZAP) $(LMMALLOC) $(LOVIS_UTIL) $(LCOLL) $(LJSON_UTIL) \
+	$(LOVIS_EVENT) -lpthread $(LOVIS_CTRL) -lm -ldl
 ldmsd_CFLAGS = $(AM_CFLAGS)
 ldmsd_LDFLAGS = $(AM_LDFLAGS) -rdynamic -pthread
 
@@ -50,8 +58,8 @@ ldmsd_CFLAGS += -DENABLE_RABBITMQ
 endif
 
 ldmsctl_SOURCES = ldmsctl.c
-ldmsctl_LDADD = -lldms libldmsd_request.la \
-		-lovis_ctrl -lovis_util -lmmalloc -lcoll -lzap -ljson_util \
+ldmsctl_LDADD = ../core/libldms.la libldmsd_request.la \
+		$(LOVIS_CTRL) $(LOVIS_UTIL) $(LMMALLOC) $(LCOLL) $(LZAP) $(LJSON_UTIL) \
 		-lm -lpthread @LDFLAGS_GETTIME@ @LDFLAGS_READLINE@
 
 ldmsd_sos_init_SOURCES = ldmsd_sos_init.c
@@ -60,11 +68,11 @@ ldmsd_sos_init_LDADD = -lsos -lods -lpthread @SOS_LIBDIR_FLAG@ @SOS_LIB64DIR_FLA
 
 lib_LTLIBRARIES += libldmsd_plugattr.la
 libldmsd_plugattr_la_SOURCES = ldmsd_plugattr.c ldmsd_plugattr.h
-libldmsd_plugattr_la_LIBADD = -lovis_util -lcoll
+libldmsd_plugattr_la_LIBADD = $(LOVIS_UTIL) $(LCOLL)
 
 test_plugattr_SOURCES = ldmsd_plugattr.c ldmsd_plugattr.h
 test_plugattr_CFLAGS = -DTEST_PLUGATTR $(AM_CFLAGS)
-test_plugattr_LDADD = -lovis_util -lcoll -lm -lpthread
+test_plugattr_LDADD = $(LOVIS_UTIL) $(LCOLL) -lm -lpthread
 
 # make sym links for aggd scripting support
 install-exec-hook:

--- a/ldms/src/ldmsd/test/Makefile.am
+++ b/ldms/src/ldmsd/test/Makefile.am
@@ -4,11 +4,17 @@ pkglib_LTLIBRARIES =
 AM_LDFLAGS = @OVIS_LIB_ABS@
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 
+COMMON_LD_ADD = ../../core/libldms.la \
+		../libldmsd_request.la \
+		../libldmsd_stream.la \
+		$(top_builddir)/lib/src/json/libjson_util.la \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la
+
 sbin_PROGRAMS += ldmsd_stream_publish
 ldmsd_stream_publish_SOURCES = ldmsd_stream_publish.c
-ldmsd_stream_publish_LDADD = -lldms -lldmsd_request -lldmsd_stream -ljson_util -lovis_util
+ldmsd_stream_publish_LDADD = $(COMMON_LD_ADD)
 
 sbin_PROGRAMS += ldmsd_stream_subscribe
 ldmsd_stream_subscribe_SOURCES = ldmsd_stream_subscribe.c
-ldmsd_stream_subscribe_LDADD = -lldms -lldmsd_request -lldmsd_stream -ljson_util -lovis_util
+ldmsd_stream_subscribe_LDADD = $(COMMON_LD_ADD)
 ldmsd_stream_subscribe_LDFLAGS = $(AM_LDFLAGS) -pthread 

--- a/ldms/src/sampler/Makefile.am
+++ b/ldms/src/sampler/Makefile.am
@@ -7,8 +7,11 @@ pkglib_LTLIBRARIES =
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
 
-CORE_LIBADD = -lldms @LDFLAGS_GETTIME@ -lovis_util
-COMMON_LIBADD = libsampler_base.la $(CORE_LIBADD) -lcoll
+CORE_LIBADD = $(top_builddir)/ldms/src/core/libldms.la \
+	      @LDFLAGS_GETTIME@ \
+	      $(top_builddir)/lib/src/ovis_util/libovis_util.la
+COMMON_LIBADD = libsampler_base.la $(CORE_LIBADD) \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 libsampler_base_la_SOURCES = sampler_base.c sampler_base.h
 libsampler_base_la_LIBADD = $(CORE_LIBADD)
@@ -29,7 +32,8 @@ endif
 
 if ENABLE_TSAMPLER
 libtsampler_la_SOURCES = tsampler.c tsampler.h
-libtsampler_la_LIBADD = $(COMMON_LIBADD) -lovis_event -lpthread
+libtsampler_la_LIBADD = $(COMMON_LIBADD) \
+			$(top_builddir)/lib/src/ovis_event/libovis_event.la -lpthread
 pkglib_LTLIBRARIES += libtsampler.la
 
 libtimer_base_la_SOURCES = timer_base.c timer_base.h
@@ -244,7 +248,8 @@ endif
 
 if ENABLE_GENERIC_SAMPLER
 libgeneric_sampler_la_SOURCES = generic_sampler.c
-libgeneric_sampler_la_LIBADD = $(COMMON_LIBADD) -lcoll
+libgeneric_sampler_la_LIBADD = $(COMMON_LIBADD) \
+			       $(top_builddir)/lib/src/coll/libcoll.la
 pkglib_LTLIBRARIES += libgeneric_sampler.la
 endif
 

--- a/ldms/src/sampler/appinfo_lib/Makefile.am
+++ b/ldms/src/sampler/appinfo_lib/Makefile.am
@@ -2,7 +2,11 @@ pkglib_LTLIBRARIES =
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 libappinfocl_la_SOURCES = ldms_appinfo.c ldms_appinfo.h ldms_appinfo_shm.h
 libappinfocl_la_LIBADD = $(COMMON_LIBADD)

--- a/ldms/src/sampler/aries_mmr/Makefile.am
+++ b/ldms/src/sampler/aries_mmr/Makefile.am
@@ -4,7 +4,11 @@ pkglib_LTLIBRARIES =
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 if ENABLE_ARIES_MMR
 # ARIES_LIBGPCD_INCDIR=@ARIES_LIBGPCD_INCDIR@

--- a/ldms/src/sampler/cray_system_sampler/Makefile.am
+++ b/ldms/src/sampler/cray_system_sampler/Makefile.am
@@ -3,7 +3,11 @@ pkglib_LTLIBRARIES =
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 if ENABLE_CRAY_SYSTEM_SAMPLER
 
@@ -30,7 +34,7 @@ CRAY_LIBADD_ = $(COMMON_LIBADD)
 
 if ENABLE_LUSTRE
 CRAY_SOURCES_ += lustre_metrics.h lustre_metrics.c
-CRAY_LIBADD_ += -llustre_sampler
+CRAY_LIBADD_ += $(top_builddir)/ldms/src/sampler/lustre/liblustre_sampler.la
 endif
 
 if ENABLE_GEMINI_GPCDR

--- a/ldms/src/sampler/dstat/Makefile.am
+++ b/ldms/src/sampler/dstat/Makefile.am
@@ -5,7 +5,12 @@ dist_man7_MANS =
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base libparse_stat.la -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		libparse_stat.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 if ENABLE_DSTAT
 lib_LTLIBRARIES += libparse_stat.la

--- a/ldms/src/sampler/examples/array_example/Makefile.am
+++ b/ldms/src/sampler/examples/array_example/Makefile.am
@@ -5,7 +5,11 @@ dist_man7_MANS =
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 if ENABLE_ARRAY_EXAMPLE
 libarray_example_la_SOURCES = array_example.c

--- a/ldms/src/sampler/examples/synthetic/Makefile.am
+++ b/ldms/src/sampler/examples/synthetic/Makefile.am
@@ -8,8 +8,11 @@ SAMPLER= ../../../sampler
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
 
-COMMON_LIBADD = -lsampler_base -lldms \
-	    @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 
 if ENABLE_SYNTHETIC

--- a/ldms/src/sampler/examples/test_sampler/Makefile.am
+++ b/ldms/src/sampler/examples/test_sampler/Makefile.am
@@ -5,7 +5,11 @@ dist_man7_MANS =
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 if ENABLE_TEST_SAMPLER_LDMS_TEST
 libtest_sampler_la_SOURCES = test_sampler.c

--- a/ldms/src/sampler/filesingle/Makefile.am
+++ b/ldms/src/sampler/filesingle/Makefile.am
@@ -7,7 +7,11 @@ EXTRA_DIST = ldms-sensors-config
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 if ENABLE_FILESINGLE
 libfilesingle_la_SOURCES = filesingle.c

--- a/ldms/src/sampler/ibm_occ/Makefile.am
+++ b/ldms/src/sampler/ibm_occ/Makefile.am
@@ -3,8 +3,8 @@ dist_man7_MANS=
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-#COMMON_LIBADD = -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
-COMMON_LIBADD = -lsampler_base -lldms
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la
 
 if ENABLE_IBM_OCC_SAMPLER
 libibm_occ_la_SOURCES = ibm_occ.c ibm_occ.h

--- a/ldms/src/sampler/job_info/Makefile.am
+++ b/ldms/src/sampler/job_info/Makefile.am
@@ -3,7 +3,12 @@ dist_man7_MANS=
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll -lpthread
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la \
+		-lpthread
 
 libjobinfo_la_SOURCES = jobinfo.c jobinfo.h
 libjobinfo_la_LIBADD = $(COMMON_LIBADD)

--- a/ldms/src/sampler/job_info_slurm/Makefile.am
+++ b/ldms/src/sampler/job_info_slurm/Makefile.am
@@ -3,7 +3,10 @@ dist_man7_MANS=
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 libjobinfo_slurm_la_SOURCES = jobinfo_slurm.c
 libjobinfo_slurm_la_LIBADD = $(COMMON_LIBADD)

--- a/ldms/src/sampler/kgnilnd/Makefile.am
+++ b/ldms/src/sampler/kgnilnd/Makefile.am
@@ -6,7 +6,11 @@ man7_MANS =
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 if ENABLE_KGNILND
 libkgnilnd_la_SOURCES = kgnilnd.c

--- a/ldms/src/sampler/llnl/Makefile.am
+++ b/ldms/src/sampler/llnl/Makefile.am
@@ -3,7 +3,11 @@ dist_man7_MANS=
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 if ENABLE_LLNL_EDAC
 libedac_la_SOURCES = edac.c

--- a/ldms/src/sampler/lustre/Makefile.am
+++ b/ldms/src/sampler/lustre/Makefile.am
@@ -2,7 +2,11 @@ pkglib_LTLIBRARIES =
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-CORE_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+CORE_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+	      $(top_builddir)/ldms/src/core/libldms.la \
+	      @LDFLAGS_GETTIME@ \
+	      $(top_builddir)/lib/src/ovis_util/libovis_util.la \
+	      $(top_builddir)/lib/src/coll/libcoll.la
 
 # libstr_map
 # libstr_map_la_SOURCES = str_map.c str_map.h fnv_hash.h

--- a/ldms/src/sampler/meminfo/Makefile.am
+++ b/ldms/src/sampler/meminfo/Makefile.am
@@ -5,7 +5,11 @@ dist_man1_MANS =
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 if ENABLE_MEMINFO
 libmeminfo_la_SOURCES = meminfo.c 

--- a/ldms/src/sampler/papi/Makefile.am
+++ b/ldms/src/sampler/papi/Makefile.am
@@ -3,11 +3,17 @@ dist_man7_MANS=
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		$(top_builddir)/ldms/src/ldmsd/libldmsd_stream.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la \
+		$(top_builddir)/lib/src/json/libjson_util.la \
+		-lpapi -lm -lpthread
 
 libpapi_sampler_la_SOURCES = papi_sampler.h papi_sampler.c papi_config.c
-libpapi_sampler_la_LIBADD = $(COMMON_LIBADD) -ljson_util -lpapi -lm \
-			    -lldmsd_stream -lpthread
+libpapi_sampler_la_LIBADD = $(COMMON_LIBADD)
 libpapi_sampler_la_CFLAGS = -DSYSCONFDIR='"$(sysconfdir)"'
 pkglib_LTLIBRARIES += libpapi_sampler.la
 

--- a/ldms/src/sampler/procinterrupts/Makefile.am
+++ b/ldms/src/sampler/procinterrupts/Makefile.am
@@ -6,7 +6,11 @@ dist_man1_MANS =
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 if ENABLE_PROCINTERRUPTS
 libprocinterrupts_la_SOURCES = procinterrupts.c 

--- a/ldms/src/sampler/procstat/Makefile.am
+++ b/ldms/src/sampler/procstat/Makefile.am
@@ -6,7 +6,11 @@ dist_man1_MANS =
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 if ENABLE_PROCSTAT
 libprocstat_la_SOURCES = procstat.c 

--- a/ldms/src/sampler/shm/Makefile.am
+++ b/ldms/src/sampler/shm/Makefile.am
@@ -8,9 +8,13 @@ SUBDIRS= shm_util mpi_profiler
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la \
+		$(top_builddir)/lib/src/third/libovis_third.la
 
-LIBADD = $(COMMON_LIBADD) -lovis_third
+LIBADD = $(COMMON_LIBADD)
 
 libshm_sampler_la_SOURCES = shm_sampler.c
 libshm_sampler_la_LIBADD = $(LIBADD) $(JOBID_LIBFLAGS) shm_util/liblshm.la -lm -lrt -lpthread

--- a/ldms/src/sampler/shm/mpi_profiler/Makefile.am
+++ b/ldms/src/sampler/shm/mpi_profiler/Makefile.am
@@ -3,7 +3,10 @@ bin_PROGRAMS =
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 CC=$(MPICC)
 CCLD=$(MPICC)
@@ -16,7 +19,9 @@ bin_PROGRAMS += MPIApp
 nodist_MPIApp_SOURCES = mpi_profiler_wrapped_functions.c
 MPIApp_SOURCES = mpi_profiler.c mpi_profiler.h mpi_profiler_configuration.c mpi_profiler_configuration.h mpi_profiler_func_list.c mpi_profiler_func_list.h sample_mpi_application.c userheader.h
 MPIApp_CFLAGS = $(AM_CFLAGS) -v
-MPIApp_LDADD = ../shm_util/liblshm.la -lovis_third -lpthread -lm
+MPIApp_LDADD = ../shm_util/liblshm.la \
+	       $(top_builddir)/lib/src/third/libovis_third.la \
+	       -lpthread -lm
 
 WRAPINPUT=$(srcdir)/wrap/input.w
 mpi_profiler_wrapped_functions.c: Makefile wrap/wrap.py wrap/input.w userheader.h

--- a/ldms/src/sampler/shm/shm_util/Makefile.am
+++ b/ldms/src/sampler/shm/shm_util/Makefile.am
@@ -4,7 +4,7 @@ AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
 #COMMON_LIBADD = -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
 
-COMMON_LIBADD = @LDFLAGS_GETTIME@ -lovis_third
+COMMON_LIBADD = @LDFLAGS_GETTIME@ $(top_builddir)/lib/src/third/libovis_third.la
 
 lib_LTLIBRARIES = liblshm.la
 

--- a/ldms/src/sampler/slurm/Makefile.am
+++ b/ldms/src/sampler/slurm/Makefile.am
@@ -3,10 +3,17 @@ dist_man7_MANS=
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms -lldmsd_stream @LDFLAGS_GETTIME@ -lovis_util -lcoll -lpthread
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		$(top_builddir)/ldms/src/ldmsd/libldmsd_stream.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la \
+		$(top_builddir)/lib/src/json/libjson_util.la \
+		-lpthread
 
 libslurm_sampler_la_SOURCES = slurm_sampler.c slurm_sampler.h
-libslurm_sampler_la_LIBADD = $(COMMON_LIBADD) -ljson_util
+libslurm_sampler_la_LIBADD = $(COMMON_LIBADD)
 libslurm_sampler_la_CFLAGS = -DSYSCONFDIR='"$(sysconfdir)"'
 pkglib_LTLIBRARIES += libslurm_sampler.la
 

--- a/ldms/src/sampler/spank/Makefile.am
+++ b/ldms/src/sampler/spank/Makefile.am
@@ -3,11 +3,16 @@ dist_man7_MANS=
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		$(top_builddir)/ldms/src/ldmsd/libldmsd_stream.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la \
+		$(top_builddir)/lib/src/json/libjson_util.la
 
 libslurm_notifier_la_SOURCES = slurm_notifier.c
-libslurm_notifier_la_LIBADD = $(COMMON_LIBADD) -ljson_util \
-			      -lldmsd_stream
+libslurm_notifier_la_LIBADD = $(COMMON_LIBADD)
 libslurm_notifier_la_CFLAGS = $(SLURM_INCDIR_FLAG) -DSYSCONFDIR='"$(sysconfdir)"'
 # libslurm_notifier_la_LDFLAGS = -module
 pkglib_LTLIBRARIES += libslurm_notifier.la

--- a/ldms/src/sampler/syspapi/Makefile.am
+++ b/ldms/src/sampler/syspapi/Makefile.am
@@ -5,7 +5,11 @@ EXTRA_DIST = test/ldmsd.sh
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@ @LIBPAPI_INCDIR_FLAG@ @LIBPFM_INCDIR_FLAG@ 
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 AM_LDFLAGS += @LIBPAPI_LIB64DIR_FLAG@ @LIBPAPI_LIBDIR_FLAG@ \
 	     @LIBPFM_LIB64DIR_FLAG@ @LIBPFM_LIBDIR_FLAG@

--- a/ldms/src/sampler/vmstat/Makefile.am
+++ b/ldms/src/sampler/vmstat/Makefile.am
@@ -5,7 +5,11 @@ dist_man1_MANS =
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+COMMON_LIBADD = ../libsampler_base.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
+		@LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/coll/libcoll.la
 
 if ENABLE_VMSTAT
 libvmstat_la_SOURCES = vmstat.c 

--- a/ldms/src/store/Makefile.am
+++ b/ldms/src/store/Makefile.am
@@ -3,10 +3,12 @@ lib_LTLIBRARIES =
 pkglib_LTLIBRARIES =
 
 AM_LDFLAGS = @OVIS_LIB_ABS@
-#COMMON_LIBADD = -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
 AM_CPPFLAGS = $(DBGFLAGS) @OVIS_INCLUDE_ABS@
 
-STORE_LIBADD = -lldms -lldmsd_plugattr -lcoll -lovis_util
+STORE_LIBADD = $(top_builddir)/ldms/src/core/libldms.la \
+	       $(top_builddir)/ldms/src/ldmsd/libldmsd_plugattr.la \
+	       $(top_builddir)/lib/src/coll/libcoll.la \
+	       $(top_builddir)/lib/src/ovis_util/libovis_util.la
 
 ldmsstoreincludedir = $(includedir)/ldms
 ldmsstoreinclude_HEADERS = store_csv_common.h
@@ -75,10 +77,4 @@ libstore_function_csv_la_SOURCES = store_common.h store_function_csv.c
 libstore_function_csv_la_LIBADD = $(STORE_LIBADD) -lpthread
 pkglib_LTLIBRARIES += libstore_function_csv.la
 
-endif
-
-if ENABLE_ME
-libconsumer_me_la_SOURCES = consumer_me.c
-libconsumer_me_la_LIBADD = $(STORE_LIBADD) -lzap
-lib_LTLIBRARIES += libconsumer_me.la
 endif

--- a/ldms/src/store/influx/Makefile.am
+++ b/ldms/src/store/influx/Makefile.am
@@ -5,11 +5,14 @@ pkglib_LTLIBRARIES =
 AM_LDFLAGS = @OVIS_LIB_ABS@
 #COMMON_LIBADD = -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
-STORE_LIBADD = -lldms -lcoll -lcurl -lovis_util
+STORE_LIBADD = $(top_builddir)/ldms/src/core/libldms.la \
+	       $(top_builddir)/lib/src/ovis_util/libovis_util.la \
+	       $(top_builddir)/lib/src/coll/libcoll.la \
+	       -lcurl
 
 if ENABLE_INFLUX
 libstore_influx_la_SOURCES = store_influx.c
-libstore_influx_la_LIBADD = $(STORE_LIBADD) -lcurl
+libstore_influx_la_LIBADD = $(STORE_LIBADD)
 pkglib_LTLIBRARIES += libstore_influx.la
 endif
 

--- a/ldms/src/store/kokkos/Makefile.am
+++ b/ldms/src/store/kokkos/Makefile.am
@@ -4,17 +4,18 @@ pkglib_LTLIBRARIES =
 CORE = ../../core
 
 AM_LDFLAGS = @OVIS_LIB_ABS@
-#COMMON_LIBADD = -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 
 CFLAGS := $(filter-out -Werror, ${CFLAGS})
 
-COMMON_LIBADD = -lldms -lovis_util
+COMMON_LIBADD = $(top_builddir)/ldms/src/core/libldms.la \
+		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		$(top_builddir)/lib/src/json/libjson_util.la
 
 libkokkos_store_la_SOURCES = kokkos_store.c
 libkokkos_store_la_CFLAGS = @SOS_INCDIR_FLAG@ $(AM_CFLAGS) -g -O0
 libkokkos_store_la_LIBADD = $(COMMON_LIBADD) \
-	@SOS_LIB64DIR_FLAG@ @SOS_LIBDIR_FLAG@ -lsos -lcrypto -ljson_util -lc
+	@SOS_LIB64DIR_FLAG@ @SOS_LIBDIR_FLAG@ -lsos -lcrypto -lc
 
 pkglib_LTLIBRARIES += libkokkos_store.la
 

--- a/ldms/src/store/papi/Makefile.am
+++ b/ldms/src/store/papi/Makefile.am
@@ -3,9 +3,10 @@ lib_LTLIBRARIES =
 pkglib_LTLIBRARIES =
 
 AM_LDFLAGS = @OVIS_LIB_ABS@
-#COMMON_LIBADD = -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
-STORE_LIBADD = -lldms -lcoll -lovis_util
+STORE_LIBADD = $(top_builddir)/ldms/src/core/libldms.la \
+	       $(top_builddir)/lib/src/coll/libcoll.la \
+	       $(top_builddir)/lib/src/ovis_util/libovis_util.la
 
 if ENABLE_SOS
 libstore_papi_la_SOURCES = store_papi.c

--- a/ldms/src/store/slurm/Makefile.am
+++ b/ldms/src/store/slurm/Makefile.am
@@ -7,7 +7,9 @@ AM_LDFLAGS = @OVIS_LIB_ABS@
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 
 AM_CFLAGS =  $(DBGFLAGS) -I$(srcdir)/../../sampler/slurm
-STORE_LIBADD = -lldms -lcoll -lovis_util
+STORE_LIBADD = $(top_builddir)/ldms/src/core/libldms.la \
+	       $(top_builddir)/lib/src/coll/libcoll.la \
+	       $(top_builddir)/lib/src/ovis_util/libovis_util.la
 
 if ENABLE_SOS
 libstore_slurm_la_SOURCES = store_slurm.c

--- a/ldms/src/store/store_flatfile/Makefile.am
+++ b/ldms/src/store/store_flatfile/Makefile.am
@@ -7,7 +7,10 @@ AM_LDFLAGS = @OVIS_LIB_ABS@
 #COMMON_LIBADD = -lldms -lldmsd_plugattr @LDFLAGS_GETTIME@ -lovis_util -lcoll
 AM_CPPFLAGS = $(DBGFLAGS) @OVIS_INCLUDE_ABS@
 
-STORE_LIBADD = -lldms -lldmsd_plugattr -lcoll -lovis_util
+STORE_LIBADD = $(top_builddir)/ldms/src/core/libldms.la \
+	       $(top_builddir)/ldms/src/ldmsd/libldmsd_plugattr.la \
+	       $(top_builddir)/lib/src/coll/libcoll.la \
+	       $(top_builddir)/lib/src/ovis_util/libovis_util.la
 
 ldmsstoreincludedir = $(includedir)/ldms
 

--- a/lib/src/json/Makefile.am
+++ b/lib/src/json/Makefile.am
@@ -27,7 +27,7 @@ ldmscoreinclude_HEADERS = json_util.h
 
 nodist_libjson_util_la_SOURCES = json_lexer.c json_parser.c json_parser.h
 libjson_util_la_SOURCES = json_util.c json_util.h
-libjson_util_la_LIBADD = -lcoll -lc -lcrypto
+libjson_util_la_LIBADD = ../coll/libcoll.la -lc -lcrypto ../third/libovis_third.la
 lib_LTLIBRARIES += libjson_util.la
 
 json_test_SOURCES = json_test.c json_util.h

--- a/m4/options.m4
+++ b/m4/options.m4
@@ -190,8 +190,8 @@ AC_DEFUN([OPTION_INCLUDE_FLAGS], [
 	dirlist=""
 	for dirtmp in $2; do
 		if test -d $srcdir/$dirtmp; then
-			tmprelflags="$tmprelflags -I$srcdir/$dirtmp"
-			tmpabsflags="$tmpabsflags -I\$(top_srcdir)/$dirtmp -I\$(top_builddir)/$dirtmp"
+			tmprelflags="$tmprelflags -I\$(top_srcdir)/$dirtmp -I\$(top_builddir)/$dirtmp"
+			tmpabsflags="$tmpabsflags -I\$(abs_top_srcdir)/$dirtmp -I\$(abs_top_builddir)/$dirtmp"
 		else
 			]AC_MSG_NOTICE([expected dir $srcdir/$dirtmp missing])[
 		fi
@@ -208,17 +208,18 @@ dnl REASON: produce lib flags list
 dnl EXAMPLE: OPTION_INC_FLAGS([ovis],[dir1 dir2])
 dnl - prefix: variable prefix
 dnl - subdirs: search locations
-dnl Defines $prefix_INCLUDE_REL (relative to top_builddir for in-configure)
-dnl Defines $prefix_INCLUDE_ABS (path to use in make)
+dnl Defines $prefix_LIB_REL (relative to top_builddir for in-configure)
+dnl Defines $prefix_LIB_ABS (path to use in make)
 AC_DEFUN([OPTION_LIB_FLAGS], [
 [ 
 	tmprelflags=""
 	tmpabsflags=""
+	tmppathflags=""
 	dirlist=""
 	for dirtmp in $2; do
 		if test -d $srcdir/$dirtmp; then
-			tmprelflags="$tmprelflags -L$srcdir/$dirtmp"
-			tmpabsflags="$tmpabsflags -L\$(top_builddir)/$dirtmp"
+			tmprelflags="$tmprelflags -Wl,-rpath-link=\$(top_builddir)/$dirtmp/.libs"
+			tmpabsflags="$tmpabsflags -Wl,-rpath-link=\$(abs_top_builddir)/$dirtmp/.libs"
 		else
 			]AC_MSG_NOTICE([expected dir $srcdir/$dirtmp missing])[
 		fi


### PR DESCRIPTION
The main issue that `--disable-rpath` did not work is that option.m4
`OPTION_LIB_FLAGS` constructed using `-L<DIR>` to add search path for
ld. However, when checking for a depended libraries, `ld` ignores `-L`
search path (see `ld(1)` under `-rpath-link` option explanation). Hence,
the linker cannot check for the 2nd-level dependency and resulted in
link error. For example, building libldms that does not use ovis_third,
but uses json_util which depends on ovis_third will result in an error.

This patch fix `OPTION_LIB_FLAGS` macro, supplying `-Wl,-rpath-link`
instead of `-L`.

Also, the in-tree library linking should use `.la` files instead of the
direct `-l` library request. This is addressed in this patch as well
(not using `.la` also resulted in build error when `--disable-rpath` is
present).

`me` module residue is also removed.

NOTE: This patch has been build/install using the following flag:
```sh
../configure --prefix=/opt/ovis \
             --enable-etc \
             --disable-rpath \
             --enable-rdma \
             --enable-fabric \
             --with-libfabric=/usr \
             --enable-sos \
             --with-sos=/opt/ovis \
             --enable-filesingle \
             --enable-perfevent \
             --enable-hweventpapi \
             --enable-fptrans \
             --enable-sysclassib \
             --enable-opa2 \
             --enable-atasmart \
             --enable-kokkos \
             --enable-jobinfo-slurm \
             --enable-spank-plugin \
             --enable-papi-sampler \
             --enable-ibm-occ \
             --enable-appinfo \
             --enable-ipmireader \
             --enable-influx \
             --enable-syspapi-sampler \
             --enable-munge
```

The installed libaries does not contain rpath information, e.g.:
```sh
root@ubuntu-1804:/opt/ovis/lib# ldd libldms.so
        linux-vdso.so.1 (0x00007ffd9938d000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f1dac561000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f1dac342000)
        libcoll.so.0 => not found
        libjson_util.so.0 => not found
        libmmalloc.so.0 => not found
        libzap.so.0 => not found
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f1dabf51000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f1dac97b000)
```
(even though they're in the same directory).