### PR TITLE
add 'extra' option to synthetic, to have N clone sets

### DIFF
--- a/ldms/scripts/examples/setclones
+++ b/ldms/scripts/examples/setclones
@@ -1,0 +1,10 @@
+export plugname=synthetic
+portbase=61060
+LDMSD 1 2
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2 -l
+SLEEP 5
+KILL_LDMSD 1
+SLEEP 5
+KILL_LDMSD 2
+file_created $STOREDIR/node/$plugname.500

--- a/ldms/scripts/examples/setclones.1
+++ b/ldms/scripts/examples/setclones.1
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} schema=synthetic.500 instance=localhost${i}/synthetic.500 component_id=${i} extra=250
+start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/setclones.2
+++ b/ldms/scripts/examples/setclones.2
@@ -1,0 +1,14 @@
+
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_start name=localhost1
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+strgp_add name=store_${testname} plugin=store_csv schema=synthetic.500 container=node
+strgp_prdcr_add name=store_${testname} regex=.*
+strgp_start name=store_${testname}


### PR DESCRIPTION
This generates many sets from a test sampler, but the names differ only in the numeric suffix, so it may not tease complex tree structures as desired.