### PR TITLE
fix json parser nits

### DIFF
--- a/lib/src/json/json_util.c
+++ b/lib/src/json/json_util.c
@@ -57,8 +57,9 @@ jbuf_t jbuf_append_va(jbuf_t jb, const char *fmt, va_list _ap)
 	va_end(ap);
 	if (cnt > space) {
 		space = jb->buf_len + cnt + JSON_BUF_START_LEN;
-		jb = realloc(jb, space);
-		if (jb) {
+		jbuf_t njb = realloc(jb, space);
+		if (njb) {
+			jb = njb;
 			jb->buf_len = space;
 			goto retry;
 		} else {
@@ -71,7 +72,6 @@ jbuf_t jbuf_append_va(jbuf_t jb, const char *fmt, va_list _ap)
 
 jbuf_t jbuf_append_str(jbuf_t jb, const char *fmt, ...)
 {
-	int cnt, space;
 	va_list ap;
 	va_start(ap, fmt);
 	jb = jbuf_append_va(jb, fmt, ap);
@@ -81,7 +81,6 @@ jbuf_t jbuf_append_str(jbuf_t jb, const char *fmt, ...)
 
 jbuf_t jbuf_append_attr(jbuf_t jb, const char *name, const char *fmt, ...)
 {
-	int cnt, space;
 	va_list ap;
 	va_start(ap, fmt);
 	jb = jbuf_append_str(jb, "\"%s\":", name);

--- a/lib/src/json/json_util.h
+++ b/lib/src/json/json_util.h
@@ -117,7 +117,9 @@ struct json_loc_s {
 	char *filename;
 };
 
+#ifndef YY_TYPEDEF_YY_SCANNER_T
 typedef void *yyscan_t;
+#endif
 typedef struct json_parser_s {
 	yyscan_t scanner;
 	struct yy_buffer_state *buffer_state;


### PR DESCRIPTION
json_util.h: ifdef sometimes redundant macro
json_util.c: fix leak from incorrect oom check; clear unused vars.