### PR TITLE
add plugins_rpath

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,7 @@ AC_C_CONST
 AC_C_FLEXIBLE_ARRAY_MEMBER
 
 OVIS_PKGLIBDIR
+
 dnl change sharedstatedir default
 test "$sharedstatedir" = '${prefix}/com' && sharedstatedir='${prefix}/var/lib'
 
@@ -472,8 +473,10 @@ if test -n "$CHECK_SOS"; then
 fi
 if test -n "$SOS_LIB64DIR"; then
 	soslibdir="$SOS_LIB64DIR"
+	plugins_rpath="$plugins_rpath:$soslibdir"
 else
 	soslibdir="$SOS_LIBDIR"
+	plugins_rpath="$plugins_rpath:$soslibdir"
 fi
 AC_SUBST(soslibdir)
 
@@ -661,6 +664,7 @@ OVIS_DO_SUBST([LDMS_SUBST_RULE], ["sed \
 -e 's,[[@]]LDMSD_PLUGIN_LIBPATH[[@]],\$(LDMSD_PLUGIN_LIBPATH),g' \
 -e 's,[[@]]ZAP_LIBPATH[[@]],\$(ZAP_LIBPATH),g' \
 -e 's,[[@]]pkglibdir[[@]],\$(pkglibdir),g' \
+-e 's,[[@]]plugins_rpath[[@]],\$(plugins_rpath),g' \
 -e 's,[[@]]pythondir[[@]],\$(pythondir),g' \
 -e 's,[[@]]SOS_LIB64DIR[[@]],\$(SOS_LIB64DIR),g' \
 -e 's,[[@]]SOS_LIBDIR[[@]],\$(SOS_LIBDIR),g' \

--- a/configure.ac
+++ b/configure.ac
@@ -473,10 +473,11 @@ if test -n "$CHECK_SOS"; then
 fi
 if test -n "$SOS_LIB64DIR"; then
 	soslibdir="$SOS_LIB64DIR"
-	plugins_rpath="$plugins_rpath:$soslibdir"
-else
+	plugins_rpath="$plugins_rpath:$SOS_LIB64DIR"
+fi
+if test -n "$SOS_LIBDIR"; then
 	soslibdir="$SOS_LIBDIR"
-	plugins_rpath="$plugins_rpath:$soslibdir"
+	plugins_rpath="$plugins_rpath:$SOS_LIBDIR"
 fi
 AC_SUBST(soslibdir)
 

--- a/ldms/scripts/envldms.sh.in
+++ b/ldms/scripts/envldms.sh.in
@@ -20,7 +20,7 @@ if test -z "$LDMSD_PLUGIN_LIBPATH"; then
 	LDMSD_PLUGIN_LIBPATH=$ovis_ldms_plugins
 fi
 export LDMSD_PLUGIN_LIBPATH
-export LD_LIBRARY_PATH=${BUILDDIR}/lib:${exec_prefix}/lib:$ovis_ldms_plugins:@libeventpath@$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${ovis_ldms_plugins_rpath}:${BUILDDIR}/lib:${exec_prefix}/lib:$ovis_ldms_plugins:@libeventpath@:$LD_LIBRARY_PATH
 bname=`basename $0`
 BUILDDIR=@prefix@
 export PATH=${BUILDDIR}/sbin:$PATH

--- a/ldms/scripts/ldms-l2_test.sh.in
+++ b/ldms/scripts/ldms-l2_test.sh.in
@@ -79,7 +79,7 @@ else
 
 fi
 echo "logs and data stored under $TESTDIR"
-export LD_LIBRARY_PATH=$ovis_ldms_libdir:$ovis_ldms_pkglibdir:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${ovis_ldms_plugins_rpath}:$ovis_ldms_libdir:$ovis_ldms_pkglibdir:$LD_LIBRARY_PATH
 export ZAP_LIBPATH=$ovis_ldms_pkglibdir
 export PATH=${BUILDDIR}/sbin:$PATH
 export LDMSD_PLUGIN_LIBPATH=$ovis_ldms_pkglibdir

--- a/ldms/scripts/ldms-plugins.sh.in
+++ b/ldms/scripts/ldms-plugins.sh.in
@@ -23,7 +23,7 @@ if test -z "$LDMSD_PLUGIN_LIBPATH"; then
 	LDMSD_PLUGIN_LIBPATH=$ovis_ldms_plugins
 fi
 export LDMSD_PLUGIN_LIBPATH
-export LD_LIBRARY_PATH=${BUILDDIR}/lib:${exec_prefix}/lib:$ovis_ldms_plugins:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${ovis_ldms_plugins_rpath}:${BUILDDIR}/lib:${exec_prefix}/lib:$ovis_ldms_plugins:$LD_LIBRARY_PATH
 export PATH=${exec_prefix}/sbin:$PATH
 
 

--- a/ldms/scripts/ldms-static-test.sh.in
+++ b/ldms/scripts/ldms-static-test.sh.in
@@ -30,7 +30,7 @@ if test -z "$LDMSD_PLUGIN_LIBPATH"; then
 	LDMSD_PLUGIN_LIBPATH=$ovis_ldms_plugins
 fi
 export LDMSD_PLUGIN_LIBPATH
-export LD_LIBRARY_PATH=${ovis_ldms_soslibdir}:${BUILDDIR}/lib:${exec_prefix}/lib:$ovis_ldms_plugins:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${ovis_ldms_plugins_rpath}:${BUILDDIR}/lib:${exec_prefix}/lib:$ovis_ldms_plugins:$LD_LIBRARY_PATH
 
 function clusage {
 cat << EOF

--- a/ldms/scripts/ldms-wrapper.in
+++ b/ldms/scripts/ldms-wrapper.in
@@ -19,7 +19,7 @@ if test -z "$LDMSD_PLUGIN_LIBPATH"; then
 	LDMSD_PLUGIN_LIBPATH=$ovis_ldms_plugins
 fi
 export LDMSD_PLUGIN_LIBPATH
-LD_LIBRARY_PATH=${ovis_ldms_soslibdir}:${BUILDDIR}/lib:${exec_prefix}/lib:$ovis_ldms_plugins:$LD_LIBRARY_PATH
+LD_LIBRARY_PATH=${ovis_ldms_plugins_rpath}:${BUILDDIR}/lib:${exec_prefix}/lib:$ovis_ldms_plugins:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH
 bname=`basename $0`
 if test -x $ovis_ldms_sbindir/$bname; then

--- a/ldms/scripts/pll-ldms-static-test.sh.in
+++ b/ldms/scripts/pll-ldms-static-test.sh.in
@@ -36,7 +36,7 @@ if test -z "$LDMSD_PLUGIN_LIBPATH"; then
 	LDMSD_PLUGIN_LIBPATH=$ovis_ldms_plugins
 fi
 export LDMSD_PLUGIN_LIBPATH
-export LD_LIBRARY_PATH=${ovis_ldms_soslibdir}:${BUILDDIR}/lib:${exec_prefix}/lib:$ovis_ldms_plugins:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${ovis_ldms_plugins_rpath}:${BUILDDIR}/lib:${exec_prefix}/lib:$ovis_ldms_plugins:$LD_LIBRARY_PATH
 
 function clusage {
 cat << EOF

--- a/ldms/src/ovis-ldms-configvars.sh.in
+++ b/ldms/src/ovis-ldms-configvars.sh.in
@@ -1,5 +1,6 @@
 #!/bin/sh
 ovis_ldms_plugins=@pkglibdir@
+ovis_ldms_plugins_rpath=@plugins_rpath@
 ovis_ldms_version=@VERSION@
 ovis_ldms_mandir=@mandir@
 ovis_ldms_localedir=@localedir@

--- a/m4/options.m4
+++ b/m4/options.m4
@@ -93,6 +93,7 @@ dnl SYNOPSIS: OPTION_WITH([name], [VAR_BASE_NAME])
 dnl EXAMPLE: OPTION_WITH([xyz], [XYZ])
 dnl NOTE: With VAR_BASE_NAME being XYZ, this macro will set XYZ_INCIDR and
 dnl 	XYZ_LIBDIR to the include path and library path respectively.
+dnl 	It also appends discovered library paths to plugins_rpath
 AC_DEFUN([OPTION_WITH], [
 dnl reset withval, or prior option_with uses bleed in here.
 withval=""
@@ -120,6 +121,7 @@ xyes | x/usr | x)
 		$2_LIBDIR=$WITH_$2/lib
 		$2_LIBDIR_FLAG="-L$WITH_$2/lib"
 		LDFLAGS="$LDFLAGS -Wl,-rpath-link=$WITH_$2/lib"
+		plugins_rpath="$plugins_rpath:$WITH_$2/lib"
 	fi
 	havelibdir=""
 	havelib64dir=""
@@ -128,12 +130,14 @@ xyes | x/usr | x)
 		$2_LIBDIR=$WITH_$2/lib64
 		$2_LIBDIR_FLAG=-L$WITH_$2/lib64
 		LDFLAGS="$LDFLAGS -Wl,-rpath-link=$WITH_$2/lib64"
+		plugins_rpath="$plugins_rpath:$WITH_$2/lib64"
 	fi
 	if test -d $WITH_$2/lib64; then
 		havelib64dir="yes"
 		$2_LIB64DIR=$WITH_$2/lib64
 		$2_LIB64DIR_FLAG="-L$WITH_$2/lib64"
 		LDFLAGS="$LDFLAGS -Wl,-rpath-link=$WITH_$2/lib64"
+		plugins_rpath="$plugins_rpath:$WITH_$2/lib64"
 	fi
 	if test -d $WITH_$2/include; then
 		$2_INCDIR=$WITH_$2/include
@@ -151,6 +155,7 @@ AC_SUBST([$2_INCDIR], [$$2_INCDIR])
 AC_SUBST([$2_LIBDIR_FLAG], [$$2_LIBDIR_FLAG])
 AC_SUBST([$2_LIB64DIR_FLAG], [$$2_LIB64DIR_FLAG])
 AC_SUBST([$2_INCDIR_FLAG], [$$2_INCDIR_FLAG])
+AC_SUBST(plugins_rpath)
 ])
 
 dnl SYNOPSIS: OPTION_WITH_PORT([name])


### PR DESCRIPTION
This adds the plugins_rpath (a generalization of the configure.ac soslibdir variable) to configure and environment scripts. Plugins_rpath can be added to the runtime LD_LIBRARY_PATH to allow resolution of any off-path libraries used by ldms plugins, such as libpapi and libsos.