### PR TITLE
Fix linking flags

### DIFF
--- a/ldms/src/ldmsd-samplers/appinfo/Makefile.am
+++ b/ldms/src/ldmsd-samplers/appinfo/Makefile.am
@@ -7,7 +7,10 @@ libappinfocl_la_CFLAGS = -I$(srcdir)/../../core \
 			 -I$(top_srcdir) @OVIS_LIB_INCDIR_FLAG@ \
 			 -I../../ -I$(srcdir)/../../ldmsd
 libappinfocl_la_LIBADD = ../../core/libldms.la \
-			 @LDFLAGS_GETTIME@ -lpthread -lovis_util -lcoll
+			 @LDFLAGS_GETTIME@  \
+			 $(top_builddir)/lib/src/ovis_util/libovis_util.la \
+			 $(top_builddir)/lib/src/coll/libcoll.la \
+			 -lpthread
 libappinfocl_la_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@
 pkglib_LTLIBRARIES += libappinfocl.la
 

--- a/ldms/src/ldmsd-samplers/dstat/Makefile.am
+++ b/ldms/src/ldmsd-samplers/dstat/Makefile.am
@@ -12,8 +12,9 @@ libdstat_la_SOURCES = dstat.c
 libdstat_la_CFLAGS  = $(SAMPLER_CFLAGS)
 libdstat_la_LIBADD  = $(SAMPLER_LIBADD) \
 		      libparse_stat.la \
-		      -lmmalloc \
-		      -lovis_util -lcoll
+		      $(top_builddir)/lib/src/mmalloc/libmmalloc.la \
+		      $(top_builddir)/lib/src/ovis_util/libovis_util.la \
+		      $(top_builddir)/lib/src/coll/libcoll.la
 libdstat_la_LDFLAGS = $(SAMPLER_LDFLAGS) @LDFLAGS_GETTIME@
 
 dist_man7_MANS = Plugin_dstat.man

--- a/ldms/src/ldmsd-samplers/filesingle/Makefile.am
+++ b/ldms/src/ldmsd-samplers/filesingle/Makefile.am
@@ -3,7 +3,9 @@ include ../common.am
 pkglib_LTLIBRARIES = libfilesingle.la
 libfilesingle_la_SOURCES = filesingle.c
 libfilesingle_la_CFLAGS  = $(SAMPLER_CFLAGS)
-libfilesingle_la_LIBADD  = $(SAMPLER_LIBADD) -lovis_util -lcoll
+libfilesingle_la_LIBADD  = $(SAMPLER_LIBADD) \
+			   $(top_builddir)/lib/src/ovis_util/libovis_util.la \
+			   $(top_builddir)/lib/src/coll/libcoll.la
 libfilesingle_la_LDFLAGS = $(SAMPLER_LDFLAGS) @LDFLAGS_GETTIME@
 
 

--- a/ldms/src/ldmsd-samplers/generic_sampler/Makefile.am
+++ b/ldms/src/ldmsd-samplers/generic_sampler/Makefile.am
@@ -4,5 +4,6 @@ pkglib_LTLIBRARIES = libgeneric_sampler.la
 
 libgeneric_sampler_la_SOURCES = generic_sampler.c
 libgeneric_sampler_la_CFLAGS = $(SAMPLER_CFLAGS)
-libgeneric_sampler_la_LIBADD = $(SAMPLER_LIBADD) -lcoll
+libgeneric_sampler_la_LIBADD = $(SAMPLER_LIBADD) \
+			       $(top_builddir)/lib/src/coll/libcoll.la
 libgeneric_sampler_la_LDFLAGS = $(SAMPLER_LDFLAGS)

--- a/ldms/src/ldmsd-samplers/jobinfo/Makefile.am
+++ b/ldms/src/ldmsd-samplers/jobinfo/Makefile.am
@@ -4,7 +4,10 @@ pkglib_LTLIBRARIES = libjobinfo.la
 
 libjobinfo_la_SOURCES = jobinfo.c jobinfo.h
 libjobinfo_la_CFLAGS  = $(SAMPLER_CFLAGS)
-libjobinfo_la_LIBADD  = $(SAMPLER_LIBADD) -lovis_util -lcoll -lpthread
+libjobinfo_la_LIBADD  = $(SAMPLER_LIBADD) \
+			$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+			$(top_builddir)/lib/src/coll/libcoll.la \
+			-lpthread
 libjobinfo_la_LDFLAGS = $(SAMPLER_LDFLAGS) @LDFLAGS_GETTIME@
 
 if ENABLE_SLURM_JOBINFO

--- a/ldms/src/ldmsd-samplers/jobinfo/jobinfo_slurm/Makefile.am
+++ b/ldms/src/ldmsd-samplers/jobinfo/jobinfo_slurm/Makefile.am
@@ -1,7 +1,7 @@
 pkglib_LTLIBRARIES = libjobinfo_slurm.la
 
 libjobinfo_slurm_la_SOURCES = jobinfo_slurm.c
-libjobinfo_slurm_la_LIBADD  = -lcoll
+libjobinfo_slurm_la_LIBADD  = $(top_builddir)/lib/src/coll/libcoll.la
 libjobinfo_slurm_la_CFLAGS  = @OVIS_LIB_INCDIR_FLAG@ $(SLURM_INCDIR_FLAG)
 libjobinfo_slurm_la_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@ \
 			      -module

--- a/ldms/src/ldmsd-samplers/papi/Makefile.am
+++ b/ldms/src/ldmsd-samplers/papi/Makefile.am
@@ -5,6 +5,7 @@ pkglib_LTLIBRARIES = libpapi_sampler.la
 libpapi_sampler_la_SOURCES = papi_sampler.c papi_sampler.h papi_config.c
 libpapi_sampler_la_CFLAGS  = $(SAMPLER_CFLAGS)
 libpapi_sampler_la_LIBADD  = $(SAMPLER_LIBADD) \
-			     -ljson_util -lpapi -lm \
-			     ../../ldmsd/libldmsd_stream.la
+			     $(top_builddir)/lib/src/json/libjson_util.la \
+			     ../../ldmsd/libldmsd_stream.la \
+			     -lpapi -lm
 libpapi_sampler_la_LDFLAGS = $(SAMPLER_LDFLAGS)

--- a/ldms/src/ldmsd-samplers/shm/Makefile.am
+++ b/ldms/src/ldmsd-samplers/shm/Makefile.am
@@ -13,6 +13,8 @@ pkglib_LTLIBRARIES = libshm_sampler.la
 libshm_sampler_la_SOURCES = shm_sampler.c
 libshm_sampler_la_CFLAGS  = $(SAMPLER_CFLAGS)
 libshm_sampler_la_LIBADD  = $(SAMPLER_LIBADD) ../../core/libldms.la \
-			    -lovis_util -lovis_third -lm -lrt -lpthread \
-			    $(JOBID_LIBFLAGS) shm_util/liblshm.la
+			    $(top_builddir)/lib/src/ovis_util/libovis_util.la \
+			    $(top_builddir)/lib/src/ovis_third/libovis_third.la \
+			    $(JOBID_LIBFLAGS) shm_util/liblshm.la \
+			    -lm -lrt -lpthread
 libshm_sampler_la_LDFLAGS = $(SAMPLER_LDFLAGS) @LDFLAGS_GETTIME@

--- a/ldms/src/ldmsd-samplers/shm/mpi_profiler/Makefile.am
+++ b/ldms/src/ldmsd-samplers/shm/mpi_profiler/Makefile.am
@@ -14,7 +14,9 @@ bin_PROGRAMS += MPIApp
 nodist_MPIApp_SOURCES = mpi_profiler_wrapped_functions.c
 MPIApp_SOURCES = mpi_profiler.c mpi_profiler_configuration.c mpi_profiler_func_list.c sample_mpi_application.c userheader.h
 MPIApp_CFLAGS = $(AM_CFLAGS) -v
-MPIApp_LDADD = ../shm_util/liblshm.la -lovis_third -lpthread -lm
+MPIApp_LDADD = ../shm_util/liblshm.la \
+	       $(top_builddir)/lib/src/ovis_third/libovis_third.la \
+	       -lpthread -lm
 
 WRAPINPUT=$(srcdir)/wrap/input.w
 mpi_profiler_wrapped_functions.c: Makefile wrap/wrap.py wrap/input.w userheader.h

--- a/ldms/src/ldmsd-samplers/shm/shm_util/Makefile.am
+++ b/ldms/src/ldmsd-samplers/shm/shm_util/Makefile.am
@@ -4,7 +4,8 @@ pkglib_LTLIBRARIES =
 #AM_CFLAGS = -I$(srcdir)/$(CORE) -I$(top_srcdir) @OVIS_LIB_INCDIR_FLAG@
 AM_CFLAGS = -I$(top_srcdir) @OVIS_LIB_INCDIR_FLAG@
 AM_LDFLAGS = @OVIS_LIB_LIB64DIR_FLAG@ @OVIS_LIB_LIBDIR_FLAG@
-COMMON_LIBADD = @LDFLAGS_GETTIME@ -lovis_third
+COMMON_LIBADD = @LDFLAGS_GETTIME@ \
+		$(top_builddir)/lib/src/ovis_third/libovis_third.la
 
 lib_LTLIBRARIES = liblshm.la
 

--- a/ldms/src/ldmsd-samplers/slurm/Makefile.am
+++ b/ldms/src/ldmsd-samplers/slurm/Makefile.am
@@ -4,7 +4,8 @@ pkglib_LTLIBRARIES = libslurm_sampler.la
 
 libslurm_sampler_la_SOURCES = slurm_sampler.c slurm_sampler.h
 libslurm_sampler_la_CFLAGS = $(SAMPLER_CFLAGS)
-libslurm_sampler_la_LIBADD = $(SAMPLER_LIBADD) -ljson_util
+libslurm_sampler_la_LIBADD = $(SAMPLER_LIBADD) \
+			     $(top_builddir)/lib/src/json/libjson_util.la
 libslurm_sampler_la_LDFLAGS = $(SAMPLER_LDFLAGS)
 
 if ENABLE_SPANK_PLUGIN

--- a/ldms/src/ldmsd-samplers/syspapi/Makefile.am
+++ b/ldms/src/ldmsd-samplers/syspapi/Makefile.am
@@ -7,7 +7,8 @@ libsyspapi_sampler_la_CFLAGS  = $(SAMPLER_CFLAGS) \
 				@LIBPAPI_INCDIR_FLAG@ \
 				@LIBPFM_INCDIR_FLAG@
 libsyspapi_sampler_la_LIBADD  = $(SAMPLER_LIBADD) \
-				-ljson_util -lpapi -lm -lpfm
+				$(top_builddir)/lib/src/json/libjson_util.la \
+				-lpapi -lm -lpfm
 libsyspapi_sampler_la_LDFLAGS = $(SAMPLER_LDFLAGS) \
 				@LIBPAPI_LIB64DIR_FLAG@ @LIBPAPI_LIBDIR_FLAG@ \
 				@LIBPFM_LIB64DIR_FLAG@ @LIBPFM_LIBDIR_FLAG@

--- a/ldms/src/ldmsd-stores/store_csv/Makefile.am
+++ b/ldms/src/ldmsd-stores/store_csv/Makefile.am
@@ -3,8 +3,10 @@ include ../common.am
 pkglib_LTLIBRARIES =
 lib_LTLIBRARIES =
 
-LDMSD = ../../ldmsd
-STORE_LIBADD += $(LDMSD)/libplugattr.la -lcoll -lovis_util -lpthread
+STORE_LIBADD = $(top_builddir)/lib/src/coll/libcoll.la \
+	       $(top_builddir)/lib/src/ovis_util/libovis_util.la \
+	       $(top_builddir)/ldms/src/ldmsd/libplugattr.la \
+	       -lpthread
 
 ldmsstoreincludedir = $(includedir)/ldms
 ldmsstoreinclude_HEADERS = store_csv_common.h

--- a/ldms/src/ldmsd-stores/store_influx/Makefile.am
+++ b/ldms/src/ldmsd-stores/store_influx/Makefile.am
@@ -4,5 +4,8 @@ pkglib_LTLIBRARIES = libstore_influx.la
 
 libstore_influx_la_SOURCES = store_influx.c
 libstore_influx_la_CFLAGS  = $(STORE_CFLAGS)
-libstore_influx_la_LIBADD  = $(STORE_LIBADD) -lcoll -lovis_util -lcurl
+libstore_influx_la_LIBADD  = $(STORE_LIBADD) \
+			     $(top_builddir)/lib/src/coll/libcoll.la \
+			     $(top_builddir)/lib/src/ovis_util/libovis_util.la \
+			     -lcurl
 libstore_influx_la_LDFLAGS = $(STORE_LDFLAGS)

--- a/lib/src/ev/Makefile.am
+++ b/lib/src/ev/Makefile.am
@@ -14,6 +14,6 @@ lib_LTLIBRARIES += libev.la
 
 ev_test_SOURCES = ev_test.c
 ev_test_CFLAGS = $(AM_CFLAGS) -g -O0
-ev_test_LDADD = -lev
+ev_test_LDADD = libev.la
 ev_test_LDFLAGS = $(AM_LDFLAGS)
 sbin_PROGRAMS = ev_test

--- a/lib/src/json/Makefile.am
+++ b/lib/src/json/Makefile.am
@@ -37,6 +37,6 @@ sbin_PROGRAMS = json_test
 
 json_apis_test_SOURCES = json_apis_test.c json_util.h
 json_apis_test_CFLAGS = $(AM_CFLAGS) -g -O0
-json_apis_test_LDADD = -ljson_util
+json_apis_test_LDADD = libjson_util.la
 json_apis_test_LDFLAGS = $(AM_LDFLAGS)
 sbin_PROGRAMS += json_apis_test

--- a/lib/src/ovis_util/Makefile.am
+++ b/lib/src/ovis_util/Makefile.am
@@ -11,7 +11,7 @@ libovis_utilinclude_HEADERS = util.h dstring.h big_dstring.h os_util.h olog.h \
 libovis_utilincludedir = $(includedir)/ovis_util
 libovis_util_conf = /etc/ld.so.conf.d/libovis_util.conf
 lib_LTLIBRARIES += libovis_util.la
-LDFLAGS_OVIS_UTIL = -lovis_util -lpthread @LDFLAGS_GETTIME@
+LDFLAGS_OVIS_UTIL = libovis_util.la -lpthread @LDFLAGS_GETTIME@
 
 bin_PROGRAMS = test_big_dstring test_dstring test_olog
 


### PR DESCRIPTION
Replace the linking flags of ovis libraries from -l to *.la. Otherwise, ovis cannot be built on Ubuntu.