### PR TITLE
fix hardcoded version number that sneaked into test scripts.

### DIFF
--- a/ldms/scripts/ldms-static-test.sh.in
+++ b/ldms/scripts/ldms-static-test.sh.in
@@ -20,7 +20,7 @@ fi
 export pkglibdir=${ovis_ldms_pkglibdir}
 export PACKAGE_TARNAME=ovis-ldms
 export docdir=${ovis_ldms_datarootdir}/doc/${PACKAGE_TARNAME}
-export exdir=${ovis_ldms_datarootdir}/doc/${PACKAGE_TARNAME}-4.3.3
+export exdir=${ovis_ldms_datarootdir}/doc/${PACKAGE_TARNAME}-@VERSION@
 
 if test -z "$ZAP_LIBPATH"; then
 	ZAP_LIBPATH=$ovis_ldms_plugins

--- a/ldms/scripts/pll-ldms-static-test.sh.in
+++ b/ldms/scripts/pll-ldms-static-test.sh.in
@@ -26,7 +26,7 @@ fi
 export pkglibdir=${ovis_ldms_pkglibdir}
 export PACKAGE_TARNAME=ovis-ldms
 export docdir=${ovis_ldms_datarootdir}/doc/${PACKAGE_TARNAME}
-export exdir=${ovis_ldms_datarootdir}/doc/${PACKAGE_TARNAME}-4.3.3
+export exdir=${ovis_ldms_datarootdir}/doc/${PACKAGE_TARNAME}-@VERSION@
 
 if test -z "$ZAP_LIBPATH"; then
 	ZAP_LIBPATH=$ovis_ldms_plugins


### PR DESCRIPTION
a hardcode version slipped into [pll-]ldms-static-test.sh. This replaces it with @VERSION@

the same branch exists in ovis-hpc/ovis directly but should not.