### PR TITLE
Enable KEEP-ALIVE in zap sock.

### DIFF
--- a/lib/src/zap/sock/zap_sock.c
+++ b/lib/src/zap/sock/zap_sock.c
@@ -305,7 +305,7 @@ static zap_err_t z_get_name(zap_ep_t ep, struct sockaddr *local_sa,
 static int __set_keep_alive(struct z_sock_ep *sep)
 {
 	int rc;
-	int optval = 0;
+	int optval = 1;
 	rc = setsockopt(sep->sock, SOL_SOCKET, SO_KEEPALIVE, &optval,
 			sizeof(int));
 	if (rc) {


### PR DESCRIPTION
The optval value was initialized to 0 which results in disabling
KEEP-ALIVE. The patch initlizes the variable to a non-zero value.