### PR TITLE
Fix no reference to LDMSDPORT

### DIFF
--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -711,7 +711,7 @@ int ldms_xprt_dir_cancel(ldms_t t);
 extern int ldms_xprt_dir(ldms_t x, ldms_dir_cb_t cb, void *cb_arg, uint32_t flags);
 
 #define LDMS_XPRT_LIBPATH_DEFAULT PLUGINDIR
-#define LDMS_DEFAULT_PORT	LDMSDPORT
+#define LDMS_DEFAULT_PORT	OVIS_LDMS_LDMSDPORT
 #define LDMS_LOOKUP_PATH_MAX	511
 
 enum ldms_lookup_flags {


### PR DESCRIPTION
LDMSDPORT is defined in `build/ldms/config.h`, and the file did not get
installed. Instead, the alternate version of the file
`build/ldms/src/ovis-ldms-config.h` is installed to avoid header file
collision. Hence, LDMSDPORT macro won't be resolved when compiling a
plugin outside of the ovis tree.

This patch change the use of LDMSDPORT to OVIS_LDMS_LDMSDPORT varient
that is defined in the installed header file ovis-ldms-config.h.