### PR TITLE
Include error messages in sampler_base ooms.

### DIFF
--- a/ldms/src/sampler/sampler_base.c
+++ b/ldms/src/sampler/sampler_base.c
@@ -331,9 +331,14 @@ ldms_set_t base_set_new(base_data_t base)
 {
 	int rc;
 	base->missing_warned = 0;
+	errno = 0;
 	base->set = ldms_set_new(base->instance_name, base->schema);
-	if (!base->set)
+	if (!base->set) {
+		const char *serr = ovis_strerror(errno);
+		base->log(LDMSD_LERROR,"base_set_new: ldms_set_new failed %d(%s) for %s\n",
+				errno, serr, base->instance_name);
 		return NULL;
+	}
 	ldms_set_producer_name_set(base->set, base->producer_name);
 	ldms_metric_set_u64(base->set, BASE_COMPONENT_ID, base->component_id);
 	ldms_metric_set_u64(base->set, BASE_JOB_ID, 0);
@@ -344,6 +349,8 @@ ldms_set_t base_set_new(base_data_t base)
 		ldms_set_delete(base->set);
 		base->set = NULL;
 		errno = rc;
+		base->log(LDMSD_LERROR,"base_set_new: ldms_set_publish failed for %s\n",
+				base->instance_name);
 		return NULL;
 	}
 	ldmsd_set_register(base->set, base->pi_name);

--- a/lib/src/ovis_util/util.c
+++ b/lib/src/ovis_util/util.c
@@ -1,9 +1,9 @@
 /* -*- c-basic-offset: 8 -*-
- * Copyright (c) 2013-2015,2017-2019 National Technology & Engineering
+ * Copyright (c) 2013-2015,2017-2020 National Technology & Engineering
  * Solutions of Sandia, LLC (NTESS). Under the terms of Contract
  * DE-NA0003525 with NTESS, the U.S. Government retains certain rights
  * in this software.
- * Copyright (c) 2013-2015,2017-2019 Open Grid Computing, Inc.
+ * Copyright (c) 2013-2015,2017-2020 Open Grid Computing, Inc.
  * All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -940,6 +940,23 @@ const char* ovis_errno_abbvr(int e)
 		return estr[e];
 	}
 	return "UNKNOWN_ERRNO";
+}
+
+/**
+ * \brief thread-safe strerror.
+ *
+ * \retval str The sys_errlist value.
+ * \retval "unknown_errno" if the errno \c e is unknown.
+ */
+const char *ovis_strerror(int e) {
+	if (e >=0 && e < sys_nerr)
+		return sys_errlist[e];
+	return "unknown_errno";
+/* the gnu linker nuisance warning about sys_errlist.
+ * If we truly hate it, we can use the code from nginx ngx_strerror
+ * here. See: http://nginx.org/en/docs/sys_errlist.html
+ * for why this is a good idea.
+ */
 }
 
 /*

--- a/lib/src/ovis_util/util.h
+++ b/lib/src/ovis_util/util.h
@@ -1,8 +1,8 @@
 /* -*- c-basic-offset: 8 -*-
- * Copyright (c) 2013-2019 National Technology & Engineering Solutions
+ * Copyright (c) 2013-2020 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
- * Copyright (c) 2013-2019 Open Grid Computing, Inc. All rights reserved.
+ * Copyright (c) 2013-2020 Open Grid Computing, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -321,6 +321,15 @@ int ovis_access_check(uid_t auid, gid_t agid, int acc,
  * \retval "UNKNOWN_ERRNO" if the errno \c e is unknown.
  */
 const char* ovis_errno_abbvr(int e);
+
+/**
+ * \brief thread-safe strerror.
+ *
+ * \retval str The sys_errlist value, or the result of
+ * .ovis_errno_abbvr(e) if sys_errlist is not available.
+ * \retval "unknown_errno" if the errno \c e is unknown.
+ */
+const char *ovis_strerror(int e);
 
 typedef
 struct ovis_pgrep_s {


### PR DESCRIPTION
report errors from sampler-base when failures occur, often due to out of set memory.