### PR TITLE
Repair autoconf quoting in AX_PYTHON_DEVEL calls

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -529,7 +529,7 @@ fi
 dnl swig stuff
 if test -z "$ENABLE_SOS_TRUE"; then
 	which cython >/dev/null 2>&1 || AC_MSG_ERROR("cython not found")
-	AX_PYTHON_DEVEL(">='3.6'")
+	AX_PYTHON_DEVEL([>='3.6'])
 	if test "x$WITH_SOS" != "xbuild"; then
 		OCFLAGS=$CFLAGS
 		CFLAGS=$SOS_INCDIR_FLAG
@@ -553,13 +553,13 @@ OPTION_DEFAULT_DISABLE([swig], [ENABLE_SWIG])
 if test -z "$ENABLE_SWIG_TRUE"; then
 	AC_PROG_SWIG
 	SWIG_PYTHON
-	AX_PYTHON_DEVEL(">='3.6'")
+	AX_PYTHON_DEVEL([>='3.6'])
 	AX_PYTHON_MODULE_VERSION(["argparse"], 1.1, "python")
 fi
 
 dnl ldms-python API's
 if test -z "$ENABLE_LDMS_PYTHON_TRUE"; then
-	AX_PYTHON_DEVEL(">='3.6'")
+	AX_PYTHON_DEVEL([>='3.6'])
 	pkgpythondir="${pythondir}/ovis_ldms"
 	pkgpyexecdir="${pkgpythondir}"
 	AX_PYTHON_MODULE_VERSION(["argparse"], 1.1, "python")


### PR DESCRIPTION
Incorrectly using " for quoting in the autoconf flavor of m4 was
resulting in an empty file name "=3.6" created at configure time.
We replace the "" with [].