### PR TITLE
Introduce automated testing of "make dist"

### DIFF
--- a/.github/workflows/test-make-dist.yaml
+++ b/.github/workflows/test-make-dist.yaml
@@ -1,0 +1,22 @@
+name: Test "make dist"
+
+on:
+  push:
+    branches: [ OVIS-4 ]
+  pull_request:
+    branches: [ OVIS-4 ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - run: sudo apt install gettext
+    - uses: actions/checkout@v2
+    - name: autogen
+      run: sh autogen.sh
+    - name: configure
+      run: ./configure
+    - name: make dist
+      run: make dist


### PR DESCRIPTION
It is not uncommon for changes to the ovis build system to break the "make dist"
target. We introduce a GitHub Actions workflow to automate the test of
the build system up through "make dist" so we will automatically be alerted
of breakage on PRs for OVIS-4 and on the OVIS-4 branch.

The master branch hasn't yet had all of the build system cleanup that OVIS-4
has had, but this testing can easily be expaned to master once that has
happened.