### PR TITLE
Patch fix to procstat.3

### DIFF
--- a/ldms/scripts/examples/procstat.3
+++ b/ldms/scripts/examples/procstat.3
@@ -13,8 +13,7 @@ updtr_prdcr_add name=allhosts regex=.*
 updtr_start name=allhosts
 
 load name=store_csv
-#config name=store_csv action=init path=${STOREDIR} altheader=0 container=node1
-config name=store_csv schema=${testname}2 path=${STOREDIR} altheader=1 container=node2
+config name=store_csv path=${STOREDIR} altheader=1
 
 strgp_add name=store_${testname}_auto plugin=store_csv schema=${testname}_auto container=node
 strgp_prdcr_add name=store_${testname}_auto regex=.*


### PR DESCRIPTION
Fixed procstat.3 config file for OVIS v4. Used with ldms-static-test.sh test script. 