### PR TITLE
fix logic bugs in v4 ldmsd_request_util

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request_util.c
+++ b/ldms/src/ldmsd/ldmsd_request_util.c
@@ -167,7 +167,7 @@ const struct req_str_id attr_str_id_table[] = {
 	{  "xprt",              LDMSD_ATTR_XPRT  },
 };
 
-uint32_t req_str_id_cmp(const struct req_str_id *a, const struct req_str_id *b)
+int32_t req_str_id_cmp(const struct req_str_id *a, const struct req_str_id *b)
 {
 	return strcmp(a->str, b->str);
 }
@@ -321,6 +321,7 @@ static int add_attr_from_attr_str(const char *name, const char *value,
 	if (!name && !value) {
 		/* Terminate the attribute list */
 		value = NULL;
+		val_sz = 0;
 		attr_sz = sizeof(uint32_t);
 		is_terminating = 1;
 	} else {
@@ -646,7 +647,7 @@ int __ldmsd_parse_auth_add_req(struct ldmsd_parse_ctxt *ctxt)
 	size_t len = strlen(av);
 	size_t cnt = 0;
 	char *tmp, *name, *value, *ptr, *dummy;
-	int rc;
+	int rc = 0;
 	dummy = NULL;
 	tmp = malloc(len);
 	if (!tmp) {


### PR DESCRIPTION
fixes:
req_str_id_cmp return unsigned is inconsistent with internal computation and use as bsearch function
	(given c casting rules, we may be operating correctly in spite of ourselves)

use of uninitilized value in add_attr_from_attr_str main logic leads to buffer overrun

use of uninitilized value in less expected branch of __ldmsd_parse_auth_add_req logic leads to incorrect return