### PR TITLE
fix make distcheck fail on aarch64 due to -msse4.2 flag

### DIFF
--- a/lib/src/third/Makefile.am
+++ b/lib/src/third/Makefile.am
@@ -31,7 +31,7 @@ cencode_test_LDADD = ../third/libovis_third.la
 cencode_test_LDFLAGS = -static
 
 city_test_SOURCES = city-test.c
-city_test_CFLAGS = -msse4.2 -O3 -DCITYSLIM
+city_test_CFLAGS = -O3 -DCITYSLIM
 city_test_LDFLAGS = -static @OVIS_LIB_ABS@
 city_test_LDADD = -lovis_third
 


### PR DESCRIPTION
The crc-based functions enabled with sse42 on some compilers/platforms are not used when CITYSLIM is defined, so omitting the flag has no effect on ldms use of cityhash.