### PR TITLE
Update sampler 'variable' to actually work as planned.

### DIFF
--- a/ldms/scripts/examples/variable
+++ b/ldms/scripts/examples/variable
@@ -1,13 +1,37 @@
 export plugname=variable
 portbase=61072
-LDMSD -p prolog.sampler 1 2
-LDMSD -p prolog.sampler -p prolog.store3 3
+DAEMONS 1 3
+LDMSD -p prolog.sampler 1
+LDMSD 3
+sleep 3
 MESSAGE ldms_ls on host 1:
-LDMS_LS 1 -l
-MESSAGE ldms_ls on host 2:
-LDMS_LS 2 -l
+# redefine interval is 4
+LDMS_LS 1 -lv
+SLEEP 3
+LDMS_LS 1 -v -v
+SLEEP 3
+LDMS_LS 1 -v -v
+SLEEP 3
+LDMS_LS 1 -v -v
+SLEEP 3
+LDMS_LS 1 -v -v
+SLEEP 20
 MESSAGE ldms_ls on host 3:
-LDMS_LS 3
-SLEEP 5
+LDMS_LS 3 -v -v
+SLEEP 40
+LDMS_LS 3 -v -v
+SLEEP 40
+LDMS_LS 3 -v -v
+SLEEP 40
+LDMS_LS 3 -v -v
+LDMS_LS 1 -lv
 KILL_LDMSD `seq 3`
-file_created $STOREDIR/node/$testname
+file_created $STOREDIR/node/${testname}1
+file_created $STOREDIR/node/${testname}2
+file_created $STOREDIR/node/${testname}3
+file_created $STOREDIR/node/${testname}4
+file_created $STOREDIR/node/${testname}5
+file_created $STOREDIR/node/${testname}6
+file_created $STOREDIR/node/${testname}7
+file_created $STOREDIR/node/${testname}8
+file_created $STOREDIR/node/${testname}9

--- a/ldms/scripts/examples/variable.3
+++ b/ldms/scripts/examples/variable.3
@@ -1,0 +1,46 @@
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_start name=localhost1
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+strgp_add name=store_${testname}1 plugin=store_csv schema=${testname}1 container=node
+strgp_prdcr_add name=store_${testname}1 regex=.*
+strgp_start name=store_${testname}1
+
+strgp_add name=store_${testname}2 plugin=store_csv schema=${testname}2 container=node
+strgp_prdcr_add name=store_${testname}2 regex=.*
+strgp_start name=store_${testname}2
+
+strgp_add name=store_${testname}3 plugin=store_csv schema=${testname}3 container=node
+strgp_prdcr_add name=store_${testname}3 regex=.*
+strgp_start name=store_${testname}3
+
+strgp_add name=store_${testname}4 plugin=store_csv schema=${testname}4 container=node
+strgp_prdcr_add name=store_${testname}4 regex=.*
+strgp_start name=store_${testname}4
+
+strgp_add name=store_${testname}5 plugin=store_csv schema=${testname}5 container=node
+strgp_prdcr_add name=store_${testname}5 regex=.*
+strgp_start name=store_${testname}5
+
+strgp_add name=store_${testname}6 plugin=store_csv schema=${testname}6 container=node
+strgp_prdcr_add name=store_${testname}6 regex=.*
+strgp_start name=store_${testname}6
+
+strgp_add name=store_${testname}7 plugin=store_csv schema=${testname}7 container=node
+strgp_prdcr_add name=store_${testname}7 regex=.*
+strgp_start name=store_${testname}7
+
+strgp_add name=store_${testname}8 plugin=store_csv schema=${testname}8 container=node
+strgp_prdcr_add name=store_${testname}8 regex=.*
+strgp_start name=store_${testname}8
+
+strgp_add name=store_${testname}9 plugin=store_csv schema=${testname}9 container=node
+strgp_prdcr_add name=store_${testname}9 regex=.*
+strgp_start name=store_${testname}9
+

--- a/ldms/src/sampler/Makefile.am
+++ b/ldms/src/sampler/Makefile.am
@@ -84,13 +84,6 @@ libfptrans_la_LIBADD = $(COMMON_LIBADD)
 pkglib_LTLIBRARIES += libfptrans.la
 endif
 
-if ENABLE_VARSET
-libvariable_la_SOURCES = variable.c
-libvariable_la_LIBADD = $(COMMON_LIBADD) -lm
-pkglib_LTLIBRARIES += libvariable.la
-endif
-
-
 # always include examples
 SUBDIRS += examples
 

--- a/ldms/src/sampler/variable/Makefile.am
+++ b/ldms/src/sampler/variable/Makefile.am
@@ -1,0 +1,18 @@
+pkglib_LTLIBRARIES =
+lib_LTLIBRARIES =
+dist_man7_MANS =
+dist_man1_MANS =
+
+AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
+AM_LDFLAGS = @OVIS_LIB_ABS@
+COMMON_LIBADD = -lsampler_base -lldms -lovis_util -lcoll \
+		@LDFLAGS_GETTIME@
+
+if ENABLE_VARSET
+libvariable_la_SOURCES = variable.c 
+libvariable_la_LIBADD = $(COMMON_LIBADD)
+pkglib_LTLIBRARIES += libvariable.la
+dist_man7_MANS += Plugin_variable.man
+endif
+
+

--- a/ldms/src/sampler/variable/Plugin_variable.man
+++ b/ldms/src/sampler/variable/Plugin_variable.man
@@ -1,0 +1,65 @@
+.\" Manpage for Plugin_variable
+.\" Contact ovis-help@ca.sandia.gov to correct errors or typos.
+.TH man 7 "08 Jul 2020" "v4" "LDMS Plugin variable man page"
+
+.SH NAME
+Plugin_variable - man page for the LDMS variable plugin
+
+.SH SYNOPSIS
+Within ldmsd_controller or a configuration file:
+.br
+config name=variable [ <attr>=<value> ]
+
+.SH DESCRIPTION
+The variable plugin provides test data with a periodically redefined schema and set.
+Currently the period is every 4th sample. The data of the sampler is monotonically increasing integers. The data set size
+changes with each redefinition.
+
+
+.SH CONFIGURATION ATTRIBUTE SYNTAX
+The variable plugin does not use the sampler_base base class, but follows the naming conventions of sampler_base except for schema and instance name.
+
+
+.TP
+.BR config
+name=<plugin_name> [schema=<sname>]
+.br
+configuration line
+.RS
+.TP
+name=<plugin_name>
+.br
+This MUST be variable.
+.TP
+schema=<schema>
+.br
+Optional schema name prefix. The string given will be suffixed with an integer N in the range 1-9 to create the
+schema name. The schema will also contain N integer metrics.
+.TP
+instance=<inst>
+.br
+Optional instance name prefix. The string given will be suffixed with an integer in the range 1-9 to create the
+instance name. If not specified, will default prefix is `$HOST/variable`.
+.RE
+
+.SH NOTES
+The intent of the sampler is to simulate any sampler which may under some condition redefine the same instance name and schema name
+for a set after properly retiring a different definition using the same names. It is not for production use.
+
+To collect CSV data from this sampler, configure 9 store policies matching ${schema}[1-9], since the current storage policy mechanism does not allow matching
+multiple schemas.
+
+.SH BUGS
+No known bugs.
+
+.SH EXAMPLES
+.PP
+Within ldmsd_controller or a configuration file:
+.nf
+load name=variable
+config name=variable producer=vm1_1 instance=vm1_1/variable
+start name=variable interval=1000000
+.fi
+
+.SH SEE ALSO
+ldmsd(8), ldms_quickstart(7), ldmsd_controller(8), ldms_sampler_base(7)


### PR DESCRIPTION
This sampler periodically redefines its sets and schemas, reusing names.
This works, but the current aggregation never sees the new definitions of recycled names.
Symptom of this is that the store only gets the first cycle of data in each schema.
Is there something about unpublish needed to convince downstream to drop old definitions?

to run the sampler, do install and then
bin/ldms-static-test.sh variable