### PR TITLE
move some examples files from /etc to /share

### DIFF
--- a/ldms/src/sampler/aries_mmr/aries_mmr_set_configs/Makefile.am
+++ b/ldms/src/sampler/aries_mmr/aries_mmr_set_configs/Makefile.am
@@ -57,7 +57,9 @@ MMR_FILES = \
 	$(srcdir)/metric_set_rtr_3_4_c \
 	$(srcdir)/metric_set_rtr_3_4_s
 
-MMR_DIR = $(DESTDIR)$(sysconfdir)/ldms/aries_mmr_set_configs
+
+OPV=-$(PACKAGE_VERSION)
+MMR_DIR = $(docdir)$(OPV)/examples/aries_mmr_set_configs
 install-data-local: $(MMR_FILES)
 	$(MKDIR_P) $(MMR_DIR)
 	$(INSTALL_DATA) $(MMR_FILES) $(MMR_DIR)/

--- a/ldms/src/sampler/hello_stream/Makefile.am
+++ b/ldms/src/sampler/hello_stream/Makefile.am
@@ -26,13 +26,14 @@ hello_cat_publisher_LDADD = $(COMMON_LIBADD) -lovis_json \
 			      ../../ldmsd/libldmsd_stream.la
 dist_man7_MANS += hello_cat_publisher.man
 
-SUBDIRS = stream_configs
 
+SUBDIRS = stream_configs
 
 HELLO_EXTRA_FILES = \
 	${srcdir}/parser.pl
 
-HELLO_DIR = $(DESTDIR)$(sysconfdir)/ldms/hello_sampler_util
+OPV=-$(PACKAGE_VERSION)
+HELLO_DIR = $(docdir)$(OPV)/examples/hello_sampler_util
 install-data-local: $(HELLO_EXTRA_FILES)
 	$(MKDIR_P) $(HELLO_DIR)
 	$(INSTALL_DATA) $(HELLO_EXTRA_FILES) $(HELLO_DIR)/

--- a/ldms/src/sampler/hello_stream/stream_configs/Makefile.am
+++ b/ldms/src/sampler/hello_stream/stream_configs/Makefile.am
@@ -7,8 +7,8 @@ STREAM_FILES = \
 	$(srcdir)/hello_stream_store.conf \
 	${srcdir}/README
 
-
-HELLO_CONF_DIR = $(DESTDIR)$(sysconfdir)/ldms/hello_sampler_util/stream_configs
+OPV=-$(PACKAGE_VERSION)
+HELLO_CONF_DIR = $(docdir)$(OPV)/examples/hello_sampler_util/stream_configs
 install-data-local: $(STREAM_FILES)
 	$(MKDIR_P) $(HELLO_CONF_DIR)
 	$(INSTALL_DATA) $(STREAM_FILES) $(HELLO_CONF_DIR)/


### PR DESCRIPTION
Re issue #310 

Moved aries_mmr_set_configs and hello_sampler_util from XXX/etc to XXX/share/doc/ovis-ldms-X.Y.Z/examples

