### PR TITLE
fix v4 util.c bugs

### DIFF
--- a/lib/src/ovis_util/test_util.c
+++ b/lib/src/ovis_util/test_util.c
@@ -27,6 +27,10 @@ void test_av()
 	av_list = av_new(4);
 	kw_list = av_new(4);
 	char *s = strdup("a=b c=d e f=ga");
+	if (!s) {
+		printf("strdup fail\n");
+		return;
+	}
 	int rc = tokenize(s, kw_list, av_list);
 	if (rc) {
 		printf("failed tokenize\n");

--- a/lib/src/ovis_util/util.c
+++ b/lib/src/ovis_util/util.c
@@ -1,5 +1,5 @@
 /* -*- c-basic-offset: 8 -*-
- * Copyright (c) 2013-2015,2017-2019 National Technology & Engineering
+ * Copyright (c) 2013-2015,2017-2020 National Technology & Engineering
  * Solutions of Sandia, LLC (NTESS). Under the terms of Contract
  * DE-NA0003525 with NTESS, the U.S. Government retains certain rights
  * in this software.
@@ -107,13 +107,15 @@ int _scpy(char **buff, size_t *slen, size_t *alen,
 	strncpy(*buff+*slen, str, len);
 	*alen -= len;
 	*slen += len;
-	(*buff)[*slen] = 0;
+	(*buff)[*slen] = '\0';
 	return 0;
 }
 
 char *str_repl_cmd(const char *_str)
 {
 	char *str = strdup(_str);
+	if (!str)
+		goto err;
 	char *buff = NULL;
 	char *xbuff;
 	const char *eos = str + strlen(str);
@@ -124,7 +126,7 @@ char *str_repl_cmd(const char *_str)
 	char *cmd;
 	int rc;
 	int count;
-	FILE *p;
+	FILE *p = NULL;
 
 	if (!str)
 		goto err;
@@ -213,6 +215,8 @@ char *str_repl_cmd(const char *_str)
 err:
 	free(str);
 	free(buff);
+	if (p)
+		pclose(p);
 	return NULL;
 }
 
@@ -526,9 +530,10 @@ int av_check_expansion(printf_t log, const char *n, const char *s)
 size_t ovis_get_mem_size(const char *s)
 {
     char unit;
-#define TSZ 256
-    char tmp[TSZ];
-    snprintf(tmp, TSZ, "%s%s", s, "B");
+
+    size_t n = strlen(s) + 3;
+    char tmp[n];
+    snprintf(tmp, n, "%s%s", s, "B");
     size_t size;
     sscanf(tmp, "%lu %c", &size, &unit);
     switch (unit) {
@@ -1044,14 +1049,14 @@ ovis_pgrep_array_t ovis_pgrep(const char *text)
 		i++;
 	}
 
-	rc = 0;
 	goto out;
 err1:
 	while ((ent = TAILQ_FIRST(&head))) {
 		TAILQ_REMOVE(&head, ent, entry);
 		free(ent);
 	}
-out:
+out: 	if (dir)
+		closedir(dir);
 	return array;
 }
 


### PR DESCRIPTION
test_util.c:
missing oom check
util:
	str_repl_cmd: missing oom check, uninit var use, pipe leak
	ovis_pgrep: directory leak, unused var
	ovis_get_mem_size: buffer overrun
	_scpy: incorrect nul terminator