### PR TITLE
Refactor the test_sampler plugin

### DIFF
--- a/ldms/src/ldmsd-samplers/test-samplers/test_sampler.c
+++ b/ldms/src/ldmsd-samplers/test-samplers/test_sampler.c
@@ -1,8 +1,8 @@
 /* -*- c-basic-offset: 8 -*-
- * Copyright (c) 2015-2018 National Technology & Engineering Solutions
+ * Copyright (c) 2015-2020 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
- * Copyright (c) 2015-2018 Open Grid Computing, Inc. All rights reserved.
+ * Copyright (c) 2015-2020 Open Grid Computing, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -72,37 +72,38 @@
 #define DEFAULT_NUM_SETS 1
 #define DEFAULT_METRIC_NAME_NAME "metric_"
 
+#define TEST_SAMPLER_DEFAULT_NUM_METRICS 3
+#define TEST_SAMPLER_DEFAULT_ARRAY_SZ 3
+#define TEST_SAMPLER_DEFAULT_UNIT ""
+#define TEST_SAMPLER_DEFAULT_SCHEMA_TYPE TEST_SAMPLER_TYPE_DEFAULT
+
+#define TEST_SAMPLER_DEFAULT_SUFFIX_W_TIME 1 /* true */
+#define TEST_SAMPLER_DEFAULT_PUSH_AT 0
+#define TEST_SAMPLER_DEFAULT_DELETE_AT 0 /* false */
+#define TEST_SAMPLER_DEFAULT_CREATE_AT 0 /* create right after delete */
+
 struct test_sampler_metric {
 	char *name;
 	int mtype; /* 2 is meta and 1 is data */
 	enum ldms_value_type vtype;
-	int count; /* Number of elements in an array metric */
+	int array_sz; /* Number of elements in an array metric */
 	int idx;
+	char *unit;
 	TAILQ_ENTRY(test_sampler_metric) entry;
 	union ldms_value init_value;
 	union ldms_value latest_value;
 };
-TAILQ_HEAD(test_sampler_metric_list, test_sampler_metric);
-
-struct test_sampler_schema {
-	char *name;
-	ldms_schema_t schema;
-	enum schema_type {
-		TEST_SAMPLER_SCHEMA_TYPE_DEFAULT = 1,
-		TEST_SAMPLER_SCHEMA_TYPE_MANUAL = 2,
-		TEST_SAMPLER_SCHEMA_TYPE_AUTO = 3
-	} type;
-	struct test_sampler_metric_list list;
-	LIST_ENTRY(test_sampler_schema) entry;
-};
-LIST_HEAD(test_sampler_schema_list, test_sampler_schema);
 
 struct test_sampler_set {
 	char *name;
-	struct test_sampler_schema *ts_schema;
 	ldms_set_t set;
-	int push;
+	int push_at;
+	int delete_at;
+	int from_delete_count;
+	int create_at;
+	int is_suffix;
 	int skip_push;
+	unsigned int sample_count;
 	LIST_ENTRY(test_sampler_set) entry;
 };
 LIST_HEAD(test_sampler_set_list, test_sampler_set);
@@ -111,52 +112,25 @@ typedef struct test_sampler_inst_s *test_sampler_inst_t;
 struct test_sampler_inst_s {
 	struct ldmsd_plugin_inst_s base;
 
+	/* Point to the ldmsd_sampler_type_s->samp_sample */
 	int (*samp_sample)(ldmsd_plugin_inst_t pi);
 
 	char base_set_name[256];
 	int num_sets;
-	int num_metrics;
-	struct test_sampler_schema_list schema_list;
+	enum {
+		TEST_SAMPLER_TYPE_SCALAR = 1,
+		TEST_SAMPLER_TYPE_ARRAY,
+		TEST_SAMPLER_TYPE_ALL,
+		TEST_SAMPLER_TYPE_DEFAULT,
+		TEST_SAMPLER_TYPE_MANUAL,
+	} type;
+	int num_metrics; /* Use only by default */
+	json_entity_t metrics; /* Use only be manual */
+	int array_sz; /* Use only by array & all */
+	TAILQ_HEAD(test_sampler_metric_list, test_sampler_metric) metric_list;
 	struct test_sampler_set_list set_list;
-	int set_del_int;
-	int ts_suffix; /* switch to append ts at the end of set name */
+	char *unit; /* default unit */
 };
-
-ldms_schema_t __schema_new(test_sampler_inst_t inst, const char *name)
-{
-	/* TODO Please change `create_schema()` API to receive name */
-	ldmsd_sampler_type_t samp = LDMSD_SAMPLER(inst);
-	const char *tmp;
-	ldms_schema_t schema;
-
-	tmp = samp->schema_name;
-	samp->schema_name = (void*)name;
-	schema = samp->create_schema(&inst->base);
-	samp->schema_name = (void*)tmp;
-	return schema;
-}
-
-static struct test_sampler_schema *__schema_find(
-		struct test_sampler_schema_list *list, const char *name)
-{
-	struct test_sampler_schema *ts_schema;
-	LIST_FOREACH(ts_schema, list, entry) {
-		if (0== strcmp(ts_schema->name, name))
-			return ts_schema;
-	}
-	return NULL;
-}
-
-static struct test_sampler_set *__set_find(
-		struct test_sampler_set_list *list, const char *name)
-{
-	struct test_sampler_set *ts_set;
-	LIST_FOREACH(ts_set, list, entry) {
-		if (0 == strcmp(ts_set->name, name))
-			return ts_set;
-	}
-	return NULL;
-}
 
 /* metric->vtype MUST be initialized before this function is called. */
 static int __metric_init_value_set(test_sampler_inst_t inst,
@@ -220,18 +194,23 @@ static int __metric_init_value_set(test_sampler_inst_t inst,
 	return 0;
 }
 
-static struct test_sampler_metric *
-__test_sampler_metric_new(test_sampler_inst_t inst, const char *name,
-			  const char *mtype, enum ldms_value_type vtype,
-			  const char *init_value, const char *count_str)
+void ts_metric_free(struct test_sampler_metric *metric)
 {
-	int count = 0;
+	if (metric->name)
+		free(metric->name);
+	if (metric->unit)
+		free(metric->unit);
+	free(metric);
+}
+
+static struct test_sampler_metric *
+ts_metric_new(test_sampler_inst_t inst, const char *name,
+			  const char *mtype, enum ldms_value_type vtype,
+			  const char *init_value, int array_sz,
+			  const char *unit)
+{
+	int count = array_sz;
 	struct test_sampler_metric *metric;
-	if (!count_str) {
-		count = 0;
-	} else {
-		count = atoi(count_str);
-	}
 
 	if (vtype == LDMS_V_CHAR_ARRAY) {
 		if (init_value && (count < strlen(init_value) + 1))
@@ -245,10 +224,12 @@ __test_sampler_metric_new(test_sampler_inst_t inst, const char *name,
 	if (!metric)
 		return NULL;
 	metric->name = strdup(name);
-	if (!metric->name) {
-		free(metric);
-		return NULL;
-	}
+	if (!metric->name)
+		goto err;
+
+	metric->unit = strdup(unit);
+	if (!metric->unit)
+		goto err;
 
 	if ((0 == strcasecmp(mtype, "data")) || (0 == strcasecmp(mtype, "d"))) {
 		metric->mtype = LDMS_MDESC_F_DATA;
@@ -256,119 +237,48 @@ __test_sampler_metric_new(test_sampler_inst_t inst, const char *name,
 			(0 == strcasecmp(mtype, "m"))) {
 		metric->mtype = LDMS_MDESC_F_META;
 	} else {
-		free(metric->name);
-		free(metric);
-		return NULL;
+		goto err;
 	}
 
 	metric->vtype = vtype;
 	if (metric->vtype == LDMS_V_NONE) {
-		free(metric->name);
-		free(metric);
-		return NULL;
+		goto err;
 	}
 
 	if (__metric_init_value_set(inst, metric, init_value)) {
-		free(metric->name);
-		free(metric);
-		return NULL;
+		goto err;
 	}
 
-	metric->count = count;
-
+	metric->array_sz = count;
+	TAILQ_INSERT_TAIL(&inst->metric_list, metric, entry);
 	return metric;
-}
-
-static struct test_sampler_metric *
-__schema_metric_new(test_sampler_inst_t inst, char *s)
-{
-	char *name, *mtype, *vtype, *init_value, *count_str, *ptr;
-	name = strtok_r(s, ":", &ptr);
-	if (!name)
-		return NULL;
-	mtype = strtok_r(NULL, ":", &ptr);
-	if (!mtype)
-		return NULL;
-	vtype = strtok_r(NULL, ":", &ptr);
-	if (!vtype)
-		return NULL;
-	init_value = strtok_r(NULL, ":", &ptr);
-	if (!init_value)
-		return NULL;
-	count_str = strtok_r(NULL, ":", &ptr);
-	if (!count_str)
-		count_str = "0";
-
-	struct test_sampler_metric *metric;
-	metric = __test_sampler_metric_new(inst, name, mtype,
-				ldms_metric_str_to_type(vtype),
-				init_value, count_str);
-
-	return metric;
-}
-
-void __schema_metric_destroy(struct test_sampler_metric *metric)
-{
-	free(metric->name);
-	free(metric);
-}
-
-static int test_sampler_set_new(test_sampler_inst_t inst,
-				struct test_sampler_set *ts_set);
-static int test_sampler_set_del(test_sampler_inst_t inst,
-				struct test_sampler_set *ts_set);
-
-static struct test_sampler_set *
-__create_test_sampler_set(test_sampler_inst_t inst, const char *instance_name,
-			  int push, struct test_sampler_schema *ts_schema)
-{
-	int rc;
-	struct test_sampler_set *ts_set = calloc(1, sizeof(*ts_set));
-	if (!ts_set) {
-		INST_LOG(inst, LDMSD_LERROR, "Out of memory\n");
-		return NULL;
-	}
-	ts_set->name = strdup(instance_name);
-	if (!ts_set->name)
-		goto err0;
-	ts_set->ts_schema = ts_schema;
-	ts_set->push = push;
-	ts_set->skip_push = 1;
-	rc = test_sampler_set_new(inst, ts_set);
-	if (rc)
-		goto err1;
-	LIST_INSERT_HEAD(&inst->set_list, ts_set, entry);
-	return ts_set;
-
-err1:
-	free(ts_set->name);
-err0:
-	free(ts_set);
+err:
+	errno = ENOMEM;
+	ts_metric_free(metric);
 	return NULL;
 }
 
-static void __delete_test_sampler_set(test_sampler_inst_t inst,
-				      struct test_sampler_set *ts_set)
+void metric_list_empty(test_sampler_inst_t inst)
 {
-	if (ts_set->set)
-		test_sampler_set_del(inst, ts_set);
-	if (ts_set->name)
-		free(ts_set->name);
-	LIST_REMOVE(ts_set, entry);
-	free(ts_set);
+	struct test_sampler_metric *metric;
+
+	metric = TAILQ_FIRST(&inst->metric_list);
+	while (metric) {
+		TAILQ_REMOVE(&inst->metric_list, metric, entry);
+		ts_metric_free(metric);
+		metric = TAILQ_FIRST(&inst->metric_list);
+	}
 }
 
 /* create a new set for test_sampler_set */
-static int test_sampler_set_new(test_sampler_inst_t inst,
+static void __set_create(test_sampler_inst_t inst,
 				struct test_sampler_set *ts_set)
 {
 	char buff[512];
 	const char *name;
 	struct timeval tv;
 	ldmsd_sampler_type_t samp = LDMSD_SAMPLER(inst);
-	if (ts_set->set)
-		return EEXIST;
-	if (inst->ts_suffix) {
+	if (ts_set->is_suffix) {
 		gettimeofday(&tv, NULL);
 		snprintf(buff, sizeof(buff), "%s:%ld.%06ld",
 			 ts_set->name, tv.tv_sec, tv.tv_usec);
@@ -377,99 +287,80 @@ static int test_sampler_set_new(test_sampler_inst_t inst,
 		name = ts_set->name;
 	}
 	ts_set->set = samp->create_set(&inst->base, name,
-				       ts_set->ts_schema->schema, ts_set);
-	if (!ts_set->set)
-		return errno;
-	return 0;
+				samp->schema, ts_set);
+	if (!ts_set->set) {
+		INST_LOG(inst, LDMSD_LERROR, "Failed to create the set "
+				"'%s' with error %d.\n", ts_set->name, errno);
+	}
 }
 
-static int test_sampler_set_del(test_sampler_inst_t inst,
+static void __set_delete(test_sampler_inst_t inst,
 				struct test_sampler_set *ts_set)
 {
-	if (!ts_set->set)
-		return ENOENT;
-	LDMSD_SAMPLER(inst)->delete_set(&inst->base, ldms_set_name_get(ts_set->set));
-	ts_set->set = NULL;
-	return 0;
-}
-
-static int create_metric_set(test_sampler_inst_t inst,
-			     const char *schema_name, int push)
-{
-	int rc, i, j;
-	union ldms_value v;
-	char metric_name[128];
-	char instance_name[512];
-	ldms_schema_t schema = NULL;
+	int rc;
 	ldmsd_sampler_type_t samp = LDMSD_SAMPLER(inst);
-
-	struct test_sampler_schema *ts_schema;
-	struct test_sampler_metric *metric;
-	ts_schema = __schema_find(&inst->schema_list, (char *)schema_name);
-	if (!ts_schema) {
-		ts_schema = malloc(sizeof(*ts_schema));
-		ts_schema->name = strdup(schema_name);
-		ts_schema->type = TEST_SAMPLER_SCHEMA_TYPE_DEFAULT;
-		schema = __schema_new(inst, schema_name);
-		if (!schema)
-			return ENOMEM;
-		ts_schema->schema = schema;
-		TAILQ_INIT(&ts_schema->list);
-		for (i = 0; i < inst->num_metrics; i++) {
-			snprintf(metric_name, 127, "metric_%d", i);
-			metric = __test_sampler_metric_new(inst,
-					metric_name, "d", LDMS_V_U64,
-					"0", NULL);
-			metric->idx = ldms_schema_metric_add(schema,
-						metric_name, LDMS_V_U64, "");
-			if (metric->idx < 0) {
-				rc = ENOMEM;
-				goto free_schema;
-			}
-			TAILQ_INSERT_TAIL(&ts_schema->list, metric, entry);
-		}
-		LIST_INSERT_HEAD(&inst->schema_list, ts_schema, entry);
+	rc = samp->delete_set(&inst->base, ldms_set_name_get(ts_set->set));
+	if (rc) {
+		INST_LOG(inst, LDMSD_LERROR, "Failed to delete the set '%s' "
+				"with error %d.\n", ts_set->name, rc);
+	} else {
+		ts_set->set = NULL;
 	}
-
-	struct test_sampler_set *ts_set, *next_ts_set;
-
-	for (i = 0; i < inst->num_sets; i++) {
-		snprintf(instance_name, 511, "%s_%d", inst->base_set_name, i);
-		ts_set = __create_test_sampler_set(inst, instance_name,
-						   push, ts_schema);
-		if (!ts_set) {
-			rc = errno;
-			goto free_sets;
-		}
-		for (j = 0; j < inst->num_metrics; j++) {
-			v.v_u64 = j;
-			ldms_metric_set(ts_set->set, samp->first_idx + j, &v);
-		}
-	}
-
-	return 0;
-
-free_sets:
-	ts_set = LIST_FIRST(&inst->set_list);
-	if (!ts_set)
-		goto free_schema;
-	while (ts_set) {
-		next_ts_set = LIST_NEXT(ts_set, entry);
-		const char *sname = ldms_set_schema_name_get(ts_set->set);
-		if (0 == strcmp(schema_name, sname)) {
-			__delete_test_sampler_set(inst, ts_set);
-		}
-		ts_set = next_ts_set;
-	}
-free_schema:
-	if (schema)
-		ldms_schema_delete(schema);
-	schema = NULL;
-	return rc;
 }
 
-static const char *__attr_find(test_sampler_inst_t inst, json_entity_t json,
-		char *ebuf, size_t ebufsz, int is_required, char *attr_name)
+static
+void ts_set_free(test_sampler_inst_t inst, struct test_sampler_set *ts_set)
+{
+	if (ts_set->set)
+		__set_delete(inst, ts_set);
+	if (ts_set->name)
+		free(ts_set->name);
+	free(ts_set);
+}
+
+void set_list_empty(test_sampler_inst_t inst)
+{
+	struct test_sampler_set *ts_set;
+	ts_set = LIST_FIRST(&inst->set_list);
+	while (ts_set) {
+		LIST_REMOVE(ts_set, entry);
+		ts_set_free(inst, ts_set);
+	}
+}
+
+static struct test_sampler_set *
+ts_set_new(test_sampler_inst_t inst, const char *instance_name,
+			  int push_at, int delete_at,
+			  int create_from_delete_at,
+			  int is_suffix)
+{
+	struct test_sampler_set *ts_set = calloc(1, sizeof(*ts_set));
+	if (!ts_set)
+		goto oom;
+	ts_set->name = strdup(instance_name);
+	if (!ts_set->name)
+		goto oom;
+	ts_set->push_at = push_at;
+	ts_set->delete_at = delete_at;
+	ts_set->create_at = create_from_delete_at;
+	ts_set->is_suffix = is_suffix;
+	ts_set->skip_push = 1;
+	ts_set->sample_count = 1;
+	LIST_INSERT_HEAD(&inst->set_list, ts_set, entry);
+	return ts_set;
+
+oom:
+	errno = ENOMEM;
+	if (ts_set)
+		free(ts_set);
+	return NULL;
+}
+
+static json_entity_t attr_find(test_sampler_inst_t inst,
+				json_entity_t json,
+				enum json_value_e json_type,
+				char *attr_name, int is_required,
+				char *ebuf, size_t ebufsz)
 {
 	json_entity_t v;
 	errno = 0;
@@ -482,176 +373,13 @@ static const char *__attr_find(test_sampler_inst_t inst, json_entity_t json,
 		}
 		return NULL;
 	}
-	if (v->type != JSON_STRING_VALUE) {
-		snprintf(ebuf, ebufsz, "%s: The given '%s' value is "
-				"not a string.\n", inst->base.inst_name, attr_name);
+	if (v->type != json_type) {
+		snprintf(ebuf, ebufsz, "%s: The given '%s' value is not a %s.\n",
+			inst->base.inst_name, attr_name, json_type_str(json_type));
 		errno = EINVAL;
 		return NULL;
 	}
-	return json_value_str(v)->str;
-}
-
-static int config_add_schema(test_sampler_inst_t inst, json_entity_t json,
-						char *ebuf, size_t ebufsz)
-{
-	int rc = 0;
-	struct test_sampler_schema *ts_schema;
-	ldms_schema_t schema;
-	const char *schema_name = __attr_find(inst, json, ebuf, ebufsz,
-							1, "schema");
-	if (!schema_name) {
-		rc = errno;
-		return rc;
-	}
-
-	ts_schema = __schema_find(&inst->schema_list, schema_name);
-	if (ts_schema) {
-		snprintf(ebuf, ebufsz, "Schema '%s' already exists.", schema_name);
-		return EEXIST;
-	}
-
-	const char *metrics, *value, *set_array_card_str;
-	const char *init_value = NULL;
-	int num_metrics, set_array_card;
-	metrics = __attr_find(inst, json, ebuf, ebufsz, 0, "metrics");
-	if (!metrics && (errno == EINVAL))
-		return EINVAL;
-	value = __attr_find(inst, json, ebuf, ebufsz, 0, "num_metrics");
-	if (!value && (errno == EINVAL))
-		return EINVAL;
-	if (!metrics && !value) {
-		snprintf(ebuf, ebufsz, "Either metrics or num_metrics "
-						"must be given.");
-		return EINVAL;
-	}
-
-	set_array_card_str = __attr_find(inst, json, ebuf, ebufsz, 0, "set_array_card");
-	if (!set_array_card_str) {
-		if (errno == EINVAL)
-			return EINVAL;
-		else
-			set_array_card = 1; /* Default */
-	} else {
-		set_array_card = strtol(set_array_card_str, NULL, 0);
-	}
-
-	ts_schema = malloc(sizeof(*ts_schema));
-	if (!ts_schema) {
-		INST_LOG(inst, LDMSD_LERROR, "Out of memory\n");
-		return ENOMEM;
-	}
-	TAILQ_INIT(&ts_schema->list);
-	LIST_INSERT_HEAD(&inst->schema_list, ts_schema, entry);
-	struct test_sampler_metric *metric;
-	if (metrics) {
-		char *_metrics = strdup(metrics);
-		if (!_metrics) {
-			INST_LOG(inst, LDMSD_LERROR, "Out of memory\n");
-			return ENOMEM;
-		}
-		ts_schema->type = TEST_SAMPLER_SCHEMA_TYPE_MANUAL;
-		char *s, *ptr;
-		s = strtok_r(_metrics, ",", &ptr);
-		while (s) {
-			metric = __schema_metric_new(inst, s);
-			if (!metric) {
-				rc = EINVAL;
-				goto cleanup;
-			}
-			s = strtok_r(NULL, ",", &ptr);
-			TAILQ_INSERT_TAIL(&ts_schema->list, metric, entry);
-		}
-	} else {
-		ts_schema->type = TEST_SAMPLER_SCHEMA_TYPE_AUTO;
-		enum ldms_value_type type;
-		num_metrics = atoi(value);
-
-		value = __attr_find(inst, json, ebuf, ebufsz, 0, "type");
-		if (value) {
-			type = ldms_metric_str_to_type(value);
-			if (type == LDMS_V_NONE) {
-				rc = EINVAL;
-				goto cleanup;
-			}
-		} else {
-			if (errno == EINVAL) {
-				rc = EINVAL;
-				goto cleanup;
-			}
-			type = LDMS_V_U64;
-		}
-
-		init_value = __attr_find(inst, json, ebuf, ebufsz, 0, "init_value");
-		if (!init_value) {
-			if (errno == EINVAL) {
-				rc = EINVAL;
-				goto cleanup;
-			}
-			init_value = "0";
-		}
-
-		int i;
-		char name[128];
-		for (i = 0; i < num_metrics; i++) {
-			snprintf(name, 128, "%s%d", DEFAULT_METRIC_NAME_NAME, i);
-			metric = __test_sampler_metric_new(inst, name, "data",
-					type, init_value, "0");
-			if (!metric) {
-				INST_LOG(inst, LDMSD_LERROR,
-					 "Failed to create metric.\n");
-				goto cleanup;
-			}
-			TAILQ_INSERT_TAIL(&ts_schema->list, metric, entry);
-		}
-	}
-
-	schema = __schema_new(inst, schema_name);
-	if (!schema) {
-		INST_LOG(inst, LDMSD_LERROR, "Failed to create a schema\n");
-		rc = ENOMEM;
-		goto cleanup;
-	}
-	ldms_schema_array_card_set(schema, set_array_card);
-	TAILQ_FOREACH(metric, &ts_schema->list, entry) {
-		if (metric->mtype == LDMS_MDESC_F_DATA) {
-			if (ldms_type_is_array(metric->vtype)) {
-				metric->idx = ldms_schema_metric_array_add(
-						schema, metric->name,
-						metric->vtype, "",
-						metric->count);
-			} else {
-				metric->idx = ldms_schema_metric_add(
-						schema, metric->name,
-						metric->vtype, "");
-			}
-		} else {
-			if (ldms_type_is_array(metric->vtype)) {
-				metric->idx = ldms_schema_meta_array_add(
-						schema, metric->name,
-						metric->vtype, "",
-						metric->count);
-			} else {
-				metric->idx = ldms_schema_meta_add(
-						schema, metric->name,
-						metric->vtype, "");
-			}
-		}
-	}
-
-	ts_schema->schema = schema;
-	ts_schema->name = strdup(schema_name);
-	return 0;
-
-cleanup:
-	metric = TAILQ_FIRST(&ts_schema->list);
-	while (metric) {
-		TAILQ_REMOVE(&ts_schema->list, metric, entry);
-		__schema_metric_destroy(metric);
-		metric = TAILQ_FIRST(&ts_schema->list);
-	}
-	LIST_REMOVE(ts_schema, entry);
-	free(ts_schema);
-	return rc;
+	return v;
 }
 
 enum ldms_value_type __type_to_scalar(enum ldms_value_type type)
@@ -725,611 +453,439 @@ void __val_inc(ldms_mval_t val, enum ldms_value_type type)
 	}
 }
 
-static int config_add_set(test_sampler_inst_t inst, json_entity_t json,
-						char *ebuf, size_t ebufsz)
-{
-	int rc = 0;
-	struct test_sampler_schema *ts_schema;
-
-	const char *schema_name = __attr_find(inst, json, ebuf, ebufsz, 1, "schema");
-	if (!schema_name) {
-		rc = errno;
-		return rc;
-	}
-
-	const char *set_name = __attr_find(inst, json, ebuf, ebufsz, 1, "instance");
-	if (!set_name) {
-		rc = errno;
-		return rc;
-	}
-	ts_schema = __schema_find(&inst->schema_list, schema_name);
-	if (!ts_schema) {
-		snprintf(ebuf, ebufsz, "Schema '%s' does not exist.", schema_name);
-		return EINVAL;
-	}
-
-	const char *producer = __attr_find(inst, json, ebuf, ebufsz, 0, "producer");
-	if (!producer && (errno == EINVAL)) {
-		return EINVAL;
-	}
-	const char *compid = __attr_find(inst, json, ebuf, ebufsz, 0, "component_id");
-	if (!compid && (errno == EINVAL))
-		return EINVAL;
-	const char *jobid = __attr_find(inst, json, ebuf, ebufsz, 0, "jobid");
-	if (!jobid && (errno == EINVAL))
-		return EINVAL;
-	const char *push_s = __attr_find(inst, json, ebuf, ebufsz, 0, "push");
-	if (!push_s && (errno == EINVAL))
-		return EINVAL;
-	int push = 0;
-	if (push_s)
-		push = atoi(push_s);
-
-	struct test_sampler_set *ts_set;
-	ts_set = __set_find(&inst->set_list, set_name);
-	if (ts_set) {
-		snprintf(ebuf, ebufsz, "Set '%s' already exists\n", set_name);
-		return EINVAL;
-	}
-
-	ts_set = __create_test_sampler_set(inst, set_name, push, ts_schema);
-	if (!ts_set) {
-		rc = errno;
-		goto err0;
-	}
-
-	union ldms_value v;
-	int mid = 0;
-	char *endptr;
-	if (compid) {
-		v.v_u64 = strtoull(compid, &endptr, 0);
-		if (*endptr != '\0') {
-			snprintf(ebuf, ebufsz, "invalid component_id %s\n", compid);
-			rc = EINVAL;
-			goto err1;
-		}
-	} else {
-		v.v_u64 = 0;
-	}
-	mid = ldms_metric_by_name(ts_set->set, "component_id");
-	if (mid >= 0)
-		ldms_metric_set(ts_set->set, mid, &v);
-	if (jobid) {
-		v.v_u64 = strtoull(jobid, &endptr, 0);
-		if (*endptr != '\0') {
-			snprintf(ebuf, ebufsz, "invalid jobid %s\n", jobid);
-			rc = EINVAL;
-			goto err1;
-		}
-	} else {
-		v.v_u64 = 0;
-	}
-	mid = ldms_metric_by_name(ts_set->set, "jobid");
-	if (mid >= 0)
-		ldms_metric_set(ts_set->set, mid, &v);
-
-	int i;
-	struct test_sampler_metric *metric;
-	TAILQ_FOREACH(metric, &ts_schema->list, entry) {
-		if (metric->vtype == LDMS_V_CHAR_ARRAY) {
-			ldms_metric_array_set(ts_set->set, metric->idx,
-					&(metric->init_value), 0, metric->count);
-		} else if (ldms_type_is_array(metric->vtype)) {
-			v = metric->init_value;
-			for (i = 0; i < metric->count; i++) {
-				ldms_metric_array_set_val(ts_set->set,
-						metric->idx,
-						i, &v);
-				__val_inc(&v, __type_to_scalar(metric->vtype));
-			}
-		} else {
-			ldms_metric_set(ts_set->set, metric->idx,
-						&(metric->init_value));
-		}
-		metric->latest_value = metric->init_value;
-	}
-
-	if (producer) {
-		ldms_set_producer_name_set(ts_set->set, producer);
-	}
-
-	return 0;
-err1:
-	__delete_test_sampler_set(inst, ts_set);
-err0:
-	return rc;
-}
-
-static int config_add_default(test_sampler_inst_t inst, json_entity_t json,
-						char *ebuf, size_t ebufsz)
-{
-	const char *sname;
-	const char *s;
-	const char *push_s;
-	int rc, push;
-	ldmsd_sampler_type_t samp = LDMSD_SAMPLER(inst);
-	sname = __attr_find(inst, json, ebuf, ebufsz, 0, "schema");
-	if (!sname && (errno = EINVAL))
-		return EINVAL;
-	if (!sname)
-		sname = samp->schema_name;
-	if (strlen(sname) == 0){
-		snprintf(ebuf, ebufsz, "schema name '%s' is invalid.", sname);
-		return EINVAL;
-	}
-
-	s = __attr_find(inst, json, ebuf, ebufsz, 0, "base");
-	if (!s && (errno == EINVAL))
-		return EINVAL;
-	if (s) {
-		snprintf(inst->base_set_name, sizeof(inst->base_set_name),
-			 "%s", s);
-	}
-
-	s = __attr_find(inst, json, ebuf, ebufsz, 0, "num_sets");
-	if (!s && (errno == EINVAL))
-		return EINVAL;
-	if (!s)
-		inst->num_sets = DEFAULT_NUM_SETS;
-	else
-		inst->num_sets = atoi(s);
-
-	s = __attr_find(inst, json, ebuf, ebufsz, 0, "num_metrics");
-	if (!s && (errno == EINVAL))
-		return EINVAL;
-	if (!s)
-		inst->num_metrics = DEFAULT_NUM_METRICS;
-	else
-		inst->num_metrics = atoi(s);
-
-	push_s = __attr_find(inst, json, ebuf, ebufsz, 0, "push");
-	if (!push_s && (errno == EINVAL))
-		return EINVAL;
-	if (push_s)
-		push = atoi(push_s);
-	else
-		push = 0;
-
-	rc = create_metric_set(inst, sname, push);
-	if (rc) {
-		INST_LOG(inst, LDMSD_LERROR, "failed to create metric sets.\n");
-		return rc;
-	}
-	return 0;
-
-}
-
-struct test_sampler_schema *__test_sampler_schema_new(test_sampler_inst_t inst,
-				const char *name, enum schema_type type,
-				ldms_schema_t schema)
-{
-	struct test_sampler_schema *ts_schema;
-	ts_schema = calloc(1, sizeof(*ts_schema));
-	if (!ts_schema) {
-		INST_LOG(inst, LDMSD_LERROR, "Out of memory\n");
-		return NULL;
-	}
-	ts_schema->name = strdup(name);
-	if (!ts_schema->name) {
-		free(ts_schema);
-		INST_LOG(inst, LDMSD_LERROR, "Out of memory\n");
-		return NULL;
-	}
-	ts_schema->type = type;
-	ts_schema->schema = schema;
-	TAILQ_INIT(&ts_schema->list);
-	LIST_INSERT_HEAD(&inst->schema_list, ts_schema, entry);
-	return ts_schema;
-}
-
-static void __test_sampler_schema_delete(test_sampler_inst_t inst,
-					 struct test_sampler_schema *ts_schema)
-{
-	struct test_sampler_metric *metric;
-	LIST_REMOVE(ts_schema, entry);
-	while ((metric = TAILQ_FIRST(&ts_schema->list))) {
-		TAILQ_REMOVE(&ts_schema->list, metric, entry);
-		__schema_metric_destroy(metric);
-	}
-	if (ts_schema->schema)
-		ldms_schema_delete(ts_schema->schema);
-	if (ts_schema->name)
-		free(ts_schema->name);
-	free(ts_schema);
-}
-
-static int __add_all_scalar(test_sampler_inst_t inst,
-			    struct test_sampler_schema *ts_schema)
-{
-	const char *mname;
-	ldms_schema_t schema = ts_schema->schema;
-	struct test_sampler_metric *metric;
-	enum ldms_value_type type;
-	for (type = LDMS_V_FIRST; type < LDMS_V_LAST; type++) {
-		if (ldms_type_is_array(type))
-			break;
-		mname = ldms_metric_type_to_str(type);
-		metric = __test_sampler_metric_new(inst, mname, "data",
-						type, "0", NULL);
-		metric->idx = ldms_schema_metric_add(schema, mname, type, "");
-		if (metric->idx < 0)
-			return metric->idx;
-		TAILQ_INSERT_TAIL(&ts_schema->list, metric, entry);
-	}
-	return 0;
-}
-
-static int __add_all_array(test_sampler_inst_t inst,
-			   struct test_sampler_schema *ts_schema,
-			   const char *array_sz_str)
-{
-	const char *mname;
-	ldms_schema_t schema = ts_schema->schema;
-	struct test_sampler_metric *metric;
-	enum ldms_value_type type;
-	for (type = LDMS_V_FIRST; type < LDMS_V_LAST; type++) {
-		if (!ldms_type_is_array(type))
-			continue;
-		mname = ldms_metric_type_to_str(type);
-		metric = __test_sampler_metric_new(inst, mname, "data",
-						type, "0", array_sz_str);
-		metric->idx = ldms_schema_metric_array_add(schema, mname, type,
-							"", metric->count);
-		if (metric->idx < 0)
-			return metric->idx;
-		TAILQ_INSERT_TAIL(&ts_schema->list, metric, entry);
-	}
-	return 0;
-}
-
-static int config_add_scalar(test_sampler_inst_t inst, json_entity_t json,
-						char *ebuf, size_t ebufsz)
-{
-	const char *schema_name, *set_array_card_str;
-	int set_array_card;
-	struct test_sampler_schema *ts_schema;
-	ldms_schema_t schema;
-	int rc;
-
-	schema_name = __attr_find(inst, json, ebuf, ebufsz, 0, "schema");
-	if (!schema_name && (errno == EINVAL))
-		return EINVAL;
-	if (!schema_name)
-		schema_name = "test_sampler_scalar";
-	if (strlen(schema_name) == 0){
-		snprintf(ebuf, ebufsz, "schema name '%s' is invalid.", schema_name);
-		return EINVAL;
-	}
-	set_array_card_str = __attr_find(inst, json, ebuf, ebufsz, 0, "set_array_card");
-	if (!set_array_card_str && (errno == EINVAL))
-		return EINVAL;
-	if (!set_array_card_str)
-		set_array_card = 1;
-	else
-		set_array_card = strtol(set_array_card_str, NULL, 0);
-
-	ts_schema = __schema_find(&inst->schema_list, schema_name);
-	if (ts_schema) {
-		snprintf(ebuf, ebufsz, "Schema '%s' already exists.\n",
-			 schema_name);
-		return EEXIST;
-	}
-
-	schema = __schema_new(inst, schema_name);
-	if (!schema) {
-		INST_LOG(inst, LDMSD_LERROR,
-			 "test_sampler: Failed to create schema '%s'\n",
-			 schema_name);
-		return ENOMEM;
-	}
-
-	ts_schema = __test_sampler_schema_new(inst, schema_name,
-				TEST_SAMPLER_SCHEMA_TYPE_AUTO, schema);
-	if (!ts_schema)
-		return ENOMEM;
-
-	ldms_schema_array_card_set(schema, set_array_card);
-	rc = __add_all_scalar(inst, ts_schema);
-	if (rc < 0) {
-		__test_sampler_schema_delete(inst, ts_schema);
-		rc = -rc;
-	}
-	return rc;
-}
-
-static int config_add_array(test_sampler_inst_t inst, json_entity_t json,
-						char *ebuf, size_t ebufsz)
-{
-	const char *schema_name, *set_array_card_str, *array_sz;
-	int set_array_card;
-	struct test_sampler_schema *ts_schema;
-	ldms_schema_t schema;
-	int rc;
-
-	schema_name = __attr_find(inst, json, ebuf, ebufsz, 0, "schema");
-	if (!schema_name && (errno == EINVAL))
-		return EINVAL;
-	if (!schema_name)
-		schema_name = "test_sampler_array";
-	if (strlen(schema_name) == 0){
-		snprintf(ebuf, ebufsz, "schema name '%s' is invalid.", schema_name);
-		return EINVAL;
-	}
-	set_array_card_str = __attr_find(inst, json, ebuf, ebufsz, 0, "set_array_card");
-	if (!set_array_card_str && (errno == EINVAL))
-		return EINVAL;
-	if (!set_array_card_str)
-		set_array_card = 1;
-	else
-		set_array_card = strtol(set_array_card_str, NULL, 0);
-	array_sz = __attr_find(inst, json, ebuf, ebufsz, 1, "metric_array_sz");
-	if (!array_sz) {
-		rc = errno;
-		return rc;
-	}
-
-	ts_schema = __schema_find(&inst->schema_list, schema_name);
-	if (ts_schema) {
-		snprintf(ebuf, ebufsz, "Schema '%s' already exists.", schema_name);
-		return EEXIST;
-	}
-
-	schema = __schema_new(inst, schema_name);
-	if (!schema) {
-		INST_LOG(inst, LDMSD_LERROR, "Failed to create "
-				"schema '%s'\n", schema_name);
-		return ENOMEM;
-	}
-
-	ts_schema = __test_sampler_schema_new(inst, schema_name,
-				TEST_SAMPLER_SCHEMA_TYPE_AUTO, schema);
-	if (!ts_schema)
-		return ENOMEM;
-
-	ldms_schema_array_card_set(schema, set_array_card);
-	rc = __add_all_array(inst, ts_schema, array_sz);
-	if (rc < 0) {
-		__test_sampler_schema_delete(inst, ts_schema);
-		rc = -rc;
-	}
-	return rc;
-}
-
-static int config_add_all(test_sampler_inst_t inst, json_entity_t json,
-					char *ebuf, size_t ebufsz)
-{
-	const char *schema_name, *set_array_card_str, *array_sz;
-	int set_array_card;
-	struct test_sampler_schema *ts_schema;
-	ldms_schema_t schema;
-	int rc;
-
-	schema_name = __attr_find(inst, json, ebuf, ebufsz, 0, "schema");
-	if (!schema_name && (errno == EINVAL))
-		return EINVAL;
-	if (!schema_name)
-		schema_name = "test_sampler_all";
-	if (strlen(schema_name) == 0){
-		snprintf(ebuf, ebufsz, "schema name '%s' is invalid.", schema_name);
-		return EINVAL;
-	}
-	set_array_card_str = __attr_find(inst, json, ebuf, ebufsz, 0, "set_array_card");
-	if (!set_array_card_str && (errno == EINVAL))
-		return EINVAL;
-	if (!set_array_card_str)
-		set_array_card = 1;
-	else
-		set_array_card = strtol(set_array_card_str, NULL, 0);
-	array_sz = __attr_find(inst, json, ebuf, ebufsz, 1, "metric_array_sz");
-	if (!array_sz) {
-		rc = errno;
-		return rc;
-	}
-
-	ts_schema = __schema_find(&inst->schema_list, schema_name);
-	if (ts_schema) {
-		snprintf(ebuf, ebufsz, "Schema '%s' already exists.",
-			 schema_name);
-		return EEXIST;
-	}
-
-	schema = __schema_new(inst, schema_name);
-	if (!schema) {
-		INST_LOG(inst, LDMSD_LERROR, "Failed to create schema '%s'\n",
-			 schema_name);
-		return ENOMEM;
-	}
-
-	ts_schema = __test_sampler_schema_new(inst, schema_name,
-				TEST_SAMPLER_SCHEMA_TYPE_AUTO, schema);
-	if (!ts_schema)
-		return ENOMEM;
-
-	ldms_schema_array_card_set(schema, set_array_card);
-	rc = __add_all_scalar(inst, ts_schema);
-	if (rc < 0) {
-		__test_sampler_schema_delete(inst, ts_schema);
-		rc = -rc;
-		return rc;
-	}
-	rc = __add_all_array(inst, ts_schema, array_sz);
-	if (rc < 0) {
-		__test_sampler_schema_delete(inst, ts_schema);
-		rc = -rc;
-	}
-	return rc;
-}
-
 static inline
-void __metric_inc(ldms_set_t set, struct test_sampler_metric *metric, int i)
+void __metric_inc(ldms_set_t set, int mid, int j)
 {
 	union ldms_value v;
-	switch (metric->vtype) {
+	switch (ldms_metric_type_get(set, mid)) {
 	case LDMS_V_U8_ARRAY:
-		v.v_u8 = ldms_metric_array_get_u8(set, metric->idx, i);
+		v.v_u8 = ldms_metric_array_get_u8(set, mid, j);
 		v.v_u8++;
-		ldms_metric_array_set_u8(set, metric->idx, i, v.v_u8);
+		ldms_metric_array_set_u8(set, mid, j, v.v_u8);
 		break;
 	case LDMS_V_S8_ARRAY:
-		v.v_s8 = ldms_metric_array_get_s8(set, metric->idx, i);
+		v.v_s8 = ldms_metric_array_get_s8(set, mid, j);
 		v.v_s8++;
-		ldms_metric_array_set_s8(set, metric->idx, i, v.v_s8);
+		ldms_metric_array_set_s8(set, mid, j, v.v_s8);
 		break;
 	case LDMS_V_U16_ARRAY:
-		v.v_u16 = ldms_metric_array_get_u16(set, metric->idx, i);
+		v.v_u16 = ldms_metric_array_get_u16(set, mid, j);
 		v.v_u16++;
-		ldms_metric_array_set_u16(set, metric->idx, i, v.v_u16);
+		ldms_metric_array_set_u16(set, mid, j, v.v_u16);
 		break;
 	case LDMS_V_S16_ARRAY:
-		v.v_s16 = ldms_metric_array_get_s16(set, metric->idx, i);
+		v.v_s16 = ldms_metric_array_get_s16(set, mid, j);
 		v.v_s16++;
-		ldms_metric_array_set_s16(set, metric->idx, i, v.v_s16);
+		ldms_metric_array_set_s16(set, mid, j, v.v_s16);
 		break;
 	case LDMS_V_U32_ARRAY:
-		v.v_u32 = ldms_metric_array_get_u32(set, metric->idx, i);
+		v.v_u32 = ldms_metric_array_get_u32(set, mid, j);
 		v.v_u32++;
-		ldms_metric_array_set_u32(set, metric->idx, i, v.v_u32);
+		ldms_metric_array_set_u32(set, mid, j, v.v_u32);
 		break;
 	case LDMS_V_S32_ARRAY:
-		v.v_s32 = ldms_metric_array_get_s32(set, metric->idx, i);
+		v.v_s32 = ldms_metric_array_get_s32(set, mid, j);
 		v.v_s32++;
-		ldms_metric_array_set_s32(set, metric->idx, i, v.v_s32);
+		ldms_metric_array_set_s32(set, mid, j, v.v_s32);
 		break;
 	case LDMS_V_S64_ARRAY:
-		v.v_s64 = ldms_metric_array_get_s64(set, metric->idx, i);
+		v.v_s64 = ldms_metric_array_get_s64(set, mid, j);
 		v.v_s64++;
-		ldms_metric_array_set_s64(set, metric->idx, i, v.v_s64);
+		ldms_metric_array_set_s64(set, mid, j, v.v_s64);
 		break;
 	case LDMS_V_U64_ARRAY:
-		v.v_u64 = ldms_metric_array_get_u64(set, metric->idx, i);
+		v.v_u64 = ldms_metric_array_get_u64(set, mid, j);
 		v.v_u64++;
-		ldms_metric_array_set_u64(set, metric->idx, i, v.v_u64);
+		ldms_metric_array_set_u64(set, mid, j, v.v_u64);
 		break;
 	case LDMS_V_F32_ARRAY:
-		v.v_f = ldms_metric_array_get_float(set, metric->idx, i);
+		v.v_f = ldms_metric_array_get_float(set, mid, j);
 		v.v_f++;
-		ldms_metric_array_set_float(set, metric->idx, i, v.v_f);
+		ldms_metric_array_set_float(set, mid, j, v.v_f);
 		break;
 	case LDMS_V_D64_ARRAY:
-		v.v_d = ldms_metric_array_get_double(set, metric->idx, i);
+		v.v_d = ldms_metric_array_get_double(set, mid, j);
 		v.v_d++;
-		ldms_metric_array_set_double(set, metric->idx, i, v.v_d);
+		ldms_metric_array_set_double(set, mid, j, v.v_d);
 		break;
 	case LDMS_V_U8:
-		v.v_u8 = ldms_metric_get_u8(set, metric->idx);
+		v.v_u8 = ldms_metric_get_u8(set, mid);
 		v.v_u8++;
-		ldms_metric_set_u8(set, metric->idx, v.v_u8);
+		ldms_metric_set_u8(set, mid, v.v_u8);
 		break;
 	case LDMS_V_S8:
-		v.v_s8 = ldms_metric_get_s8(set, metric->idx);
+		v.v_s8 = ldms_metric_get_s8(set, mid);
 		v.v_s8++;
-		ldms_metric_set_s8(set, metric->idx, v.v_s8);
+		ldms_metric_set_s8(set, mid, v.v_s8);
 		break;
 	case LDMS_V_U16:
-		v.v_u16 = ldms_metric_get_u16(set, metric->idx);
+		v.v_u16 = ldms_metric_get_u16(set, mid);
 		v.v_u16++;
-		ldms_metric_set_u16(set, metric->idx, v.v_u16);
+		ldms_metric_set_u16(set, mid, v.v_u16);
 		break;
 	case LDMS_V_S16:
-		v.v_s16 = ldms_metric_get_s16(set, metric->idx);
+		v.v_s16 = ldms_metric_get_s16(set, mid);
 		v.v_s16++;
-		ldms_metric_set_s16(set, metric->idx, v.v_s16);
+		ldms_metric_set_s16(set, mid, v.v_s16);
 		break;
 	case LDMS_V_U32:
-		v.v_u32 = ldms_metric_get_u32(set, metric->idx);
+		v.v_u32 = ldms_metric_get_u32(set, mid);
 		v.v_u32++;
-		ldms_metric_set_u32(set, metric->idx, v.v_u32);
+		ldms_metric_set_u32(set, mid, v.v_u32);
 		break;
 	case LDMS_V_S32:
-		v.v_s32 = ldms_metric_get_s32(set, metric->idx);
+		v.v_s32 = ldms_metric_get_s32(set, mid);
 		v.v_s32++;
-		ldms_metric_set_s32(set, metric->idx, v.v_s32);
+		ldms_metric_set_s32(set, mid, v.v_s32);
 		break;
 	case LDMS_V_S64:
-		v.v_s64 = ldms_metric_get_s64(set, metric->idx);
+		v.v_s64 = ldms_metric_get_s64(set, mid);
 		v.v_s64++;
-		ldms_metric_set_s64(set, metric->idx, v.v_s64);
+		ldms_metric_set_s64(set, mid, v.v_s64);
 		break;
 	case LDMS_V_U64:
-		v.v_u64 = ldms_metric_get_u64(set, metric->idx);
+		v.v_u64 = ldms_metric_get_u64(set, mid);
 		v.v_u64++;
-		ldms_metric_set_u64(set, metric->idx, v.v_u64);
+		ldms_metric_set_u64(set, mid, v.v_u64);
 		break;
 	case LDMS_V_F32:
-		v.v_f = ldms_metric_get_float(set, metric->idx);
+		v.v_f = ldms_metric_get_float(set, mid);
 		v.v_f++;
-		ldms_metric_set_float(set, metric->idx, v.v_f);
+		ldms_metric_set_float(set, mid, v.v_f);
 		break;
 	case LDMS_V_D64:
-		v.v_d = ldms_metric_get_double(set, metric->idx);
+		v.v_d = ldms_metric_get_double(set, mid);
 		v.v_d++;
-		ldms_metric_set_double(set, metric->idx, v.v_d);
+		ldms_metric_set_double(set, mid, v.v_d);
 		break;
 	default:
 		return;
 	}
 }
 
-static void __metric_increment(test_sampler_inst_t inst,
-			       struct test_sampler_metric *metric,
-			       ldms_set_t set)
+static
+int update_schema_manual(test_sampler_inst_t inst, ldms_schema_t schema)
 {
-	int i = 0;
+	struct test_sampler_metric *m;
 
-	if (ldms_type_is_array(metric->vtype)) {
-		for (i = 0; i < metric->count; i++) {
-			__metric_inc(set, metric, i);
+	TAILQ_FOREACH(m, &inst->metric_list, entry) {
+		if (m->mtype == LDMS_MDESC_F_DATA) {
+			if (ldms_type_is_array(m->vtype)) {
+				m->idx = ldms_schema_metric_array_add(schema,
+							m->name, m->vtype,
+							m->unit, m->array_sz);
+			} else {
+				m->idx = ldms_schema_metric_add(schema,
+						m->name, m->vtype, m->unit);
+			}
+		} else {
+			if (ldms_type_is_array(m->mtype)) {
+				m->idx = ldms_schema_meta_array_add(schema,
+							m->name, m->vtype,
+							m->unit, m->array_sz);
+			} else {
+				m->idx = ldms_schema_meta_add(schema,
+						m->name, m->vtype, m->unit);
+			}
 		}
-	} else {
-		__metric_inc(set, metric, 0);
+		if (m->idx < 0)
+			return m->idx;
 	}
+	return 0;
 }
 
-static void __test_schema_free(struct test_sampler_schema *tschema)
+static int update_schema_default(test_sampler_inst_t inst, ldms_schema_t schema)
 {
-	struct test_sampler_metric *tm;
-	tm = TAILQ_FIRST(&tschema->list);
-	while (tm) {
-		TAILQ_REMOVE(&tschema->list, tm, entry);
-		__schema_metric_destroy(tm);
-		tm = TAILQ_FIRST(&tschema->list);
-	}
-	if (tschema->name) {
-		free(tschema->name);
-		tschema->name = NULL;
-	}
+	char *name;
+	int i, idx, rc;
 
-	if (tschema->schema) {
-		ldms_schema_delete(tschema->schema);
-		tschema->schema = NULL;
+	for (i = 0; i < inst->num_metrics; i++) {
+		rc = asprintf(&name, "metric_%d", i);
+		if (rc < 0) {
+			INST_LOG(inst, LDMSD_LCRITICAL, "Out of memory\n");
+			return ENOMEM;
+		}
+		idx = ldms_schema_metric_add(schema, name, LDMS_V_U64, inst->unit);
+		free(name);
+		if (idx < 0)
+			return -idx;
 	}
-
-	free(tschema);
+	return 0;
 }
 
+static int update_schema_array(test_sampler_inst_t inst, ldms_schema_t schema)
+{
+	int t, idx;
+	const char *name;
+
+	for (t = LDMS_V_CHAR_ARRAY; t < LDMS_V_LAST; t++) {
+		name = ldms_metric_type_to_str(t);
+		idx = ldms_schema_metric_array_add(schema, name, t,
+						inst->unit, inst->array_sz);
+		if (idx < 0)
+			return -idx;
+	}
+	return 0;
+}
+
+static int update_schema_scalar(test_sampler_inst_t inst, ldms_schema_t schema)
+{
+	int t, idx;
+	const char *name;
+
+	for (t = LDMS_V_FIRST; t < LDMS_V_LAST; t++) {
+		if (ldms_type_is_array(t))
+			break;
+		name = ldms_metric_type_to_str(t);
+		idx = ldms_schema_metric_add(schema, name, t, inst->unit);
+		if (idx < 0)
+			return -idx;
+	}
+	return 0;
+}
+
+static int update_schema_all(test_sampler_inst_t inst, ldms_schema_t schema)
+{
+	int rc = update_schema_scalar(inst, schema);
+	if (rc)
+		return rc;
+	return update_schema_array(inst, schema);
+}
+
+static
+int process_instances(test_sampler_inst_t inst, json_entity_t instances,
+						char *ebuf, size_t ebufsz)
+{
+	json_entity_t ent, v, d;
+	int push_at, delete_at, create_at, is_suffix;
+	struct test_sampler_set *ts_set;
+	char *set_name;
+
+	for (ent = json_attr_first(instances); ent; ent = json_attr_next(ent)) {
+		set_name = json_attr_name(ent)->str;
+		d = json_attr_value(ent);
+
+		/* push */
+		v = attr_find(inst, d, JSON_INT_VALUE,
+					"push_at", 0, ebuf, ebufsz);
+		if (!v && (errno == EINVAL))
+			return EINVAL;
+		if (!v)
+			push_at = TEST_SAMPLER_DEFAULT_PUSH_AT;
+		else
+			push_at = json_value_int(v);
+
+		/* delete */
+		v = attr_find(inst, d, JSON_INT_VALUE,
+					"delete_at", 0, ebuf, ebufsz);
+		if (!v && (errno == EINVAL))
+			return EINVAL;
+		if (!v)
+			delete_at = TEST_SAMPLER_DEFAULT_DELETE_AT;
+		else
+			delete_at = json_value_int(v);
+
+		/* create */
+		v = attr_find(inst, d, JSON_INT_VALUE,
+					"create_from_delete_at", 0, ebuf, ebufsz);
+		if (!v && (errno == EINVAL))
+			return EINVAL;
+		if (!v)
+			create_at = TEST_SAMPLER_DEFAULT_CREATE_AT;
+		else
+			create_at = json_value_int(v);
+
+		/* suffix */
+		v = attr_find(inst, d, JSON_BOOL_VALUE,
+					"suffix_with_time", 0, ebuf, ebufsz);
+		if (!v && (errno == EINVAL))
+			return EINVAL;
+		if (!v)
+			is_suffix = TEST_SAMPLER_DEFAULT_SUFFIX_W_TIME;
+		else
+			is_suffix = json_value_bool(v);
+
+		/* Create test_sampler_set */
+		ts_set = ts_set_new(inst, set_name, push_at, delete_at, create_at, is_suffix);
+		if (!ts_set)
+			return ENOMEM;
+	}
+	return 0;
+}
+
+static
+int process_metrics(test_sampler_inst_t inst, json_entity_t metrics,
+					char *ebuf, size_t ebufsz)
+{
+	int rc;
+	json_entity_t ent, v, d;
+	char *name, *mtype, *init_value, *unit;
+	enum ldms_value_type vtype;
+	int array_sz;
+	struct test_sampler_metric *metric;
+
+	for (ent = json_attr_first(metrics); ent; ent = json_attr_next(ent)) {
+		name = json_attr_name(ent)->str;
+		d = json_attr_value(ent);
+
+		/* metric_type */
+		v = attr_find(inst, d, JSON_STRING_VALUE, "metric_type",
+							0, ebuf, ebufsz);
+		if (v) {
+			mtype = json_value_str(v)->str;
+		} else {
+			if (errno == EINVAL) {
+				rc = EINVAL;
+				goto err;
+			} else {
+				mtype = "data";
+			}
+		}
+
+		/* value_type */
+		v = attr_find(inst, d, JSON_STRING_VALUE, "value_type",
+							0, ebuf, ebufsz);
+		if (v) {
+			vtype = ldms_metric_str_to_type(json_value_str(v)->str);
+			if (LDMS_V_NONE == vtype) {
+				snprintf(ebuf, ebufsz, "%s: metric %s has "
+						"invalid value type (%s).",
+						inst->base.inst_name, name,
+						json_value_str(v)->str);
+				rc = EINVAL;
+				goto err;
+			}
+		} else {
+			if (errno == EINVAL) {
+				rc = EINVAL;
+				goto err;
+			}else{
+				vtype = LDMS_V_U64;
+			}
+		}
+
+		/* init_value */
+		v = attr_find(inst, d, JSON_STRING_VALUE, "init_value",
+							0, ebuf, ebufsz);
+		if (v) {
+			init_value = json_value_str(v)->str;
+		} else {
+			if (EINVAL == errno) {
+				rc = EINVAL;
+				goto err;
+			} else {
+				init_value = "0";
+			}
+		}
+
+		/* array_sz */
+		v = attr_find(inst, d, JSON_INT_VALUE, "array_sz",
+							0, ebuf, ebufsz);
+		if (v) {
+			if (!ldms_type_is_array(vtype)) {
+				snprintf(ebuf, ebufsz, "%s: metric %s not an "
+						"array. array_sz is ignored.",
+						inst->base.inst_name, name);
+				array_sz = 0;
+			} else {
+				array_sz = json_value_int(v);
+			}
+		} else {
+			if (EINVAL == errno) {
+				rc = EINVAL;
+				goto err;
+			} else {
+				array_sz = 0;
+			}
+		}
+
+		/* unit */
+		v = attr_find(inst, d, JSON_STRING_VALUE,
+				"unit", 0, ebuf, ebufsz);
+		if (!v) {
+			if (EINVAL == errno) {
+				snprintf(ebuf, ebufsz, "%s: unit of "
+						"metric (%s) is not a string.",
+						LDMSD_INST(inst)->inst_name, name);
+				rc = EINVAL;
+				goto err;
+			} else {
+				unit = inst->unit;
+			}
+		} else {
+			unit = json_value_str(v)->str;
+		}
+
+		metric = ts_metric_new(inst, name, mtype, vtype,
+						init_value, array_sz, unit);
+		if (!metric)
+			goto oom;
+	}
+
+	return 0;
+oom:
+	INST_LOG(inst, LDMSD_LCRITICAL, "Out of memory\n");
+	rc = ENOMEM;
+err:
+	metric_list_empty(inst);
+	return rc;
+}
 
 /* ============== Sampler Plugin APIs ================= */
 
 static
 int test_sampler_update_schema(ldmsd_plugin_inst_t pi, ldms_schema_t schema)
 {
-	/* do nothing */
-	return 0;
+	int rc = 0;
+	test_sampler_inst_t inst = (void *)pi;
+
+	switch (inst->type) {
+	case TEST_SAMPLER_TYPE_SCALAR:
+		rc = update_schema_scalar(inst, schema);
+		break;
+	case TEST_SAMPLER_TYPE_ARRAY:
+		rc = update_schema_array(inst, schema);
+		break;
+	case TEST_SAMPLER_TYPE_ALL:
+		rc = update_schema_all(inst, schema);
+		break;
+	case TEST_SAMPLER_TYPE_DEFAULT:
+		rc = update_schema_default(inst, schema);
+		break;
+	case TEST_SAMPLER_TYPE_MANUAL:
+		rc = update_schema_manual(inst, schema);
+		break;
+	default:
+		INST_LOG(inst, LDMSD_LCRITICAL, "Unknown schema type. This is "
+				"impossible because the plugin checked the type "
+				"at the configuration time.");
+		assert(0 == "Impossible");
+		break;
+	}
+	return rc;
 }
 
 static
 int test_sampler_update_set(ldmsd_plugin_inst_t pi, ldms_set_t set, void *ctxt)
 {
-	test_sampler_inst_t inst = (void*)pi;
-	struct test_sampler_set *ts_set = ctxt;
-	struct test_sampler_metric *metric;
+	int j, idx, card, len;
+	ldmsd_sampler_type_t samp = LDMSD_SAMPLER(pi);
 
-	TAILQ_FOREACH(metric, &ts_set->ts_schema->list, entry) {
-		if (metric->mtype == LDMS_MDESC_F_META)
+	card = ldms_set_card_get(set);
+	for (idx = samp->first_idx; idx < card; idx++) {
+		if (ldms_metric_flags_get(set, idx) & LDMS_MDESC_F_META) {
+			/* Don't change meta metric value */
 			continue;
-		if (0 == strcmp(metric->name, "job_id"))
-			continue;
-		__metric_increment(inst, metric, set);
+		}
+
+		if (ldms_metric_is_array(set, idx)) {
+			len = ldms_metric_array_get_len(set, idx);
+			for (j = 0; j < len; j++) {
+				__metric_inc(set, idx, j);
+			}
+		} else {
+			__metric_inc(set, idx, 0);
+		}
 	}
 
 	return 0;
@@ -1338,43 +894,45 @@ int test_sampler_update_set(ldmsd_plugin_inst_t pi, ldms_set_t set, void *ctxt)
 int test_sampler_sample(ldmsd_plugin_inst_t pi)
 {
 	test_sampler_inst_t inst = (void*)pi;
-	int rc;
-	static int sample_count = 0;
-
 	int j;
 	struct test_sampler_set *ts_set;
 
-	sample_count += 1;
-
 	/* intercept normal sample routine to optionally delete sets */
 	LIST_FOREACH(ts_set, &inst->set_list, entry) {
-		if (inst->set_del_int > 0) {
-			j = (sample_count) % inst->set_del_int;
+		if (ts_set->delete_at > 0) {
+			ts_set->from_delete_count++;
+			if (NULL == ts_set->set)
+				goto create_set;
+			j = ts_set->sample_count % ts_set->delete_at;
 			if (j == 0) {
-				if (!ts_set->set)
-					continue; /* no need to delete */
 				/* delete the set */
-				test_sampler_set_del(inst, ts_set);
-				continue;
+				__set_delete(inst, ts_set);
+				ts_set->from_delete_count = 0;
+			} else {
+				/* nothing to do */
 			}
-			/* else, let through */
-		}
-		if (!ts_set->set) {
-			/* try re-creating the set */
-			rc = test_sampler_set_new(inst, ts_set);
-			if (rc)
-				continue;
-		}
+		create_set:
+			if (ts_set->from_delete_count == ts_set->create_at) {
+				__set_create(inst, ts_set);
+			}
 
+		}
 	}
 	/* then, resume normal sample routine */
 	inst->samp_sample(&inst->base);
 
-	/* all sets updated, do push routine */
+	/*
+	 * All sets have been updated, increment the sample counts
+	 * and do push routine.
+	 */
 	LIST_FOREACH(ts_set, &inst->set_list, entry) {
-		if (!ts_set->push)
+		ts_set->sample_count++;
+		if (NULL == ts_set->set)
 			continue;
-		if (ts_set->push == ts_set->skip_push) {
+		/* push */
+		if (!ts_set->push_at)
+			continue;
+		if (ts_set->push_at == ts_set->skip_push) {
 			ldms_xprt_push(ts_set->set);
 			ts_set->skip_push = 1;
 		} else {
@@ -1497,131 +1055,168 @@ const char *test_sampler_help(ldmsd_plugin_inst_t pi)
 	return _help;
 }
 
-typedef int (*action_fn)(test_sampler_inst_t inst, json_entity_t json,
-					char *ebuf, size_t ebufsz);
-
 static
 int test_sampler_config(ldmsd_plugin_inst_t pi, json_entity_t json,
-				      char *ebuf, int ebufsz)
+				      	      char *ebuf, int ebufsz)
 {
 	test_sampler_inst_t inst = (void*)pi;
 	ldmsd_sampler_type_t samp = (void*)inst->base.base;
 	int rc;
-	const char *action;
-	const char *compid;
-	const char *jobid;
-	const char *set_del_int_str;
-	const char *ts_suffix_str;
-	const char *producer_name;
-	action_fn act_fn;
+	json_entity_t v;
+	char *s;
 
 	rc = samp->base.config(pi, json, ebuf, ebufsz);
 	if (rc)
 		return rc;
 
-	action = __attr_find(inst, json, ebuf, ebufsz, 0, "action");
-	if (!action && (errno == EINVAL))
+	v = attr_find(inst, json, JSON_DICT_VALUE,
+				"instances", 1, ebuf, ebufsz);
+	if (!v)
 		return EINVAL;
-	if (action) {
-		rc = 0;
-		if (0 == strcmp(action, "add_schema")) {
-			act_fn = config_add_schema;
-		} else if (0 == strcmp(action, "add_set")) {
-			act_fn = config_add_set;
-		} else if (0 == strcmp(action, "default")) {
-			act_fn = config_add_default;
-		} else if (0 == strcmp(action, "add_scalar")) {
-			act_fn = config_add_scalar;
-		} else if (0 == strcmp(action, "add_array")) {
-			act_fn = config_add_array;
-		} else if (0 == strcmp(action, "add_all")) {
-			act_fn = config_add_all;
+
+	/* schema_type */
+	v = attr_find(inst, json, JSON_STRING_VALUE, "schema_type", 0, ebuf, ebufsz);
+	if (v) {
+		s = json_value_str(v)->str;
+		if (0 == strncmp(s, "scalar", 6))
+			inst->type = TEST_SAMPLER_TYPE_SCALAR;
+		else if (0 == strncmp(s, "array", 5))
+			inst->type = TEST_SAMPLER_TYPE_ARRAY;
+		else if (0 == strncmp(s, "all", 3))
+			inst->type = TEST_SAMPLER_TYPE_ALL;
+		else if (0 == strncmp(s, "default", 7))
+			inst->type = TEST_SAMPLER_TYPE_DEFAULT;
+		else if (0 == strncmp(s, "manual", 7))
+			inst->type = TEST_SAMPLER_TYPE_MANUAL;
+		else {
+			snprintf(ebuf, ebufsz, "%s: Invalid auto_type '%s'",
+					pi->inst_name, s);
+			return EINVAL;
+		}
+	} else {
+		inst->type = TEST_SAMPLER_DEFAULT_SCHEMA_TYPE;
+	}
+
+	/* num_metrics */
+	v = attr_find(inst, json, JSON_INT_VALUE, "num_metrics", 0, ebuf, ebufsz);
+	if (v) {
+		if (inst->type != TEST_SAMPLER_TYPE_DEFAULT) {
+			snprintf(ebuf, ebufsz, "%s: num_metrics is ignored.",
+								pi->inst_name);
 		} else {
-			act_fn = NULL;
-			snprintf(ebuf, ebufsz,
-					"Unrecognized action '%s'.\n", action);
+			inst->num_metrics = json_value_int(v);
+		}
+	} else {
+		if (EINVAL == errno) {
+			rc = errno;
+			goto err;
+		}
+		inst->num_metrics = TEST_SAMPLER_DEFAULT_NUM_METRICS;
+	}
+
+	/* array_size */
+	v = attr_find(inst, json, JSON_INT_VALUE, "array_size", 0, ebuf, ebufsz);
+	if (v) {
+		inst->array_sz = json_value_int(v);
+	} else {
+		if (EINVAL == errno) {
+			rc = errno;
+			goto err;
+		}
+		inst->array_sz = TEST_SAMPLER_DEFAULT_ARRAY_SZ;
+	}
+
+	/* unit */
+	v = attr_find(inst, json, JSON_STRING_VALUE, "unit", 0, ebuf, ebufsz);
+	if (v) {
+		inst->unit = strdup(json_value_str(v)->str);
+	} else {
+		if (EINVAL == errno) {
+			rc = errno;
+			goto err;
+		}
+		inst->unit = strdup(TEST_SAMPLER_DEFAULT_UNIT);
+	}
+	if (!inst->unit) {
+		rc = ENOMEM;
+		goto err;
+	}
+
+	/* metrics */
+	v = attr_find(inst, json, JSON_DICT_VALUE, "metrics", 0, ebuf, ebufsz);
+	if (v) {
+		if (inst->type != TEST_SAMPLER_TYPE_MANUAL) {
+			snprintf(ebuf, ebufsz, "%s: metrics is ignored.",
+							pi->inst_name);
 			rc = EINVAL;
+			goto err;
+		} else {
+			inst->metrics = json_entity_copy(v);
+			if (!inst->metrics) {
+				INST_LOG(inst, LDMSD_LCRITICAL, "Out of memory\n");
+				rc = ENOMEM;
+				goto err;
+			}
 		}
-		if (act_fn)
-			rc = act_fn(inst, json, ebuf, ebufsz);
-		return rc;
+		rc = process_metrics(inst, v, ebuf, ebufsz);
+		if (rc)
+			goto err;
+	} else {
+		if (EINVAL == errno) {
+			rc = errno;
+			goto err;
+		}
+		inst->metrics = NULL;
 	}
 
-	producer_name = __attr_find(inst, json, ebuf, ebufsz, 0, "producer");
-	if (!producer_name && (errno == EINVAL))
-		return EINVAL;
-	compid = __attr_find(inst, json, ebuf, ebufsz, 0, "component_id");
-	if (!compid && (errno == EINVAL))
-		return EINVAL;
-	jobid = __attr_find(inst, json, ebuf, ebufsz, 0, "jobid");
-	if (!jobid && (errno == EINVAL))
-		return EINVAL;
-	set_del_int_str = __attr_find(inst, json, ebuf, ebufsz, 0, "set_delete_interval");
-	if (!set_del_int_str && (errno == EINVAL))
-		return EINVAL;
-	ts_suffix_str = __attr_find(inst, json, ebuf, ebufsz, 0, "ts_suffix");
-	if (!ts_suffix_str && (errno == EINVAL))
-		return EINVAL;
+	/* instances */
+	v = attr_find(inst, json, JSON_DICT_VALUE, "instances", 1, ebuf, ebufsz);
+	if (!v) {
+		snprintf(ebuf, ebufsz, "%s: instances is missing.", pi->inst_name);
+		rc = EINVAL;
+		goto err;
+	}
+	rc = process_instances(inst, v, ebuf, ebufsz);
+	if (rc)
+		goto err;
 
-	if (!compid)
-		compid = "0";
-	if (!jobid)
-		jobid = "0";
-	if (set_del_int_str)
-		inst->set_del_int = atoi(set_del_int_str);
-	if (ts_suffix_str)
-		inst->ts_suffix = atoi(ts_suffix_str);
+	/* Create schema */
+	samp->schema = samp->create_schema(pi);
+	if (!samp->schema) {
+		rc = errno;
+		goto err;
+	}
 
+	/* Create set */
 	struct test_sampler_set *ts_set;
-	union ldms_value vcompid, vjobid;
-	sscanf(compid, "%" SCNu64, &vcompid.v_u64);
-	sscanf(jobid, "%" SCNu64, &vjobid.v_u64);
-	int mid;
-
 	LIST_FOREACH(ts_set, &inst->set_list, entry) {
-		if (producer_name)
-			ldms_set_producer_name_set(ts_set->set, producer_name);
-		if (compid) {
-
-			mid = ldms_metric_by_name(ts_set->set, "component_id");
-			if (mid < 0) {
-				INST_LOG(inst, LDMSD_LINFO,
-					 "No component_id in set '%s'\n",
-					 ts_set->name);
-				continue;
-			}
-			ldms_metric_set(ts_set->set, mid, &vcompid);
-		}
-		if (jobid) {
-			mid = ldms_metric_by_name(ts_set->set, "jobid");
-			if (mid < 0) {
-				INST_LOG(inst, LDMSD_LINFO,
-					 "No job ID in set '%s'\n",
-					 ts_set->name);
-				continue;
-			}
-			ldms_metric_set(ts_set->set, mid, &vjobid);
+		ts_set->set = samp->create_set(pi, ts_set->name, samp->schema, ts_set);
+		if (!ts_set->set) {
+			rc = errno;
+			goto err;
 		}
 	}
+
 	return 0;
+err:
+	if (inst->unit)
+		free(inst->unit);
+	metric_list_empty(inst);
+	set_list_empty(inst);
+	return rc;
 }
 
 static
 void test_sampler_del(ldmsd_plugin_inst_t pi)
 {
 	test_sampler_inst_t inst = (void*)pi;
-	struct test_sampler_set *ts;
-	struct test_sampler_schema *tschema;
 
-	while ((ts = LIST_FIRST(&inst->set_list))) {
-		__delete_test_sampler_set(inst, ts);
-	}
-
-	while ((tschema = LIST_FIRST(&inst->schema_list))) {
-		LIST_REMOVE(tschema, entry);
-		__test_schema_free(tschema);
-	}
+	if (inst->metrics)
+		json_entity_free(inst->metrics);
+	set_list_empty(inst);
+	metric_list_empty(inst);
 }
+
 
 static
 json_entity_t test_sampler_query(ldmsd_plugin_inst_t pi, const char *q)
@@ -1647,15 +1242,22 @@ static
 int test_sampler_init(ldmsd_plugin_inst_t pi)
 {
 	test_sampler_inst_t inst = (void*)pi;
-	ldmsd_sampler_type_t samp = (void*)inst->base.base;
+	ldmsd_sampler_type_t samp = LDMSD_SAMPLER(inst);
 	/* override update_schema() and update_set() */
 	samp->update_schema = test_sampler_update_schema;
 	samp->update_set = test_sampler_update_set;
+	/*
+	 * Preserve the pointer to
+	 * the regular sample routine of
+	 * ldmsd_sampler_type
+	 */
 	inst->samp_sample = samp->sample;
 	samp->sample = test_sampler_sample;
 
 	/* NOTE More initialization code here if needed */
 	samp->base.query = test_sampler_query;
+
+	TAILQ_INIT(&inst->metric_list);
 	return 0;
 }
 
@@ -1679,7 +1281,7 @@ struct test_sampler_inst_s __inst = {
 
 ldmsd_plugin_inst_t new()
 {
-	test_sampler_inst_t inst = malloc(sizeof(*inst));
+	test_sampler_inst_t inst = calloc(1, sizeof(*inst));
 	if (inst)
 		*inst = __inst;
 	return &inst->base;


### PR DESCRIPTION
Without the patch, the test_sampler plugin requests multiple 'config'
lines to define a schema and to add a set. This design is incompatible
with the new JSON configuration protocol. Moreover, the test_sampler
plugin was extended many times, and its code has become complicated.

The change simplifies the plugin code and makes it compatible with the
JSON protocol.