### PR TITLE
zap must not be freed by ldms (potential use-after-free)

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2571,13 +2571,11 @@ int __ldms_xprt_zap_new(struct ldms_xprt *x, const char *name,
 	if (!x->zap_ep) {
 		log_fn("ERROR: Cannot create zap endpoint.\n");
 		ret = ENOMEM;
-		goto err1;
+		goto err0;
 	}
 	x->max_msg = zap_max_msg(x->zap);
 	zap_set_ucontext(x->zap_ep, x);
 	return 0;
-err1:
-	free(x->zap);
 err0:
 	return ret;
 }


### PR DESCRIPTION
In `__ldms_xprt_zap_new()`, the zap driver is obtained and is cached
by `__ldms_zap_get(); zap_get();` call chain. But, in the error path of
`__ldms_xprt_zap_new()`, the cached `zap` driver is freed, leading to
use-after-free for the next call of the same transport type. This patch
modify the error path to not free the cached zap driver.