### PR TITLE
shared zap map and ldms rbd removal

### DIFF
--- a/NOTE-ZAP-TEST-SHARED-MAP.md
+++ b/NOTE-ZAP-TEST-SHARED-MAP.md
@@ -1,0 +1,56 @@
+`zap_test_shared_man`
+=====================
+
+The test program is located at `lib/src/zap/test/zap_test_shared_map.c`. The
+configure option `--enable-zaptest` must be given to build the test program.
+The following is the configure options Narate used to build the test program.
+
+```sh
+../configure \
+        --prefix=${PREFIX} \
+        --enable-etc \
+        --enable-python \
+        --enable-test_sampler \
+        --enable-ldms-test \
+        --enable-zaptest \
+	--enable-rdma \
+        PYTHON='/usr/bin/python3' \
+        CFLAGS='-ggdb3 -O0 -Wall -Werror'
+```
+
+Test Scenario
+-------------
+
+- We will have a server (`zap_test_shared_map -m server`) that listens to
+  multiple transport and a single memory region to share with all clients
+  connecting to it.  Initially, the memory block is initialized with zeros.
+
+- A "writer" client (`zap_test_shared_map -m writer`) then connects to the
+  server and write a pre-defined data to the memory block in the server.
+
+- A "reader" client (`zap_test_shared_map -m reader`) connects to the server to
+  read the memory block and verifies that the data is as expected.
+
+
+It is recommended that the server run on one node, and the clients run on
+another node. On cygnus cluster, rdma transport to self does not work.
+
+The following is an example of sequence of execution:
+
+```sh
+# Listen on sock 20000 and rdma 20001
+root@cygnus-08 $ zap_test_shared_map -m server -x sock:*:20000 -x rdma:*:20001
+
+# On another node, run the writer using rdma
+root@cygnus-07 $ zap_test_shared_map -m writer -x rdma:cygnus-08-iw:20001
+
+# Then verify with sock
+root@cygnus-07 $ zap_test_shared_map -m reader -x sock:cygnus-08:20000
+Info: data verified
+
+# It is OK to verify multiple times with any transport
+root@cygnus-07 $ zap_test_shared_map -m reader -x rdma:cygnus-08-iw:20001
+
+# If we want to test writing using sock, the server need to be restarted as the
+# data has already been modified.
+```

--- a/ldms/examples/multiple-xprt/ldmsd.cfg
+++ b/ldms/examples/multiple-xprt/ldmsd.cfg
@@ -1,0 +1,28 @@
+# ldmsd can listen to multiple transports
+
+# `sock` transport can listen on `*` address. This can be reached using:
+#     ldms_ls -x sock -p 10000 -h cygnus-07 -l
+listen xprt=sock port=10000
+
+# fabric needs specific listening address. The following config command makes
+# ldmsd listen on port 10001 at cygnus-07 using fabric transport with sockets
+# fabric provider and enp1s0 domain. This can be reached via:
+#     ldms_ls -x fabric.sockets -p 10001 -h cygnus-07 -l
+listen xprt=fabric.sockets@enp1s0 host=cygnus-07 port=10001
+
+# fabric needs specific listening address. The following config command makes
+# ldmsd listen on port 10001 at cygnus-07-iw (the address of the iwarp card)
+# using fabric transport with verbs fabric provider. By omitting the domain,
+# fi_info() will choose the domain for us. This can be reached via:
+#     ldms_ls -x fabric.verbs -p 10002 -h cygnus-07-iw -l
+listen xprt=fabric.verbs host=cygnus-07-iw port=10002
+
+# similar to above, but using zap_rdma transport instead of libfabric. This can
+# be reached via:
+#     ldms_ls -x rdma -p 10003 -h cygnus-07-iw -l
+listen xprt=rdma host=cygnus-07-iw port=10003
+
+load name=mem plugin=meminfo
+config name=mem
+smplr_add name=mem_samp instance=mem interval=1000000 offset=0
+smplr_start name=mem_samp

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -68,8 +68,7 @@
 extern "C" {
 #endif
 typedef struct ldms_xprt *ldms_t;
-typedef struct ldms_rbuf_desc *ldms_rbuf_t;
-typedef struct ldms_rbuf_desc *ldms_set_t;
+typedef struct ldms_set *ldms_set_t;
 typedef struct ldms_value_s *ldms_value_t;
 typedef struct ldms_schema_s *ldms_schema_t;
 

--- a/ldms/src/test/test_ldms_push.c
+++ b/ldms/src/test/test_ldms_push.c
@@ -255,7 +255,6 @@ static const char *metric_type_enum2str(enum metric_type type)
 static void __print_json_set(ldms_set_t s, enum update_type type)
 {
 	int i;
-	struct ldms_set *set = (struct ldms_set *)s->set;
 	printf("{"
 		"\"type\":\"%s\","
 		"\"set_name\":\"%s\","
@@ -266,9 +265,9 @@ static void __print_json_set(ldms_set_t s, enum update_type type)
 		"\"metrics\":[",
 		update_type_enum2str(type),
 		ldms_set_instance_name_get(s),
-		set->meta->meta_gn,
-		set->data->meta_gn,
-		set->data->gn,
+		s->meta->meta_gn,
+		s->data->meta_gn,
+		s->data->gn,
 		ldms_set_card_get(s));
 	for (i = 0; i < ldms_set_card_get(s); i++) {
 		if (i > 0)
@@ -290,14 +289,13 @@ static void __print_json_set(ldms_set_t s, enum update_type type)
 
 static void __print_set(ldms_set_t s)
 {
-	struct ldms_set *set = (struct ldms_set *)s->set;
 	int card = ldms_set_card_get(s);
 	enum ldms_value_type type;
 	printf("--------------------------------\n");
 	printf("set name: %s\n", ldms_set_instance_name_get(s));
-	printf("       meta->meta_gn: %" PRIu64 "\n", set->meta->meta_gn);
-	printf("       data->meta_gn: %" PRIu64 "\n", set->data->meta_gn);
-	printf("            data->gn: %" PRIu64 "\n", set->data->gn);
+	printf("       meta->meta_gn: %" PRIu64 "\n", s->meta->meta_gn);
+	printf("       data->meta_gn: %" PRIu64 "\n", s->data->meta_gn);
+	printf("            data->gn: %" PRIu64 "\n", s->data->gn);
 	printf("   Number of metrics: %d\n", card);
 	printf("	%-10s %16s\n", "MetricName", "Value");
 	int i, j, n;

--- a/ldms/src/test/test_ldms_set_info.c
+++ b/ldms/src/test/test_ldms_set_info.c
@@ -359,7 +359,7 @@ int test_ldms_set_info_set(ldms_set_t s, const char *key, const char *value)
 		assert(0);
 	}
 
-	pair = LIST_FIRST(&s->set->local_info);
+	pair = LIST_FIRST(&s->local_info);
 	if (!pair) {
 		printf("\n	Failed to add key '%s' value '%s'\n", key, value);
 		assert(0);
@@ -393,7 +393,7 @@ int test_ldms_set_info_reset_value(ldms_set_t s, const char *key,
 		assert(0);
 	}
 
-	pair = __set_info_get(&s->set->local_info, key);
+	pair = __set_info_get(&s->local_info, key);
 	if (!pair) {
 		printf("\n	Failed!. The key does not exist.\n");
 		assert(0);
@@ -414,7 +414,7 @@ int test_ldms_set_info_unset(ldms_set_t s, const char *key, const char *value)
 	__add_pair(key, NULL);
 	ldms_set_info_unset(s, key);
 
-	pair = __set_info_get(&s->set->local_info, key);
+	pair = __set_info_get(&s->local_info, key);
 	if (pair) {
 		printf("\n	Failed. The pair still exists after it was removed.\n");
 		assert(0);

--- a/lib/src/zap/rdma/zap_rdma.h
+++ b/lib/src/zap/rdma/zap_rdma.h
@@ -100,10 +100,11 @@ struct z_rdma_reject_msg {
 #pragma pack()
 
 struct z_rdma_map {
-	struct zap_map map;
-	struct ibv_mr *mr;
 	uint32_t rkey;
+	struct ibv_mr *mr[OVIS_FLEX];
 };
+
+#define Z_RDMA_MAP_SZ (sizeof(struct z_rdma_map) + ZAP_RDMA_MAX_PD*sizeof(struct ibv_mr *))
 
 struct z_rdma_buffer {
 	char *data;
@@ -153,6 +154,8 @@ struct z_rdma_ep {
 	struct ibv_cq *sq_cq;
 	struct ibv_pd *pd;
 	struct ibv_qp *qp;
+
+	int ce_id;
 
 	union {
 		struct z_rdma_conn_data conn_data; /* flexi */

--- a/lib/src/zap/sock/zap_sock.h
+++ b/lib/src/zap/sock/zap_sock.h
@@ -54,8 +54,8 @@
 #include "ovis_event/ovis_event.h"
 #include "ovis-lib-config.h"
 #include "coll/rbt.h"
-#include "zap.h"
-#include "zap_priv.h"
+#include "zap/zap.h"
+#include "zap/zap_priv.h"
 
 #define SOCKBUF_SZ 1024 * 1024
 
@@ -87,15 +87,12 @@
  */
 #define ZAP_SOCK_KEEPINTVL 2
 
-struct zap_sock_map {
-	struct zap_map map;
-	uint32_t key; /**< Key of the map. */
-};
-
 struct z_sock_key {
 	struct rbn rb_node;
-	struct zap_sock_map *map; /**< reference to zap_map */
+	struct zap_map *map; /**< reference to zap_map */
 };
+#define SOCK_MAP_KEY_GET(map) ((uint32_t)(uint64_t)((map)->mr[ZAP_SOCK]))
+#define SOCK_MAP_KEY_SET(map, key) (map)->mr[ZAP_SOCK] = (void*)(uint64_t)(key)
 
 typedef enum sock_msg_type {
 	SOCK_MSG_CONNECT = 1,     /*  Connect     data          */

--- a/lib/src/zap/test/Makefile.am
+++ b/lib/src/zap/test/Makefile.am
@@ -20,3 +20,7 @@ zap_test_disconnect_LDADD = $(builddir)/../libzap.la -lpthread -ldl
 sbin_PROGRAMS += zap_test_reconnect_many
 zap_test_reconnect_many_SOURCES = zap_test_reconnect_many.c
 zap_test_reconnect_many_LDADD = $(builddir)/../libzap.la -lpthread -ldl
+
+sbin_PROGRAMS += zap_test_shared_map
+zap_test_shared_map_SOURCES = zap_test_shared_map.c
+zap_test_shared_map_LDADD = $(builddir)/../libzap.la -lpthread -ldl

--- a/lib/src/zap/test/zap_test.c
+++ b/lib/src/zap/test/zap_test.c
@@ -227,7 +227,7 @@ void handle_recv(zap_ep_t ep, zap_event_t ev)
 	strcpy(mem.write_buf, WRITE_DATA_2);
 
 	/* Map the data to send */
-	err = zap_map(ep, &src_write_map, mem.write_buf, sizeof mem.write_buf,
+	err = zap_map(&src_write_map, mem.write_buf, sizeof mem.write_buf,
 			ZAP_ACCESS_NONE);
 	if (err) {
 		printf("%s:%d returns %d.\n", __func__, __LINE__, err);
@@ -262,7 +262,7 @@ void handle_rendezvous(zap_ep_t ep, zap_event_t ev)
 	strcpy(mem.write_buf, WRITE_DATA);
 
 	/* map the data to send */
-	err = zap_map(ep, &src_write_map, mem.write_buf, sizeof mem.write_buf,
+	err = zap_map(&src_write_map, mem.write_buf, sizeof mem.write_buf,
 			ZAP_ACCESS_NONE);
 	if (err) {
 		printf("%s:%d returns %d.\n", __func__, __LINE__, err);
@@ -282,7 +282,7 @@ void handle_rendezvous(zap_ep_t ep, zap_event_t ev)
 
 	/* Create a map for our peer to read from */
 	strcpy(mem.read_buf, READ_DATA);
-	err = zap_map(ep, &read_map, mem.read_buf, sizeof mem.read_buf, ZAP_ACCESS_READ);
+	err = zap_map(&read_map, mem.read_buf, sizeof mem.read_buf, ZAP_ACCESS_READ);
 	if (err) {
 		printf("Error %d for map of RDMA_READ memory.\n", err);
 		return;
@@ -307,7 +307,7 @@ void do_write_complete(zap_ep_t ep, zap_event_t ev)
 	}
 	zap_map_t write_src_map = (void *)(unsigned long)ev->context;
 	printf("Unmapping write map %p.\n", write_src_map);
-	err = zap_unmap(ep, write_src_map);
+	err = zap_unmap(write_src_map);
 	if (err)
 		printf("%s:%d returns %d.\n", __func__, __LINE__, err);
 	if (ev->status != ZAP_ERR_OK) {
@@ -371,11 +371,11 @@ void server_cb(zap_ep_t ep, zap_event_t ev)
 		break;
 	case ZAP_EVENT_DISCONNECTED:
 		if (remote_map) {
-			zap_unmap(ep, remote_map);
+			zap_unmap(remote_map);
 			remote_map = NULL;
 		}
 		if (read_map) {
-			zap_unmap(ep, read_map);
+			zap_unmap(read_map);
 			read_map = NULL;
 		}
 		assert((server_events & SERVER_DISCONNECTED) == 0);
@@ -408,7 +408,7 @@ void do_rendezvous(zap_ep_t ep)
 {
 	zap_err_t err;
 
-	err = zap_map(ep, &write_map, mem.write_buf, sizeof(mem.write_buf),
+	err = zap_map(&write_map, mem.write_buf, sizeof(mem.write_buf),
 		      ZAP_ACCESS_WRITE);
 	if (err) {
 		printf("Error %d mapping the write buffer.\n", err);
@@ -446,7 +446,7 @@ void do_read_and_verify_write(zap_ep_t ep, zap_event_t ev)
 	}
 
 	/* Create some memory to receive the read data */
-	err = zap_map(ep, &dst_read_map, mem.read_buf, zap_map_len(src_read_map),
+	err = zap_map(&dst_read_map, mem.read_buf, zap_map_len(src_read_map),
 		      ZAP_ACCESS_WRITE | ZAP_ACCESS_READ);
 	if (err) {
 		printf("Error %d mapping RDMA_READ data sink memory.\n", err);
@@ -479,7 +479,7 @@ void do_read_complete(zap_ep_t ep, zap_event_t ev)
 	zap_err_t err;
 	zap_map_t read_sink_map = (void *)(unsigned long)ev->context;
 	printf("Unmapping read map %p.\n", read_sink_map);
-	err = zap_unmap(ep, read_sink_map);
+	err = zap_unmap(read_sink_map);
 	if (err)
 		printf("%s:%d returns %d.\n", __func__, __LINE__, err);
 #if 0
@@ -493,7 +493,7 @@ void do_read_complete(zap_ep_t ep, zap_event_t ev)
 	assert (0 == (client_events & CLIENT_READ_SUCCESS));
 	client_events |= CLIENT_READ_SUCCESS;
 
-	zap_unmap(ep, write_map);
+	zap_unmap(write_map);
 
 	do_send(ep, dare);
 }
@@ -562,7 +562,7 @@ void client_cb(zap_ep_t ep, zap_event_t ev)
 		break;
 	case ZAP_EVENT_DISCONNECTED:
 		if (remote_map) {
-			zap_unmap(ep, remote_map);
+			zap_unmap(remote_map);
 			remote_map = NULL;
 		}
 		assert (0 == (client_events & CLIENT_DISCONNECTED));

--- a/lib/src/zap/test/zap_test_big.c
+++ b/lib/src/zap/test/zap_test_big.c
@@ -142,7 +142,7 @@ void server_cb(zap_ep_t ep, zap_event_t ev)
 		}
 		break;
 	case ZAP_EVENT_CONNECTED:
-		err = zap_map(ep, &map0, mem0, WSIZE,
+		err = zap_map(&map0, mem0, WSIZE,
 			      ZAP_ACCESS_READ|ZAP_ACCESS_WRITE);
 		if (err) {
 			printf("Error: zap_map() error: %d\n", err);
@@ -152,18 +152,18 @@ void server_cb(zap_ep_t ep, zap_event_t ev)
 		err = zap_share(ep, map0, NULL, 0);
 		if (err) {
 			printf("Error: zap_share() error: %d\n", err);
-			zap_unmap(ep, map0);
+			zap_unmap(map0);
 			zap_close(ep);
 			break;
 		}
 		break;
 	case ZAP_EVENT_DISCONNECTED:
 		if (map0) {
-			zap_unmap(ep, map0);
+			zap_unmap(map0);
 			map0 = NULL;
 		}
 		if (map1) {
-			zap_unmap(ep, map1);
+			zap_unmap(map1);
 			map1 = NULL;
 		}
 		zap_free(ep);
@@ -202,15 +202,15 @@ void client_cb(zap_ep_t ep, zap_event_t ev)
 		break;
 	case ZAP_EVENT_DISCONNECTED:
 		if (map0) {
-			zap_unmap(ep, map0);
+			zap_unmap(map0);
 			map0 = NULL;
 		}
 		if (map1) {
-			zap_unmap(ep, map1);
+			zap_unmap(map1);
 			map1 = NULL;
 		}
 		if (remote_map) {
-			zap_unmap(ep, remote_map);
+			zap_unmap(remote_map);
 			remote_map = NULL;
 		}
 		zap_free(ep);
@@ -245,14 +245,14 @@ void client_cb(zap_ep_t ep, zap_event_t ev)
 		assert(ev->map);
 		remote_map = ev->map;
 		memset(mem0, fill_ch, WSIZE);
-		err = zap_map(ep, &map0, mem0, WSIZE,
+		err = zap_map(&map0, mem0, WSIZE,
 			      ZAP_ACCESS_READ|ZAP_ACCESS_WRITE);
 		if (err) {
 			printf("zap_map() error: %d\n", err);
 			zap_close(ep);
 			break;
 		}
-		err = zap_map(ep, &map1, mem1, WSIZE,
+		err = zap_map(&map1, mem1, WSIZE,
 			      ZAP_ACCESS_READ|ZAP_ACCESS_WRITE);
 		if (err) {
 			printf("zap_map() error: %d\n", err);

--- a/lib/src/zap/test/zap_test_shared_map.c
+++ b/lib/src/zap/test/zap_test_shared_map.c
@@ -1,0 +1,524 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2020 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ * Copyright (c) 2020 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \file zap_test_shared_map.c
+ *
+ * \brief Zap shared map functionality test.
+ *
+ * This program run in three modes: server, writer, and reader.
+ *
+ * The server allocates a block of memory and register it with `zap_map()`.
+ * Then, it will `zap_share()` that map to anybody connecting to it. The server
+ * listen on multiple endpoints (specified multiple times by `-x xprt:addr:port`
+ * option). The memory block is initialized with all zeroes. The server process
+ * stays up for the entire life of the test.
+ *
+ * The writer connects to the server (-x xprt:addr:port) and wait for the
+ * RENDEZVOUS event. Then, it zap_write() data to the server, close
+ * connection and exit.
+ *
+ * The reader connects to the server (-x xprt:addr:port) using different
+ * transport and wait for the RENDEZVOUS event. Then, it zap_read() the data
+ * from the server and verifies that the data is the same as the writer wrote it
+ * then exit with success or failure.
+ *
+ * Example:
+ * $ zap_test_shared_map -m server -x sock:*:10000 -x rdma:*:10001
+ *
+ * # in another terminal / or on other node
+ * $ zap_test_shared_map -m writer -x sock:1.2.3.4:10000
+ *
+ * # on another node
+ * $ zap_test_shared_map -m reader -x rdma:5.6.7.8:10001
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <netinet/ip.h>
+#include <netdb.h>
+#include <stdarg.h>
+
+#include "zap.h"
+
+#ifndef ARRAY_LEN
+#define ARRAY_LEN(a) (sizeof(a)/sizeof((a)[0]))
+#endif
+
+/* data for verification */
+char data[1024] = "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG.";
+
+/* the memory block for read/write */
+char mem[1024] = {0};
+zap_map_t map; /* describe mem */
+zap_map_t peer_map; /* describe peer's mem */
+struct zap_mem_info meminfo = {.start = mem, .len = sizeof(mem)};
+
+int completed = 0;
+
+const char *shortopts = "x:m:?";
+
+struct xprt_spec_s {
+	const char *xprt;
+	const char *fabric_provider;
+	const char *fabric_domain;
+	struct sockaddr_in addr;
+};
+
+enum proc_mode {
+	MODE_NONE,
+	MODE_SERVER,
+	MODE_WRITER,
+	MODE_READER,
+	MODE_LAST,
+};
+typedef enum proc_mode proc_mode_t;
+
+struct xprt_spec_s xprt_spec[16] = {{0}}; /* should be enough */
+int xprt_spec_n = 0;
+proc_mode_t proc_mode = MODE_NONE;
+
+
+struct option longopts[] = {
+	{ "xprt" , 1 , 0 , 'x' },
+	{ "mode" , 1 , 0 , 'm' },
+	{ "help" , 1 , 0 , 'h' },
+	{ 0      , 0 , 0 ,  0  }
+};
+
+const char *_usage = "\
+SYNOPSIS\n\
+	zap_test_shared_map -m MODE -x XPRT:ADDR:PORT [-x ...]\n\
+\n\
+DESCRIPTION\n\
+\n\
+This program run in three modes: server, writer, and reader.\n\
+\n\
+The server allocates a block of memory and register it with `zap_map()`.\n\
+Then, it will `zap_share()` that map to anybody connecting to it. The server\n\
+listen on multiple endpoints (specified multiple times by `-x xprt:addr:port`\n\
+option). The memory block is initialized with all zeroes. The server process\n\
+stays up for the entire life of the test.\n\
+\n\
+The writer connects to the server (-x xprt:addr:port) and wait for the\n\
+RENDEZVOUS event. Then, it zap_write() data to the server, close\n\
+connection and exit.\n\
+\n\
+The reader connects to the server (-x xprt:addr:port) using different\n\
+transport and wait for the RENDEZVOUS event. Then, it zap_read() the data\n\
+from the server and verifies that the data is the same as the writer wrote it\n\
+then exit with success or failure.\n\
+\n\
+Example:\n\
+$ zap_test_shared_map -m server -x sock:*:10000 -x rdma:*:10001\n\
+\n\
+# in another terminal / or on other node\n\
+$ zap_test_shared_map -m writer -x sock:1.2.3.4:10000\n\
+\n\
+# on another node\n\
+$ zap_test_shared_map -m reader -x rdma:5.6.7.8:10001\n\
+\n\
+";
+
+void usage()
+{
+	printf("%s", _usage);
+}
+
+void __log(const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	vprintf(fmt, ap);
+	va_end(ap);
+}
+
+zap_mem_info_t __meminfo(void)
+{
+	return &meminfo;
+}
+
+
+void server_cb(zap_ep_t ep, zap_event_t ev)
+{
+	zap_err_t zerr;
+	switch (ev->type) {
+	case ZAP_EVENT_CONNECT_REQUEST:
+		printf("Info: conn request %p.\n", ep);
+		zap_accept(ep, server_cb, NULL, 0);
+		break;
+	case ZAP_EVENT_CONNECTED:
+		/* ep is the new endpoint */
+		printf("Info: connected %p.\n", ep);
+		zerr = zap_share(ep, map, NULL, 0);
+		assert(zerr == ZAP_ERR_OK);
+		break;
+	case ZAP_EVENT_DISCONNECTED:
+		printf("Info: disconnected %p.\n", ep);
+		/* no-op */
+		break;
+	case ZAP_EVENT_READ_COMPLETE:
+	case ZAP_EVENT_WRITE_COMPLETE:
+	case ZAP_EVENT_RECV_COMPLETE:
+	case ZAP_EVENT_REJECTED:
+	case ZAP_EVENT_RENDEZVOUS:
+	case ZAP_EVENT_CONNECT_ERROR:
+	case ZAP_EVENT_LAST:
+	default:
+		printf("Error: unexpected %s\n", zap_event_str(ev->type));
+		break;
+	}
+}
+
+void server_proc()
+{
+	int i;
+	zap_err_t zerr;
+	zap_ep_t zep;
+
+	zerr = zap_map(&map, mem, sizeof(mem), ZAP_ACCESS_READ|ZAP_ACCESS_WRITE);
+	if (zerr) {
+		printf("Error: zap_map() error: %d\n", zerr);
+		assert(0);
+		exit(-1);
+	}
+
+	for (i = 0; i < xprt_spec_n; i++) {
+		zep = zap_new_from_str(xprt_spec[i].xprt, server_cb,
+					__log, __meminfo);
+		if (!zep) {
+			printf("Error: zap_new() error: %d\n", errno);
+			assert(0);
+			exit(-1);
+		}
+		zerr = zap_listen(zep, (void*)&xprt_spec[i].addr,
+					sizeof(xprt_spec[i].addr));
+		if (zerr) {
+			printf("Error: zap_listen() error: %d\n", errno);
+			assert(0);
+			exit(-1);
+		}
+	}
+	while (!completed) {
+		sleep(1);
+	}
+	zap_unmap(map);
+}
+
+void writer_cb(zap_ep_t ep, zap_event_t ev)
+{
+	zap_err_t zerr;
+	switch (ev->type) {
+	case ZAP_EVENT_CONNECTED:
+		/* no-op */
+		printf("Info: connected.\n");
+		break;
+	case ZAP_EVENT_RENDEZVOUS:
+		peer_map = ev->map;
+		printf("Info: writing data to the server\n");
+		zerr = zap_write(ep, map, data,
+				 peer_map, zap_map_addr(peer_map),
+				 64, NULL);
+		if (zerr) {
+			printf("Error: zap_write() error: %d\n", zerr);
+			assert(0);
+			exit(-1);
+		}
+		break;
+	case ZAP_EVENT_WRITE_COMPLETE:
+		printf("Info: write completed, status: %d.\n", ev->status);
+		if (ev->status)
+			printf("Error: write completed with error: %d\n", ev->status);
+		completed = 1;
+		break;
+	case ZAP_EVENT_DISCONNECTED:
+		printf("Info: disconnected.\n");
+		/* no-op */
+		break;
+	case ZAP_EVENT_REJECTED:
+		printf("Error: connection rejected");
+		assert(0);
+		break;
+	case ZAP_EVENT_CONNECT_ERROR:
+		printf("Error: connect error");
+		assert(0);
+		break;
+	case ZAP_EVENT_CONNECT_REQUEST:
+	case ZAP_EVENT_READ_COMPLETE:
+	case ZAP_EVENT_RECV_COMPLETE:
+	case ZAP_EVENT_LAST:
+	default:
+		printf("Error: unexpected %s\n", zap_event_str(ev->type));
+		break;
+	}
+}
+
+void writer_proc()
+{
+	zap_err_t zerr;
+	zap_ep_t zep;
+	struct xprt_spec_s *spec = &xprt_spec[0];
+
+	zerr = zap_map(&map, data, sizeof(data), ZAP_ACCESS_READ);
+	if (zerr) {
+		printf("Error: zap_map() error: %d\n", zerr);
+		assert(0);
+		exit(-1);
+	}
+	zep = zap_new_from_str(spec->xprt, writer_cb, __log, __meminfo);
+	if (!zep) {
+		printf("Error: zap_new() error: %d\n", errno);
+		assert(0);
+		exit(-1);
+	}
+	zerr = zap_connect(zep, (void*)&spec->addr, sizeof(spec->addr), NULL, 0);
+	if (zerr) {
+		printf("Error: zap_connect() error: %d\n", zerr);
+		assert(0);
+		exit(-1);
+	}
+	while (!completed) {
+		sleep(1);
+	}
+	zap_unmap(peer_map);
+	zap_unmap(map);
+	zap_close(zep);
+}
+
+void reader_cb(zap_ep_t ep, zap_event_t ev)
+{
+	zap_err_t zerr;
+	switch (ev->type) {
+	case ZAP_EVENT_CONNECTED:
+		printf("Info: connected.\n");
+		/* no-op */
+		break;
+	case ZAP_EVENT_RENDEZVOUS:
+		printf("Info: map rendezvous.\n");
+		peer_map = ev->map;
+		zerr = zap_read(ep, peer_map, zap_map_addr(peer_map),
+				 map, mem,
+				 sizeof(mem), NULL);
+		if (zerr) {
+			printf("Error: zap_write() error: %d\n", zerr);
+			assert(0);
+			exit(-1);
+		}
+		break;
+	case ZAP_EVENT_READ_COMPLETE:
+		printf("Info: read completed, status: %d\n", ev->status);
+		if (ev->status)
+			printf("Error: read completed with error: %d\n", ev->status);
+		if (0 != memcmp(data, mem, sizeof(data))) {
+			/* bad */
+			printf("Error: bad read, data: %s\n", mem);
+			assert(0);
+			exit(-1);
+		} else {
+			/* good */
+			printf("Info: data verified\n");
+		}
+		completed = 1;
+		break;
+	case ZAP_EVENT_DISCONNECTED:
+		printf("Info: disconnected.\n");
+		/* no-op */
+		break;
+	case ZAP_EVENT_REJECTED:
+		printf("Error: connection rejected");
+		assert(0);
+		exit(-1);
+		break;
+	case ZAP_EVENT_CONNECT_ERROR:
+		printf("Error: connect error");
+		assert(0);
+		exit(-1);
+		break;
+	case ZAP_EVENT_CONNECT_REQUEST:
+	case ZAP_EVENT_RECV_COMPLETE:
+	case ZAP_EVENT_WRITE_COMPLETE:
+	case ZAP_EVENT_LAST:
+	default:
+		printf("Error: unexpected %s\n", zap_event_str(ev->type));
+		break;
+	}
+}
+
+void reader_proc()
+{
+	zap_err_t zerr;
+	zap_ep_t zep;
+	struct xprt_spec_s *spec = &xprt_spec[0];
+
+	zerr = zap_map(&map, mem, sizeof(mem), ZAP_ACCESS_READ|ZAP_ACCESS_WRITE);
+	if (zerr) {
+		printf("Error: zap_map() error: %d\n", zerr);
+		assert(0);
+		exit(-1);
+	}
+	zep = zap_new_from_str(spec->xprt, reader_cb, __log, __meminfo);
+	if (!zep) {
+		printf("Error: zap_new() error: %d\n", errno);
+		assert(0);
+		exit(-1);
+	}
+	zerr = zap_connect(zep, (void*)&spec->addr, sizeof(spec->addr), NULL, 0);
+	if (zerr) {
+		printf("Error: zap_connect() error: %d\n", zerr);
+		assert(0);
+		exit(-1);
+	}
+	while (!completed) {
+		sleep(1);
+	}
+	zap_unmap(peer_map);
+	zap_unmap(map);
+	zap_close(zep);
+}
+
+int parse_spec(char *text, struct xprt_spec_s *s, int ai_hint_flags)
+{
+	char *host, *port;
+	char *ptr;
+	struct addrinfo *ai;
+	struct addrinfo hint = {.ai_family = AF_INET, .ai_flags = ai_hint_flags};
+	int rc;
+	s->xprt = strtok_r(text, ":", &ptr);
+	host = strtok_r(NULL, ":", &ptr);
+	port = strtok_r(NULL, ":", &ptr);
+	if (!s->xprt || !host || !port) {
+		printf( "Error: spec parse error, expecting XPRT:ADDR:PORT, "
+			"but got: %s\n", text);
+		return EINVAL;
+	}
+	rc = getaddrinfo(host, port, &hint, &ai);
+	if (rc) {
+		printf("Error: getaddrinfo() error %d\n", rc);
+		return EINVAL;
+	}
+	memcpy(&s->addr, ai->ai_addr, ai->ai_addrlen);
+	freeaddrinfo(ai);
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	int opt;
+	int rc;
+	int ai_hint_flags = 0;
+	while ((opt=getopt_long(argc, argv, shortopts, longopts, NULL))>=0) {
+		switch (opt) {
+		case 'm':
+			if (proc_mode) {
+				printf("Error: mode has already been set\n");
+				assert(0);
+				exit(-1);
+			}
+			if (0 == strcasecmp("server", optarg)) {
+				proc_mode = MODE_SERVER;
+				ai_hint_flags = AI_PASSIVE;
+			} else if (0 == strcasecmp("writer", optarg)) {
+				proc_mode = MODE_WRITER;
+			} else if (0 == strcasecmp("reader", optarg)) {
+				proc_mode = MODE_READER;
+			} else {
+				printf("Error: unknown mode '%s'\n", optarg);
+				assert(0);
+				exit(-1);
+			}
+			break;
+		case 'x':
+			if (xprt_spec_n >= ARRAY_LEN(xprt_spec)) {
+				printf("Error: too many xprts\n");
+				assert(0);
+				exit(-1);
+			}
+			rc = parse_spec(optarg, &xprt_spec[xprt_spec_n++], ai_hint_flags);
+			if (rc) {
+				assert(0);
+				exit(-1);
+			}
+			break;
+		default:
+			usage();
+			exit(0);
+		}
+	}
+
+	if (!xprt_spec_n) {
+		printf("Error: xprt not specified.\n");
+		exit(-1);
+	}
+
+	switch (proc_mode) {
+	case MODE_SERVER:
+		server_proc();
+		break;
+	case MODE_WRITER:
+		writer_proc();
+		break;
+	case MODE_READER:
+		reader_proc();
+		break;
+	case MODE_NONE:
+		printf("Error: mode not set\n");
+		exit(-1);
+	default:
+		printf("Error: bad mode: %d\n", proc_mode);
+		exit(-1);
+	}
+	printf("Info: exiting...\n");
+
+	return 0;
+}

--- a/lib/src/zap/ugni/zap_ugni.h
+++ b/lib/src/zap/ugni/zap_ugni.h
@@ -112,9 +112,10 @@
 
 #define ZAP_UGNI_INIT_RECV_BUFF_SZ 4096
 
+/* This is used by handle rendezvous */
 struct zap_ugni_map {
 	struct zap_map map;
-	gni_mem_handle_t gni_mh; /**< GNI memory handle */
+	gni_mem_handle_t gni_mh;
 };
 
 struct z_ugni_key {

--- a/lib/src/zap/zap_priv.h
+++ b/lib/src/zap/zap_priv.h
@@ -233,12 +233,8 @@ struct zap {
 			  zap_map_t dst_map, char *dst, size_t sz,
 			  void *context);
 
-	/** Allocate a remote buffer */
-	zap_err_t (*map)(zap_ep_t ep, zap_map_t *pm, void *addr, size_t len,
-			 zap_access_t acc);
-
 	/** Free a remote buffer */
-	zap_err_t (*unmap)(zap_ep_t ep, zap_map_t map);
+	zap_err_t (*unmap)(zap_map_t map);
 
 	/** Share a mapping with a remote peer */
 	zap_err_t (*share)(zap_ep_t ep, zap_map_t m,
@@ -265,6 +261,19 @@ struct zap {
 
 	/** Pointer to the transport's private data */
 	void *private;
+
+	/** Endpoint option setter */
+	zap_err_t (*ep_setopt)(zap_ep_t ep, const char *name, const char *value);
+
+	/**
+	 * Create new endpoint from str.
+	 *
+	 * The `args` is the string after the '.' in the transport string
+	 * format. For example, if the xprt string is "fabric.sockets@eth0", the
+	 * `args` is "sockets@eth0". `args` could be NULL. Also see
+	 * `zap_new_from_str()` function.
+	 */
+	zap_ep_t (*new_from_str)(zap_t z, zap_cb_fn_t cb, const char *args);
 };
 
 static inline zap_err_t
@@ -292,6 +301,7 @@ struct zap_map {
 	zap_access_t acc;	  /*! Access rights */
 	char *addr;		  /*! Address of buffer. */
 	size_t len;		  /*! Length of the buffer */
+	void *mr[ZAP_LAST];	  /*! xprt-specific memory registrations */
 };
 
 struct zap_event_entry {


### PR DESCRIPTION
[x] zap_sock
[x] zap_rdma
[x] zap_ugni
    - 2 samp
    - 1 agg1
    - 1 agg2 -> sos
      - also tried killing 1 samp ... the set went away
      - resurrecting the sampler and the set was aggregated and stored
        again.
[x] fabric
    [x] add a way to select fabric provider/domain in
        [x] zap API
        [x] ldms xprt name (format: fabric.PROVIDER@DOM)
    [x] test zap sock with:
        [x] fabric.sockets@eth0
        [x] fabric.verbs
        [x] fabric.ugni - not supported due to lack of WAIT_FD and
	    fi_poll in gni provider.
[x] zaptest
[x] ldms/ldmsd
    [x] modify ldms to use shared map.
    [x] getting rid of rbd
    [x] Pass ldms-test/agg_test
    [x] Pass test_ldms_push
    [x] Pass test_ldms_notify
    [x] Pass all test cases in ldms-test repo (sock xprt)

[x] manually tested with the following use case:
    - 1 sampler (meminfo) listening on sock, fabric.sockets and
      fabric.verbs.
    - 1 aggregator collecting from the sampler over sock, and the
      aggregator also listen to sock, fabric.sockets and fabric.verbs
    - ldms_ls to aggregator over each transport type (sock,
      fabric.sockets, and fabric.verbs).
    - kill the sampler
    - ldms_ls to aggregator -- making sure it returns nothing
    - resurrect the sampler
    - ldms_ls over each tranport to aggregator verifying that the set
      (meminfo) is back.