### PR TITLE
ldms_xprt: send_req_cancel_push() returns a random value on success

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -3298,7 +3298,7 @@ static int send_req_cancel_push(struct ldms_rbuf_desc *r)
 	struct ldms_xprt *x = r->xprt;
 	struct ldms_request req;
 	size_t len;
-	int rc;
+	int rc = 0;
 
 	ldms_xprt_get(x);
 	len = sizeof(struct ldms_request_hdr)


### PR DESCRIPTION
The rc variable wasn't initialized so the function might return a random
number on success.