### PR TITLE
Fix `-l<LIB>` build issue for internal libraries

### DIFF
--- a/ldms/src/sampler/meminfo/Makefile.am
+++ b/ldms/src/sampler/meminfo/Makefile.am
@@ -5,11 +5,8 @@ dist_man1_MANS =
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
-		$(top_builddir)/ldms/src/core/libldms.la \
-		@LDFLAGS_GETTIME@ \
-		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
-		$(top_builddir)/lib/src/coll/libcoll.la
+COMMON_LIBADD = -lsampler_base -lldms -lovis_util -lcoll \
+		@LDFLAGS_GETTIME@
 
 if ENABLE_MEMINFO
 libmeminfo_la_SOURCES = meminfo.c 

--- a/m4/options.m4
+++ b/m4/options.m4
@@ -220,6 +220,8 @@ AC_DEFUN([OPTION_LIB_FLAGS], [
 		if test -d $srcdir/$dirtmp; then
 			tmprelflags="$tmprelflags -Wl,-rpath-link=\$(top_builddir)/$dirtmp/.libs"
 			tmpabsflags="$tmpabsflags -Wl,-rpath-link=\$(abs_top_builddir)/$dirtmp/.libs"
+			tmprelflags="$tmprelflags -L\$(top_builddir)/$dirtmp/.libs"
+			tmpabsflags="$tmpabsflags -L\$(abs_top_builddir)/$dirtmp/.libs"
 		else
 			]AC_MSG_NOTICE([expected dir $srcdir/$dirtmp missing])[
 		fi


### PR DESCRIPTION
The previous `--disable-rpath` build issue fix replaced `-L` with
`-Wl,-rpath-link` in OVIS_LIB flag building in `options.m4`. As a
result, the `-l<LIB>` (e.g. `-lldms`) style in `*_LDADD` (vs
`$(top_builddir)/ldms/src/core/libldms.la` style) will get a library not
found error.

This patch added back the `-L` option when building the OVIS_LIB flag in
`options.m4` to support internal library `-l<LIB>` in LDADD. The
`meminfo` Makefile.am was added in this patch as a showcase.

NOTE: This patch has been tested both with and without
`--disable-rpath`.