### PR TITLE
add attrs to transport error output.

### DIFF
--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -955,15 +955,17 @@ int listen_on_ldms_xprt(ldmsd_listen_t listen)
 	listen->x = ldms_xprt_new_with_auth(listen->xprt, ldmsd_linfo,
 			listen->auth_name, listen->auth_attrs);
 	if (!listen->x) {
+		char *args = av_to_string(listen->auth_attrs, AV_EXPAND);
 		ldmsd_log(LDMSD_LERROR,
 			  "'%s' transport creation with auth '%s' "
-			  "failed, error: %s(%d). Please check transpot "
+			  "failed, error: %s(%d). args='%s'. Please check transport "
 			  "configuration, authentication configuration, "
 			  "ZAP_LIBPATH (env var), and LD_LIBRARY_PATH.\n",
 			  listen->xprt,
 			  auth_name,
 			  ovis_errno_abbvr(errno),
-			  errno);
+			  errno, args ? args : "(empty conf=)");
+		free(args);
 		cleanup(6, "error creating transport");
 	}
 	sin.sin_family = AF_INET;


### PR DESCRIPTION
more output (xprt options) in ldmsd_config if transport new fails.