### PR TITLE
fix V4 fabric xprt mem inits

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -1917,7 +1917,8 @@ static void ldms_zap_handle_conn_req(zap_ep_t zep)
 {
 	static char rej_msg[64] = "Insufficient resources";
 	struct sockaddr lcl, rmt;
-	socklen_t xlen;
+	memset(&rmt, 0, sizeof(rmt));
+	socklen_t xlen = sizeof(lcl);
 	struct ldms_conn_msg msg;
 #define RMT_NM_SZ 256
 	char rmt_name[RMT_NM_SZ];
@@ -2469,10 +2470,9 @@ static int __ldms_conn_msg_verify(struct ldms_xprt *x, const void *data,
  */
 static void ldms_zap_cb(zap_ep_t zep, zap_event_t ev)
 {
-	struct ldms_xprt_event event = {
-			.type = LDMS_XPRT_EVENT_LAST,
-			.data = NULL,
-			.data_len = 0};
+	struct ldms_xprt_event event;
+	memset(&event, 0, sizeof(event));
+	event.type = LDMS_XPRT_EVENT_LAST;
 	char rej_msg[128];
 	struct ldms_xprt *x = zap_get_ucontext(zep);
 #ifdef DEBUG

--- a/lib/src/zap/fabric/zap_fabric.c
+++ b/lib/src/zap/fabric/zap_fabric.c
@@ -536,8 +536,8 @@ _buffer_init_pool(struct z_fi_ep *rep)
 
 	rep->num_bufs = RQ_DEPTH + SQ_DEPTH + 4;  // +4 for credit updates
 	rep->buf_sz   = RQ_BUF_SZ;
-	rep->buf_pool = malloc(rep->num_bufs * rep->buf_sz);
-	rep->buf_objs = malloc(rep->num_bufs * sizeof(struct z_fi_buffer));
+	rep->buf_pool = calloc(1, rep->num_bufs * rep->buf_sz);
+	rep->buf_objs = calloc(1, rep->num_bufs * sizeof(struct z_fi_buffer));
 	if (!rep->buf_pool || !rep->buf_objs)
 		return -ENOMEM;
 	ret = fi_mr_reg(rep->domain, rep->buf_pool, rep->num_bufs*rep->buf_sz, FI_SEND|FI_RECV, 0,


### PR DESCRIPTION
this fixes information leak to network by initializing raw buffers and fixes insufficiently initialized addr and event data in ldms_xprt.c..