### PR TITLE
Create a worker/event library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,7 @@ OPTION_INCLUDE_FLAGS([OVIS],[ \
 	lib/src/ovis_util \
 	lib/src/ovis_auth \
 	lib/src/ovis_ctrl \
+	lib/src/ovis_ev \
 	lib/src/ovis_event \
 	lib/src/ovis_json \
 	lib/src/zap \
@@ -97,6 +98,7 @@ OPTION_LIB_FLAGS([OVIS],[ \
 	lib/src/ovis_util \
 	lib/src/ovis_auth \
 	lib/src/ovis_ctrl \
+	lib/src/ovis_ev \
 	lib/src/ovis_event \
 	lib/src/ovis_json \
 	lib/src/zap \
@@ -116,6 +118,7 @@ AC_SUBST([LDFLAGS_GETTIME])
 LIBS=""
 
 OPTION_DEFAULT_ENABLE([coll], [ENABLE_COLL])
+OPTION_DEFAULT_ENABLE([ovis_ev], [ENABLE_OVIS_EV])
 OPTION_DEFAULT_ENABLE([ovis_event], [ENABLE_OVIS_EVENT])
 OPTION_DEFAULT_ENABLE([mmalloc], [ENABLE_MMALLOC])
 OPTION_DEFAULT_ENABLE([ovis_ctrl], [ENABLE_OVIS_CTRL])
@@ -714,6 +717,7 @@ lib/src/ovis_json/Makefile
 lib/src/third/Makefile
 lib/src/coll/Makefile
 lib/src/mmalloc/Makefile
+lib/src/ovis_ev/Makefile
 lib/src/ovis_event/Makefile
 lib/src/ovis_ctrl/Makefile
 lib/src/ovis_util/Makefile

--- a/lib/src/Makefile.am
+++ b/lib/src/Makefile.am
@@ -30,6 +30,10 @@ if ENABLE_OVIS_EVENT
 SUBDIRS += ovis_event
 endif
 
+if ENABLE_OVIS_EV
+SUBDIRS += ovis_ev
+endif
+
 if ENABLE_ZAP
 SUBDIRS += zap
 endif

--- a/lib/src/ovis_ev/Makefile.am
+++ b/lib/src/ovis_ev/Makefile.am
@@ -1,0 +1,19 @@
+SUBDIRS =
+lib_LTLIBRARIES =
+
+AM_CFLAGS = -I$(srcdir) -I$(srcdir)/..
+AM_LDFLAGS = -L$(builddir) -pthread
+
+libovis_evincludedir = $(includedir)/ovis_ev
+libovis_evinclude_HEADERS = ev.h
+
+libovis_ev_la_SOURCES = ev.c evw.c ev_priv.h
+libovis_ev_la_CFLAGS = $(AM_CFLAGS)
+libovis_ev_la_LIBADD = -lc ../coll/libcoll.la
+lib_LTLIBRARIES += libovis_ev.la
+
+ovis_ev_test_SOURCES = ovis_ev_test.c
+ovis_ev_test_CFLAGS = $(AM_CFLAGS)
+ovis_ev_test_LDADD = libovis_ev.la
+ovis_ev_test_LDFLAGS = $(AM_LDFLAGS)
+sbin_PROGRAMS = ovis_ev_test

--- a/lib/src/ovis_ev/ev.c
+++ b/lib/src/ovis_ev/ev.c
@@ -1,0 +1,205 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <coll/rbt.h>
+#include "ev.h"
+#include "ev_priv.h"
+
+static uint32_t next_type_id = 1;
+
+static int type_cmp(void *a, const void *b)
+{
+	return strcmp(a, b);
+}
+
+static pthread_mutex_t type_lock = PTHREAD_MUTEX_INITIALIZER;
+static struct rbt type_tree = RBT_INITIALIZER(type_cmp);
+
+ev_type_t ev_type_new(const char *name, size_t size)
+{
+	ev_type_t evt = calloc(1, sizeof(*evt));
+	struct rbn *rbn;
+
+	evt = calloc(1, sizeof(*evt));
+	if (!evt)
+		goto err_0;
+	evt->t_name = strdup(name);
+	if (!evt->t_name)
+		goto err_1;
+	evt->t_size = size;
+	evt->t_id = __sync_fetch_and_add(&next_type_id, 1);
+
+	pthread_mutex_lock(&type_lock);
+	rbn = rbt_find(&type_tree, name);
+	if (rbn)
+		goto err_2;
+	rbn_init(&evt->t_rbn, evt->t_name);
+	rbt_ins(&type_tree, &evt->t_rbn);
+	pthread_mutex_unlock(&type_lock);
+	return evt;
+
+ err_2:
+	pthread_mutex_unlock(&type_lock);
+ err_1:
+	free(evt->t_name);
+ err_0:
+	free(evt);
+	return NULL;
+}
+
+ev_type_t ev_type_get(const char *name)
+{
+	ev_type_t evt = NULL;
+	struct rbn *rbn;
+
+	pthread_mutex_lock(&type_lock);
+	rbn = rbt_find(&type_tree, name);
+	if (rbn) {
+		evt = container_of(rbn, struct ev_type_s, t_rbn);
+	} else {
+		errno = ENOENT;
+	}
+	pthread_mutex_unlock(&type_lock);
+	return evt;
+}
+
+ev_type_t ev_type(ev_t ev)
+{
+	ev__t e = EV(ev);
+	return e->e_type;
+}
+
+uint32_t ev_type_id(ev_type_t t)
+{
+	return t->t_id;
+}
+
+const char *ev_type_name(ev_type_t t)
+{
+	return t->t_name;
+}
+
+ev_t ev_new(ev_type_t evt)
+{
+	ev__t e = malloc(sizeof(*e) + evt->t_size);
+	if (!e)
+		return NULL;
+
+	e->e_refcount = 1;
+	e->e_type = evt;
+	e->e_posted = 0;
+
+	return (ev_t)&e->e_ev;
+}
+
+void ev_put(ev_t ev)
+{
+	ev__t e = EV(ev);
+	assert(e->e_refcount);
+	if (0 == __sync_sub_and_fetch(&e->e_refcount, 1)) {
+		free(e);
+	}
+}
+
+ev_t ev_get(ev_t ev)
+{
+	ev__t e = EV(ev);
+	assert(__sync_fetch_and_add(&e->e_refcount, 1) > 0);
+	return ev;
+}
+
+int ev_posted(ev_t ev)
+{
+	ev__t e = EV(ev);
+	return e->e_posted;
+}
+
+int ev_post(ev_worker_t src, ev_worker_t dst, ev_t ev, struct timespec *to)
+{
+	ev__t e = EV(ev);
+	int rc;
+
+	/* If multiple threads attempt to post the same event all but
+	 * one will receive EBUSY. If the event is already posted all
+	 * will receive EBUSY */
+	if (__sync_val_compare_and_swap(&e->e_posted, 0, 1))
+		return EBUSY;
+
+	e->e_status = EV_OK;
+
+	if (to) {
+		e->e_to = *to;
+	} else {
+		e->e_to.tv_sec = 0;
+		e->e_to.tv_nsec = 0;
+	}
+
+	e->e_src = src;
+	e->e_dst = dst;
+	rbn_init(&e->e_to_rbn, &e->e_to);
+
+	pthread_mutex_lock(&dst->w_lock);
+	if (dst->w_state == EV_WORKER_FLUSHING)
+		goto err;
+	ev_get(&e->e_ev);
+	if (to)
+		rbt_ins(&dst->w_event_tree, &e->e_to_rbn);
+	else
+		TAILQ_INSERT_TAIL(&dst->w_event_list, e, e_entry);
+	rc = (ev_time_cmp(&e->e_to, &dst->w_sem_wait) <= 0);
+	pthread_mutex_unlock(&dst->w_lock);
+	if (rc)
+		sem_post(&dst->w_sem);
+
+	return 0;
+ err:
+	e->e_posted = 0;
+	pthread_mutex_unlock(&dst->w_lock);
+	return EBUSY;
+}
+
+int ev_cancel(ev_t ev)
+{
+	ev__t e = EV(ev);
+	int rc = EINVAL;
+	struct timespec now;
+
+	pthread_mutex_lock(&e->e_dst->w_lock);
+	if (!e->e_posted)
+		goto out;
+
+	/*
+	 * Set the status to EV_CANCEL so the actor will see that
+	 * status
+	 */
+	e->e_status = EV_FLUSH;
+
+	/*
+	 * If the event is on the list or is soon to expire, do
+	 * nothing. This avoids racing with the worker.
+	 */
+	rc = 0;
+	(void)clock_gettime(CLOCK_REALTIME, &now);
+	if (ev_time_diff(&e->e_to, &now) < 1.0) {
+		rc = EBUSY;
+		goto out;
+	}
+
+	rbt_del(&e->e_dst->w_event_tree, &e->e_to_rbn);
+	TAILQ_INSERT_TAIL(&e->e_dst->w_event_list, e, e_entry);
+ out:
+	pthread_mutex_unlock(&e->e_dst->w_lock);
+	if (!rc)
+		sem_post(&e->e_dst->w_sem);
+	return rc;
+}
+
+static void __attribute__ ((constructor)) ev_init(void)
+{
+}
+
+static void __attribute__ ((destructor)) ev_term(void)
+{
+}

--- a/lib/src/ovis_ev/ev.h
+++ b/lib/src/ovis_ev/ev.h
@@ -1,0 +1,291 @@
+#ifndef __EV_H_
+#define __EV_H_
+#include <time.h>
+#include <inttypes.h>
+/**
+ * Events (ev_t) are exchanged between workers (ev_worker_t) to do
+ * work. Workers that are interested in events register to receive
+ * them. Workers that wish to communicate with other workers do so by
+ * generating events.
+ *
+ * There are two fundamental kinds of events: directed, multicast. A
+ * directed event is sent directly from one worker to another. A
+ * multicast event is sent to any worker that has registered to
+ * receive it.
+ *
+ * ev_worker_t timer = ev_worker_get("TIMER");
+ * ev_type_t to = ev_type_get("TIMEOUT");
+ * ev_t to_ev = ev_new(to, my_worker, &timeout);
+ *
+ * ev_send(my_worker, timer, to_ev);
+ *
+ */
+
+typedef struct ev_worker_s *ev_worker_t;
+typedef struct ev_type_s *ev_type_t;
+typedef struct ev_s {
+	uint8_t e_data[0];
+} *ev_t;
+
+typedef enum ev_status_e {
+	EV_OK = 0,
+	EV_FLUSH,
+} ev_status_t;
+
+/**
+ * \brief The worker's event callback function
+ *
+ * \param src Sending worker handle
+ * \param dst Receiving worker handle
+ * \param status EV_OK, or EV_FLUSH
+ * \param ev The event handle
+ * \retval The result of handling the event
+ */
+typedef int (*ev_actor_t)(ev_worker_t src, ev_worker_t dst, ev_status_t status, ev_t ev);
+
+ev_t ev_new(ev_type_t evt);
+ev_t ev_get(ev_t ev);
+void ev_put(ev_t ev);
+
+/**
+ * \brief Creates a worker
+ *
+ * A worker implements a single threaded execution context for
+ * events. See the ev_post() documentation for information on
+ * the ordering of event delivery.
+ *
+ * Workers must have a name that is unique in the process.
+ *
+ * The thread that implements the worker will be given the name with
+ * the last 16 charactres of the worker name as an aid to debugging.
+ *
+ * \param name The worker name
+ * \param actor_fn A pointer to the worker's actor function
+ * \retval 0 The worker was created
+ * \retval EINVAL An invalid argument was specified
+ * \retval ENOMEM Insufficient resources
+ * \retval EEXIST A worker named \c name already exists
+ */
+ev_worker_t ev_worker_new(const char *name, ev_actor_t actor_fn);
+
+/**
+ * \brief Return the worker's name
+ *
+ * \param w The worker handle
+ * \returns The worker name
+ */
+const char *ev_worker_name(ev_worker_t w);
+
+/**
+ * \brief Get the worker handle
+ *
+ * \param name The worker name
+ * \returns The worker handle or NULL if the worker is not found
+ */
+ev_worker_t ev_worker_get(const char *name);
+
+/**
+ * \brief Create an event type
+ *
+ * Event types allow for workers to register for events and deliver
+ * them to actors. Actors that handle multiple events may also use to
+ * the event type to determine the actions to take.
+ *
+ * If the \c name already exists, \c errno is set to \c EEXIST and
+ *  \c NULL is returned. If there is insufficient memory, \c errno is set
+ * to ENOMEM and NULL is returned.
+ *
+ * \param name The unique event name.
+ * \param size The number of bytes required for application data
+ * \returns !NULL The event type handle or NULL on error.
+ */
+ev_type_t ev_type_new(const char *name, size_t size);
+
+/**
+ * \brief Return the event type \c name
+ *
+ * \param name The event type name
+ * \retval !NULL The event type handle
+ * \retval NULL The event type was not found.
+ */
+ev_type_t ev_type_get(const char *name);
+
+/**
+ * \brief Get the event type
+ *
+ * Workers will register for occurrances of this event type by
+ * name.
+ *
+ * \param name The unique event name
+ * \returns An event type handle or NULL if there are insufficient resources
+ */
+ev_type_t ev_type_get(const char *name);
+
+/**
+ * \brief Listen for multi-cast events
+ *
+ * \param evw The event worker handle
+ * \param evt The event type handle
+ */
+int ev_listen(ev_worker_t evw, ev_type_t evt);
+
+/**
+ * \brief Post an event to a worker
+ *
+ * An event can be posted only once before it is delivered. After it
+ * is delivered, it can be posted again. The event actor can re-post
+ * the event from inside the actor function.
+ *
+ * If multiple threads attempt to post the same event all but
+ * one will receive EBUSY. If the event is already posted all
+ * will receive EBUSY.
+ *
+ * Events posted with a NULL timeout will be delivered as soon as
+ * possible in the order they were posted. If mutliple threads are
+ * posting events to the same worker, the delivery order is
+ * unspecified.
+ *
+ * Events posted with a timeout will be delivered when the timeout
+ * expires. If two events are posted with the same timeout, the order
+ * in which they are delivered is undefined.
+ *
+ * \param src The source worker
+ * \param dst The destination worker
+ * \param ev The event
+ * \param to The scheduled event deliver time (null == now)
+ *
+ * \retval 0 Event posted
+ * \retval EBUSY The event is already posted
+ */
+int ev_post(ev_worker_t src, ev_worker_t dst, ev_t ev, struct timespec *to);
+
+/**
+ * \brief Cancel a posted event
+ *
+ * A cancelled event is delivered as soon as possible to the
+ * associated actor function with an event status of EV_FLUSH.
+ *
+ * Note that is not guaranteed that the event will be delivered with
+ * EV_FLUSH if it is concurrently being delivered by the worker.
+ *
+ * The caller is only guaranteed that the event will be delivered
+ * exactly once with either EV_OK, or EV_FLUSH.
+ *
+ * \param ev The event to cancel
+ * \retval 0 The event was cancelled
+ * \retval ENOENT The event was not posted
+ */
+int ev_cancel(ev_t ev);
+
+/**
+ * \brief Flush all events queued to a worker
+ *
+ * This function has the affect of calling ev_cancel() on all events
+ * currently posted to the worker. The event actors will all be called
+ * with a status of \c EV_FLUSH.
+ *
+ * \param w The worker handle
+ */
+void ev_flush(ev_worker_t w);
+
+/**
+ * \brief Convenience function to schedule a timespec in the future
+ *
+ * Gets the current time in \c to and then adds \c secs to \c tv_sec,
+ * and \c nsecs to \c tv_nsec
+ *
+ * Calling ev_sched_to(&to, 0, 0) will return the current time in
+ * \c to.
+ *
+ * \param to Pointer to a timespec structure
+ * \param secs Seconds to add to to->tv_sec
+ * \param nsecs Nanoseconds to add to to->tv_nsec
+ */
+void ev_sched_to(struct timespec *to, time_t secs, int nsecs);
+
+/**
+ * \brief Convience macro to access user data in the event
+ *
+ * \param _ptr_ ev_t pointer
+ * \param _type_ The type to which the event data is cast
+ * \retval The event data cast to _type_
+ */
+#define EV_DATA(_ptr_, _type_) ((_type_ *)(_ptr_))
+
+/**
+ * \brief Return an event type's internal event id.
+ *
+ * This can be usefull for indexing application data by a unique event
+ * number.
+ *
+ * \param t The event type handle
+ * \returns The event type id
+ */
+uint32_t ev_type_id(ev_type_t t);
+
+/**
+ * \brief Return the event type name
+ *
+ * \param t The event type handle
+ * \returns The event type name
+ */
+const char *ev_type_name(ev_type_t t);
+
+/**
+ * \brief Return an event's type
+ *
+ * \param ev The event handle
+ * \returns The event type
+ */
+ev_type_t ev_type(ev_t ev);
+
+/**
+ * \brief Instruct the worker on how to dispatch events
+ *
+ * This function associates an event type with an event
+ * actor. Whenever an event of the specified type is delivered by this
+ * worker, it is passed to the specified \c fn.
+ *
+ * \param w The worker handle
+ * \param t The event type handle
+ * \param fn The actor function that handles this event type
+ * \retval 0 Success
+ * \retval EINVAL The \c w or \c t parameters are invalid.
+ */
+int ev_dispatch(ev_worker_t w, ev_type_t t, ev_actor_t fn);
+
+/**
+ * \brief Returns 1 if the event is posted
+ *
+ * \retval 1 Event is posted
+ * \retval 0 Event is not posted
+ */
+int ev_posted(ev_t ev);
+
+/**
+* \brief Compare two timespec values
+*
+* Compares two timespace values *tsa and *tsb and returns:
+* -1 if tsa < tsb, 0 if tsa == tsb, and 1 if tsa > tsb.
+*
+* \param tsa Pointer to timespec structure
+* \param tsb Pointer to timespec structure
+* \retval -1 *tsa < *tsb
+* \retval 0 *tsa == *tsb
+* \retval 1 *tsa > *tsb
+*/
+int ev_time_cmp(struct timespec *tsa, const struct timespec *tsb);
+
+
+/**
+ * \brief Return the time difference in seconds
+ *
+ * Returns the difference in seconds of \c tsa - \c tsb
+ *
+ * \param tsa Pointer to timespec
+ * \param tsb Pointer to timespec
+ * \returns The difference in seconds
+ */
+double ev_time_diff(struct timespec *tsa, const struct timespec *tsb);
+
+#endif

--- a/lib/src/ovis_ev/ev_priv.h
+++ b/lib/src/ovis_ev/ev_priv.h
@@ -1,0 +1,55 @@
+#ifndef __EV_PRIV_H_
+#define __EV_PRIV_H_
+
+#include <sys/queue.h>
+#include <semaphore.h>
+#include <inttypes.h>
+#include <coll/rbt.h>
+#include "ev.h"
+
+struct ev_type_s {
+	char *t_name;
+	uint64_t t_id;
+	struct rbn t_rbn;
+	size_t t_size;
+};
+
+typedef struct ev__s {
+	ev_worker_t e_src;
+	ev_worker_t e_dst;
+	ev_type_t e_type;
+	uint32_t e_refcount;
+	int e_posted;
+	ev_status_t e_status;
+	struct timespec e_to;
+	struct rbn e_to_rbn;
+	TAILQ_ENTRY(ev__s) e_entry;
+	struct ev_s e_ev;
+} *ev__t;
+
+enum evw_state_e {
+	EV_WORKER_STOPPED,
+	EV_WORKER_RUNNING,
+	EV_WORKER_FLUSHING
+};
+
+struct ev_worker_s {
+	char *w_name;
+	ev_actor_t w_actor;
+	pthread_t w_thread;
+	enum evw_state_e w_state;
+	struct timespec w_sem_wait;
+	sem_t w_sem;
+	struct rbn w_rbn;
+	pthread_mutex_t w_lock;
+	ev_actor_t *w_dispatch;
+	size_t w_dispatch_len;
+	/* An ordered tree of events with timeouts */
+	struct rbt w_event_tree;
+	/* A list of events without timeouts */
+	TAILQ_HEAD(w_event_list, ev__s) w_event_list;
+};
+
+#define EV(_e_) container_of(_e_, struct ev__s, e_ev);
+#endif
+

--- a/lib/src/ovis_ev/evw.c
+++ b/lib/src/ovis_ev/evw.c
@@ -1,0 +1,274 @@
+#define _GNU_SOURCE
+#include <linux/param.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <pthread.h>
+#include <time.h>
+#include <inttypes.h>
+#include <coll/rbt.h>
+#include "ev.h"
+#include "ev_priv.h"
+
+static pthread_mutex_t worker_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static int type_cmp(void *a, const void *b)
+{
+	return strcmp(a, b);
+}
+static struct rbt worker_tree = RBT_INITIALIZER(type_cmp);
+
+/* Returns the time difference in seconds */
+double ev_time_diff(struct timespec *tsa, const struct timespec *tsb)
+{
+	double diff;
+	diff = tsa->tv_sec - tsb->tv_sec;
+	diff += (double)tsa->tv_sec / 1e9;
+	diff -= (double)tsb->tv_sec / 1e9;
+	return diff;
+
+}
+
+int ev_time_cmp(struct timespec *tsa, const struct timespec *tsb)
+{
+	if (tsa->tv_sec < tsb->tv_sec)
+		return -1;
+	if (tsa->tv_sec > tsb->tv_sec)
+		return 1;
+	if (tsa->tv_nsec < tsb->tv_nsec)
+		return -1;
+	if (tsa->tv_nsec > tsb->tv_nsec)
+		return 1;
+	return 0;
+
+}
+
+/*
+ * Process all of the events in the worker's event list.
+ *
+ * Called with the worker lock held.
+ */
+static void process_immediate_events(ev_worker_t w)
+{
+	ev__t e;
+	ev_actor_t actor;
+ next:
+	if (TAILQ_EMPTY(&w->w_event_list))
+		return;
+
+	e = TAILQ_FIRST(&w->w_event_list);
+	TAILQ_REMOVE(&w->w_event_list, e, e_entry);
+	e->e_posted = 0;
+
+	if (w->w_state == EV_WORKER_FLUSHING)
+		e->e_status = EV_FLUSH;
+
+	pthread_mutex_unlock(&w->w_lock);
+	actor = NULL;
+	if (e->e_type->t_id < w->w_dispatch_len)
+		actor = w->w_dispatch[e->e_type->t_id];
+	if (!actor)
+		actor = w->w_actor;
+	actor(e->e_src, e->e_dst, e->e_status, &e->e_ev);
+	ev_put(&e->e_ev);
+	pthread_mutex_lock(&w->w_lock);
+	goto next;
+}
+
+/*
+ * Process all of the events in the worker's event tree that have a
+ * timeout before or at the current time.
+ *
+ * Return the 1st event that has a timeout > now
+ */
+static ev__t process_to_events(ev_worker_t w)
+{
+	ev__t e;
+	struct rbn *rbn;
+	struct timespec now;
+	ev_actor_t actor;
+	clock_gettime(CLOCK_REALTIME, &now);
+ next:
+	e = NULL;
+	rbn = rbt_min(&w->w_event_tree);
+	if (!rbn)
+		goto out;
+
+	e = container_of(rbn, struct ev__s, e_to_rbn);
+	if (w->w_state == EV_WORKER_FLUSHING) {
+		e->e_status = EV_FLUSH;
+	} else {
+		if (ev_time_cmp(&e->e_to, &now) > 0)
+			goto out;
+	}
+
+	rbt_del(&w->w_event_tree, &e->e_to_rbn);
+	e->e_posted = 0;
+	pthread_mutex_unlock(&w->w_lock);
+	actor = NULL;
+	if (e->e_type->t_id < w->w_dispatch_len)
+		actor = w->w_dispatch[e->e_type->t_id];
+	if (!actor)
+		actor = w->w_actor;
+	actor(e->e_src, e->e_dst, e->e_status, &e->e_ev);
+	ev_put(&e->e_ev);
+	pthread_mutex_lock(&w->w_lock);
+	goto next;
+
+ out:
+	return e;
+}
+
+void ev_sched_to(struct timespec *to, time_t secs, int nsecs)
+{
+	clock_gettime(CLOCK_REALTIME, to);
+	to->tv_sec += secs;
+	to->tv_nsec += nsecs;
+}
+
+static void *worker_proc(void *arg)
+{
+	ev__t e;
+	ev_worker_t w = arg;
+	w->w_state = EV_WORKER_RUNNING;
+	ev_sched_to(&w->w_sem_wait, 0, 0);
+	sem_timedwait(&w->w_sem, &w->w_sem_wait);
+	while (1) {
+		pthread_mutex_lock(&w->w_lock);
+		process_immediate_events(w);
+		e = process_to_events(w);
+		if (e) {
+			w->w_sem_wait = e->e_to;
+		} else {
+			ev_sched_to(&w->w_sem_wait, 10, 0);
+		}
+		if (w->w_state == EV_WORKER_FLUSHING)
+			w->w_state = EV_WORKER_RUNNING;
+		pthread_mutex_unlock(&w->w_lock);
+		sem_timedwait(&w->w_sem, &w->w_sem_wait);
+	}
+	return NULL;
+}
+
+void ev_flush(ev_worker_t w)
+{
+	pthread_mutex_lock(&w->w_lock);
+	w->w_state = EV_WORKER_FLUSHING;
+	pthread_mutex_unlock(&w->w_lock);
+	sem_post(&w->w_sem);
+}
+
+ev_worker_t ev_worker_new(const char *name, ev_actor_t actor_fn)
+{
+	int err = ENOMEM;
+	ev_worker_t w = calloc(1, sizeof(*w));
+	struct rbn *rbn;
+
+	w = calloc(1, sizeof(*w));
+	if (!w)
+		goto err_0;
+	w->w_name = strdup(name);
+	if (!w->w_name)
+		goto err_1;
+	w->w_actor = actor_fn;
+	err = sem_init(&w->w_sem, 0, 0);
+	if (err)
+		goto err_2;
+
+	w->w_state = EV_WORKER_STOPPED;
+	pthread_mutex_init(&w->w_lock, NULL);
+	rbt_init(&w->w_event_tree, (int (*)(void *, const void*))ev_time_cmp);
+	TAILQ_INIT(&w->w_event_list);
+
+	pthread_mutex_lock(&worker_lock);
+	err = EEXIST;
+	rbn = rbt_find(&worker_tree, name);
+	if (rbn)
+		goto err_2;
+	rbn_init(&w->w_rbn, w->w_name);
+	rbt_ins(&worker_tree, &w->w_rbn);
+	pthread_mutex_unlock(&worker_lock);
+
+	err = pthread_create(&w->w_thread, NULL, worker_proc, w);
+	if (err)
+		goto err_2;
+	size_t namelen = strlen(w->w_name);
+	size_t nameoff = 0;
+	if (namelen > 15)
+		/* Use the last 16 chars of the worker name */
+		nameoff = namelen - 15;
+	pthread_setname_np(w->w_thread, &w->w_name[nameoff]);
+	errno = 0;
+	return w;
+ err_2:
+	pthread_mutex_unlock(&worker_lock);
+ err_1:
+	free(w->w_name);
+ err_0:
+	free(w);
+	errno = err;
+	return NULL;
+}
+
+ev_worker_t ev_worker_get(const char *name)
+{
+	ev_worker_t w = NULL;
+	struct rbn *rbn;
+
+	pthread_mutex_lock(&worker_lock);
+	rbn = rbt_find(&worker_tree, name);
+	if (rbn) {
+		w = container_of(rbn, struct ev_worker_s, w_rbn);
+	} else {
+		errno = ENOENT;
+	}
+	pthread_mutex_unlock(&worker_lock);
+	return w;
+}
+
+const char *ev_worker_name(ev_worker_t w)
+{
+	return w->w_name;
+}
+
+/**
+ * \brief Dispatch an event type to an actor
+ *
+ * Specify a particular actor for an event type. Events without an
+ * actor are routed to the default actor specified when the worker was
+ * created.
+ *
+ * \param w Worker handle
+ * \param t The event tyep
+ * \param fn The actor function
+ *
+ * \retval 0 success
+ */
+#define EV_DISPATCH_TBL_SIZE 100
+int ev_dispatch(ev_worker_t w, ev_type_t t, ev_actor_t fn)
+{
+	size_t size;
+	if (!w->w_dispatch) {
+		if (t->t_id < EV_DISPATCH_TBL_SIZE)
+			size = EV_DISPATCH_TBL_SIZE;
+		else
+			size = t->t_id << 1;
+		w->w_dispatch = calloc(size, sizeof(ev_actor_t));
+		if (!w->w_dispatch)
+			return ENOMEM;
+		w->w_dispatch_len = size;
+	} else {
+		if (t->t_id >= w->w_dispatch_len) {
+			int i, new_len;
+			new_len = t->t_id << 1;
+			w->w_dispatch = realloc(w->w_dispatch, new_len * sizeof(ev_actor_t));
+			if (!w->w_dispatch)
+				return ENOMEM;
+			for (i = w->w_dispatch_len; i < new_len; i++)
+				w->w_dispatch[i] = NULL;
+			w->w_dispatch_len = new_len;
+		}
+	}
+	w->w_dispatch[t->t_id] = fn;
+	return 0;
+}

--- a/lib/src/ovis_ev/ovis_ev_test.c
+++ b/lib/src/ovis_ev/ovis_ev_test.c
@@ -1,0 +1,78 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <time.h>
+#include <pthread.h>
+#include "ev.h"
+#include "ev_priv.h"
+
+ev_type_t to_type;
+
+struct data_s {
+	int v;
+};
+
+pthread_mutex_t io_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static int timer_actor(ev_worker_t src, ev_worker_t dst, ev_status_t status, ev_t e)
+{
+	struct timespec to;
+	ev_sched_to(&to, 0, 0);
+
+	pthread_mutex_lock(&io_lock);
+	printf("%s: type=%s, id=%d\n", __func__, ev_type_name(ev_type(e)), ev_type_id(ev_type(e)));
+	printf("    status  : %s\n", status ? "FLUSH" : "OK");
+	printf("    src     : %s\n", src->w_name);
+	printf("    dst     : %s\n", dst->w_name);
+	printf("    tv_sec  : %ld\n", to.tv_sec);
+	printf("    tv_nsec : %ld\n", to.tv_nsec);
+	printf("    v       : %d\n", EV_DATA(e, struct data_s)->v);
+	pthread_mutex_unlock(&io_lock);
+
+	EV_DATA(e, struct data_s)->v += 1;
+
+	to.tv_sec += 5;
+	to.tv_nsec = 0;
+	ev_post(src, dst, e, &to);
+
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	struct timespec to;
+	ev_worker_t timer, a, b;
+	ev_type_t timeout, request, response;
+	ev_t to_ev, req_ev, resp_ev;
+
+	timer = ev_worker_new("TIMER", timer_actor);
+	a = ev_worker_new("A", timer_actor);
+	b = ev_worker_new("B", timer_actor);
+
+	timeout = ev_type_new("timeout", sizeof(struct data_s));
+	request = ev_type_new("request", sizeof(struct data_s));
+	response = ev_type_new("response", sizeof(struct data_s));
+
+	to_ev = ev_new(timeout);
+	EV_DATA(to_ev, struct data_s)->v = 10000;
+
+	req_ev = ev_new(request);
+	EV_DATA(req_ev, struct data_s)->v = 0;
+
+	resp_ev = ev_new(response);
+	EV_DATA(resp_ev, struct data_s)->v = 1000;
+
+	ev_sched_to(&to, 0, 0);
+	ev_post(a, b, req_ev, &to);
+	ev_sched_to(&to, 1, 0);
+	ev_post(b, a, resp_ev, &to);
+	ev_sched_to(&to, 2, 0);
+	ev_post(timer, timer, to_ev, &to);
+
+	sleep(30);
+	ev_flush(timer);
+	ev_flush(a);
+	ev_flush(b);
+	sleep(5);
+	return 0;
+}


### PR DESCRIPTION
This API provides a mechanism to schedule events to worker threads. This
will replace the ldmsd_task paradigm in order to simplify the ldmsd
state machine.