### PR TITLE
fix spaces missing after sampler names in config usage lines

### DIFF
--- a/ldms/src/sampler/clock.c
+++ b/ldms/src/sampler/clock.c
@@ -145,7 +145,7 @@ static int config_check(struct attr_value_list *kwl, struct attr_value_list *avl
 
 static const char *usage(struct ldmsd_plugin *self)
 {
-	return  "config name=" SAMP BASE_CONFIG_USAGE;
+	return  "config name=" SAMP " " BASE_CONFIG_USAGE;
 }
 
 static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct attr_value_list *avl)

--- a/ldms/src/sampler/dstat/dstat.c
+++ b/ldms/src/sampler/dstat/dstat.c
@@ -311,7 +311,7 @@ static bool get_bool(const char *val, char *name)
 
 static const char *usage(struct ldmsd_plugin *self)
 {
-	return  "config name=" SAMP BASE_CONFIG_USAGE
+	return  "config name=" SAMP " " BASE_CONFIG_USAGE
 		" [io=<bool>] [stat=<bool>] [statm=<bool>] [mmalloc=<bool>]\n"
 		"    If none of io, stat, statm, mmalloc is given, all but mmalloc default true.\n"
 		"    If any of io, stat, statm is given, unmentioned ones default false.\n"

--- a/ldms/src/sampler/examples/array_example/all_example.c
+++ b/ldms/src/sampler/examples/array_example/all_example.c
@@ -282,7 +282,7 @@ static void term(struct ldmsd_plugin *self)
 
 static const char *usage(struct ldmsd_plugin *self)
 {
-	return "config_name=" SAMP BASE_CONFIG_USAGE;
+	return "config_name=" SAMP " " BASE_CONFIG_USAGE;
 }
 
 static struct ldmsd_sampler all_example_plugin = {

--- a/ldms/src/sampler/loadavg/loadavg.c
+++ b/ldms/src/sampler/loadavg/loadavg.c
@@ -273,7 +273,7 @@ static int config_check(struct attr_value_list *kwl, struct attr_value_list *avl
 
 static const char *usage(struct ldmsd_plugin *self)
 {
-	return  "config name=" SAMP BASE_CONFIG_USAGE " [metrics=<mlist>] [force_integer]\n"
+	return  "config name=" SAMP " " BASE_CONFIG_USAGE " [metrics=<mlist>] [force_integer]\n"
 		"                 If force_integer is present, coerces load averages into (uint64_t)100*value\n"
 		"                 and changes the default schema name base from loadavg to loadavgi\n"
 		"    <sname>      The schema name, if generated default is not good enough.\n"

--- a/ldms/src/sampler/meminfo/meminfo.c
+++ b/ldms/src/sampler/meminfo/meminfo.c
@@ -169,7 +169,7 @@ static int config_check(struct attr_value_list *kwl, struct attr_value_list *avl
 
 static const char *usage(struct ldmsd_plugin *self)
 {
-	return  "config name=" SAMP BASE_CONFIG_USAGE;
+	return  "config name=" SAMP " " BASE_CONFIG_USAGE;
 }
 
 static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct attr_value_list *avl)

--- a/ldms/src/sampler/procinterrupts/procinterrupts.c
+++ b/ldms/src/sampler/procinterrupts/procinterrupts.c
@@ -190,7 +190,7 @@ err:
 
 static const char *usage(struct ldmsd_plugin *self)
 {
-	return "config name=" SAMP BASE_CONFIG_USAGE;
+	return "config name=" SAMP " " BASE_CONFIG_USAGE;
 }
 
 /**

--- a/ldms/src/sampler/vmstat/vmstat.c
+++ b/ldms/src/sampler/vmstat/vmstat.c
@@ -160,7 +160,7 @@ static int config_check(struct attr_value_list *kwl, struct attr_value_list *avl
 
 static const char *usage(struct ldmsd_plugin *self)
 {
-	return  "config name=" SAMP BASE_CONFIG_USAGE;
+	return  "config name=" SAMP " " BASE_CONFIG_USAGE;
 }
 
 


### PR DESCRIPTION
fixes #358 