### PR TITLE
Separate auth and core subdirectories

### DIFF
--- a/ldms/src/Makefile.am
+++ b/ldms/src/Makefile.am
@@ -11,16 +11,11 @@ do_subst = @LDMS_SUBST_RULE@
 	$(do_subst) < $< > $@
 	chmod 755 $@
 
-if ENABLE_CORE
 SUBDIRS += core
-endif
+SUBDIRS += ldmsd
 
 if ENABLE_OVIS_AUTH
 SUBDIRS += auth
-endif
-
-if ENABLE_LDMSD
-SUBDIRS += ldmsd
 endif
 
 if ENABLE_SAMPLER

--- a/ldms/src/Makefile.am
+++ b/ldms/src/Makefile.am
@@ -13,6 +13,9 @@ do_subst = @LDMS_SUBST_RULE@
 
 if ENABLE_CORE
 SUBDIRS += core
+endif
+
+if ENABLE_OVIS_AUTH
 SUBDIRS += auth
 endif
 


### PR DESCRIPTION
Sub-directories "core" and "auth" are built when CORE and OVIS_AUTH are enabled, respectively.