### PR TITLE
Fix `json_entity_new()` call in json_parser

### DIFF
--- a/lib/src/json/json_parser.y
+++ b/lib/src/json/json_parser.y
@@ -36,7 +36,7 @@ static inline json_entity_t new_dict_val(void) {
 
 static inline json_entity_t add_dict_attr(json_entity_t e, json_entity_t name, json_entity_t value)
 {
-	json_entity_t a = json_entity_new(JSON_ATTR_VALUE, name, value);
+	json_entity_t a = json_entity_new(JSON_ATTR_VALUE, name->value.str_->str, value);
 	if (a) {
 		json_attr_add(e, a);
 		return e;


### PR DESCRIPTION
`json_parser` was broken by the `json_entity_new()` API change.