### PR TITLE
Add pthread_cancel/join logic to the RDMA transport

### DIFF
--- a/lib/src/zap/zap.c
+++ b/lib/src/zap/zap.c
@@ -549,6 +549,7 @@ zap_err_t zap_get_name(zap_ep_t ep, struct sockaddr *local_sa,
 
 void zap_get_ep(zap_ep_t ep)
 {
+	assert(ep->ref_count);
 	(void)__sync_fetch_and_add(&ep->ref_count, 1);
 }
 


### PR DESCRIPTION
The mlx5 driver now has logic that destroys the verbs
context on exit. This resulted in applications such
as ldms_ls crashing on exit.

Destructor logic has been added to the Zap RDMA
transport driver to cancel and join the threads
that were using these mlx5 resources.