### PR TITLE
add base_auth_parse to allow samplers to use standard uid/gid/perm

### DIFF
--- a/ldms/src/sampler/sampler_base.h
+++ b/ldms/src/sampler/sampler_base.h
@@ -166,4 +166,16 @@ void base_sample_end(base_data_t base);
  * the schema, and the containing structure. The set is not destroyed
  */
 void base_del(base_data_t base);
+
+/**
+ * \brief parse uid, gid, and perm values from attributes.
+ * \param avl attribute source to use.
+ * \param uid output location of uid
+ * \param gid output location of gid
+ * \param perm output location of perm
+ * Default output is uid,gid of current user and 777 permission.
+ * \return 0 on success, 1 on invalid user/group lookup.
+ */
+int base_auth_parse(struct attr_value_list *avl, uid_t *uid, gid_t *gid, int *perm, ldmsd_msg_log_f log);
+
 #endif


### PR DESCRIPTION
Parsing and checking uid/gid/perm is complicated enough that every
sampler should be able to use it without cloning code or being forced to use the
base schema jobid/compid/appid logic. This factors out the security
config parsing into a function and then calls it from the base_config
function.

I have a network sampler coming that needs this.