### PR TITLE
stream_unsubscribe + prdcr_unsubscribe

### DIFF
--- a/ldms/python/ldmsd/ldmsd_config.py
+++ b/ldms/python/ldmsd/ldmsd_config.py
@@ -103,6 +103,7 @@ LDMSD_CTRL_CMD_MAP = {'usage': {'req_attr': [], 'opt_attr': ['name']},
                       'prdcr_set_status': {'opt_attr': ['producer', 'instance', 'schema']},
                       'prdcr_hint_tree': {'req_attr':['name'], 'opt_attr': []},
                       'prdcr_subscribe': {'req_attr':['regex', 'stream'], 'opt_attr': []},
+                      'prdcr_unsubscribe': {'req_attr':['regex', 'stream'], 'opt_attr': []},
                       ##### Updater Policy #####
                       'updtr_add': {'req_attr': ['name'],
                                     'opt_attr': ['offset', 'push', 'interval', 'auto_interval']},
@@ -132,6 +133,7 @@ LDMSD_CTRL_CMD_MAP = {'usage': {'req_attr': [], 'opt_attr': ['name']},
                       ##### Streams ###
                       'publish': {'req_attr': ['name'], 'opt_attr': []},
                       'subscribe': {'req_attr': ['name'], 'opt_attr': []},
+                      'stream_client_dump': {'req_attr': [], 'opt_attr': []},
                       ##### Daemon #####
                       'daemon_status': {'req_attr': [], 'opt_attr': []},
                       ##### Misc. #####

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -401,6 +401,18 @@ class LdmsdCmdParser(cmd.Cmd):
     def complete_prdcr_subscribe(self, text, line, begidx, endidx):
         return self.__complete_attr_list('prdcr_subscribe', text)
 
+    def do_prdcr_unsubscribe(self, arg):
+        """
+        Subscribe for stream data from all matching producers
+        Parameters:
+        regex=     A regular expression matching producer names
+        stream=    The stream name
+        """
+        self.handle('prdcr_unsubscribe', arg);
+
+    def complete_prdcr_unsubscribe(self, text, line, begidx, endidx):
+        return self.__complete_attr_list('prdcr_unsubscribe', text)
+
     def do_updtr_add(self, arg):
         """
         Add an Updater that will periodically update Producer metric sets either
@@ -1252,6 +1264,21 @@ class LdmsdCmdParser(cmd.Cmd):
 
     def complete_prdcr_hint_tree(self, text, line, begidx, endidx):
         return self.__complete_attr_list('prdcr_hint_tree', text)
+
+    def do_stream_client_dump(self, arg):
+        """
+        Dump stream client information (for debugging)
+
+        No parameters
+        """
+        resp = self.handle('stream_client_dump', None)
+        if not resp:
+            raise RuntimeError("no response")
+        obj = json.loads(resp['msg'])
+        print(json.dumps(obj, indent=2))
+
+    def complete_stream_client_dump(self, text, line, begidx, endidx):
+        return self.__complete_attr_list('stream_client_dump', text)
 
     def parseline(self, line):
         """Parse the line into a command name and a string containing

--- a/ldms/python/ldmsd/ldmsd_request.py
+++ b/ldms/python/ldmsd/ldmsd_request.py
@@ -277,6 +277,7 @@ class LDMSD_Request(object):
     PRDCR_SET_STATUS = 0x100 + 7
     PRDCR_HINT_TREE = 0x100 + 8
     PRDCR_SUBSCRIBE = 0x100 + 9
+    PRDCR_UNSUBSCRIBE = 0x100 + 10
 
     STRGP_ADD = 0x200
     STRGP_DEL = 0x200 + 1
@@ -344,6 +345,8 @@ class LDMSD_Request(object):
 
     STREAM_PUBLISH = 0x900
     STREAM_SUBSCRIBE = STREAM_PUBLISH + 1
+    STREAM_UNSUBSCRIBE = STREAM_PUBLISH + 2
+    STREAM_CLIENT_DUMP = STREAM_PUBLISH + 3
 
     LDMSD_REQ_ID_MAP = {
             'example': {'id': EXAMPLE},
@@ -361,6 +364,7 @@ class LDMSD_Request(object):
             'prdcr_set_status': {'id': PRDCR_SET_STATUS},
             'prdcr_hint_tree': {'id': PRDCR_HINT_TREE},
             'prdcr_subscribe': {'id': PRDCR_SUBSCRIBE},
+            'prdcr_unsubscribe': {'id': PRDCR_UNSUBSCRIBE},
 
             'strgp_add': {'id': STRGP_ADD},
             'strgp_del': {'id': STRGP_DEL},
@@ -419,6 +423,9 @@ class LDMSD_Request(object):
 
             'publish'       :  {'id': STREAM_PUBLISH },
             'subscribe'     :  {'id' : STREAM_SUBSCRIBE },
+            'unsubscribe'   :  {'id' : STREAM_UNSUBSCRIBE },
+
+            'stream_client_dump'   :  {'id' : STREAM_CLIENT_DUMP },
         }
 
     TYPE_CONFIG_CMD = 1

--- a/ldms/src/core/ldms_xprt.h
+++ b/ldms/src/core/ldms_xprt.h
@@ -441,6 +441,11 @@ struct ldms_xprt {
 
 	struct rbt rbd_rbt;
 	LIST_ENTRY(ldms_xprt) xprt_link;
+
+	/* for addr caching */
+	socklen_t sa_len;
+	struct sockaddr local_sa;
+	struct sockaddr remote_sa;
 };
 
 void __ldms_xprt_term(struct ldms_xprt *x);

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -913,6 +913,9 @@ int ldmsd_prdcr_stop_regex(const char *prdcr_regex,
 int ldmsd_prdcr_subscribe_regex(const char *prdcr_regex, char *stream_name,
 				char *rep_buf, size_t rep_len,
 				ldmsd_sec_ctxt_t ctxt);
+int ldmsd_prdcr_unsubscribe_regex(const char *prdcr_regex, char *stream_name,
+				char *rep_buf, size_t rep_len,
+				ldmsd_sec_ctxt_t ctxt);
 
 int __ldmsd_prdcr_start(ldmsd_prdcr_t prdcr, ldmsd_sec_ctxt_t ctxt);
 int __ldmsd_prdcr_stop(ldmsd_prdcr_t prdcr, ldmsd_sec_ctxt_t ctxt);

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -977,12 +977,16 @@ void ldmsd_recv_msg(ldms_t x, char *data, size_t data_len)
 	}
 }
 
+/* implemented in ldmsd_request.c */
+void stream_xprt_term(ldms_t x);
+
 static void __listen_connect_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 {
 	switch (e->type) {
 	case LDMS_XPRT_EVENT_CONNECTED:
 		break;
 	case LDMS_XPRT_EVENT_DISCONNECTED:
+		stream_xprt_term(x);
 	case LDMS_XPRT_EVENT_REJECTED:
 	case LDMS_XPRT_EVENT_ERROR:
 		ldms_xprt_put(x);
@@ -1095,7 +1099,7 @@ static int ldmd_plugins_check_dir(const char *path, int verbose) {
 	memset(&buf, 0, sizeof(buf));
 	int serr = stat(path, &buf);
 	int err = 0;
-	if (serr < 0) { 
+	if (serr < 0) {
 		err = errno;
 		fprintf(stderr, "%s: unable to stat plugin library path %s (%d).\n",
 			APP, path, err);

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -157,6 +157,7 @@ static int prdcr_stop_regex_handler(ldmsd_req_ctxt_t req_ctxt);
 static int prdcr_status_handler(ldmsd_req_ctxt_t req_ctxt);
 static int prdcr_set_status_handler(ldmsd_req_ctxt_t req_ctxt);
 static int prdcr_subscribe_regex_handler(ldmsd_req_ctxt_t req_ctxt);
+static int prdcr_unsubscribe_regex_handler(ldmsd_req_ctxt_t req_ctxt);
 static int strgp_add_handler(ldmsd_req_ctxt_t req_ctxt);
 static int strgp_del_handler(ldmsd_req_ctxt_t req_ctxt);
 static int strgp_start_handler(ldmsd_req_ctxt_t req_ctxt);
@@ -227,6 +228,8 @@ static int setgroup_rm_handler(ldmsd_req_ctxt_t req_ctxt);
 
 static int stream_publish_handler(ldmsd_req_ctxt_t req_ctxt);
 static int stream_subscribe_handler(ldmsd_req_ctxt_t reqc);
+static int stream_unsubscribe_handler(ldmsd_req_ctxt_t reqc);
+static int stream_client_dump_handler(ldmsd_req_ctxt_t reqc);
 
 static int listen_handler(ldmsd_req_ctxt_t reqc);
 
@@ -274,6 +277,10 @@ static struct request_handler_entry request_handler[] = {
 	},
 	[LDMSD_PRDCR_SUBSCRIBE_REQ] = {
 		LDMSD_PRDCR_SUBSCRIBE_REQ, prdcr_subscribe_regex_handler,
+		XUG | LDMSD_PERM_FAILOVER_ALLOWED
+	},
+	[LDMSD_PRDCR_UNSUBSCRIBE_REQ] = {
+		LDMSD_PRDCR_UNSUBSCRIBE_REQ, prdcr_unsubscribe_regex_handler,
 		XUG | LDMSD_PERM_FAILOVER_ALLOWED
 	},
 
@@ -494,6 +501,12 @@ static struct request_handler_entry request_handler[] = {
 	},
 	[LDMSD_STREAM_SUBSCRIBE_REQ] = {
 		LDMSD_STREAM_SUBSCRIBE_REQ, stream_subscribe_handler, XUG
+	},
+	[LDMSD_STREAM_UNSUBSCRIBE_REQ] = {
+		LDMSD_STREAM_UNSUBSCRIBE_REQ, stream_unsubscribe_handler, XUG
+	},
+	[LDMSD_STREAM_CLIENT_DUMP_REQ] = {
+		LDMSD_STREAM_CLIENT_DUMP_REQ, stream_client_dump_handler, XUG
 	},
 
 	/* LISTEN */
@@ -823,6 +836,7 @@ size_t Snprintf(char **dst, size_t *len, char *fmt, ...)
 	return cnt;
 }
 
+__attribute__((format(printf, 2, 3)))
 int linebuf_printf(struct ldmsd_req_ctxt *reqc, char *fmt, ...)
 {
 	va_list ap;
@@ -1674,6 +1688,45 @@ static int prdcr_subscribe_regex_handler(ldmsd_req_ctxt_t reqc)
 						    stream_name,
 						    reqc->line_buf,
 						    reqc->line_len, &sctxt);
+	/* on error, reqc->line_buf will be filled */
+
+send_reply:
+	ldmsd_send_req_response(reqc, reqc->line_buf);
+	if (prdcr_regex)
+		free(prdcr_regex);
+	return 0;
+}
+
+static int prdcr_unsubscribe_regex_handler(ldmsd_req_ctxt_t reqc)
+{
+	char *prdcr_regex;
+	char *stream_name;
+	size_t cnt = 0;
+	struct ldmsd_sec_ctxt sctxt;
+
+	reqc->errcode = 0;
+
+	prdcr_regex = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_REGEX);
+	if (!prdcr_regex) {
+		reqc->errcode = EINVAL;
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+				"The attribute 'regex' is required by prdcr_stop_regex.");
+		goto send_reply;
+	}
+
+	stream_name = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_STREAM);
+	if (!stream_name) {
+		reqc->errcode = EINVAL;
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+				"The attribute 'stream' is required by prdcr_subscribe_regex.");
+		goto send_reply;
+	}
+
+	ldmsd_req_ctxt_sec_get(reqc, &sctxt);
+	reqc->errcode = ldmsd_prdcr_unsubscribe_regex(prdcr_regex,
+						      stream_name,
+						      reqc->line_buf,
+						      reqc->line_len, &sctxt);
 	/* on error, reqc->line_buf will be filled */
 
 send_reply:
@@ -5723,11 +5776,118 @@ static int stream_republish_cb(ldmsd_stream_client_t c, void *ctxt,
 	return rc;
 }
 
+/* RSE: remote stream entry */
+struct __RSE_key_s {
+	/* remote addr */
+	struct sockaddr addr;
+	/* remote addr len */
+	uint32_t addr_len;
+	/* stream name */
+	char name[];
+};
+
+typedef struct __RSE_s {
+	struct rbn rbn;
+	ldmsd_stream_client_t client;
+	struct __RSE_key_s key;
+} *__RSE_t;
+
+int __RSE_cmp(void *tree_key, const void *key)
+{
+	const struct __RSE_key_s *k0, *k1;
+	size_t len;
+	int rc, ln_rc;
+	k0 = tree_key;
+	k1 = key;
+	if (k0->addr_len < k1->addr_len) {
+		len = k0->addr_len;
+		ln_rc = -1;
+	} else if (k0->addr_len > k1->addr_len) {
+		len = k1->addr_len;
+		ln_rc = 1;
+	} else {
+		len = k0->addr_len;
+		ln_rc = 0;
+	}
+	rc = memcmp(&k0->addr, &k1->addr, len);
+	if (rc)
+		return rc;
+	if (ln_rc)
+		return ln_rc;
+	/* reaching here means same address */
+	return strcmp(k0->name, k1->name);
+}
+
+pthread_mutex_t __RSE_rbt_mutex = PTHREAD_MUTEX_INITIALIZER;
+struct rbt __RSE_rbt = RBT_INITIALIZER(__RSE_cmp);
+
+static inline
+void __RSE_rbt_lock()
+{
+	pthread_mutex_lock(&__RSE_rbt_mutex);
+}
+
+static inline
+void __RSE_rbt_unlock()
+{
+	pthread_mutex_unlock(&__RSE_rbt_mutex);
+}
+
+static inline
+__RSE_t __RSE_alloc(const char *name, struct sockaddr *sa, socklen_t sa_len)
+{
+	__RSE_t ent;
+	ent = calloc(1, sizeof(*ent) + strlen(name) + 1);
+	if (!ent)
+		return NULL;
+	sprintf(ent->key.name, "%s", name);
+	memcpy(&ent->key.addr, sa, sa_len);
+	ent->key.addr_len = sa_len;
+	rbn_init(&ent->rbn, &ent->key);
+	return ent;
+}
+
+static inline
+void __RSE_free(__RSE_t ent)
+{
+	free(ent);
+}
+
+static inline
+__RSE_t __RSE_find(const struct __RSE_key_s *key)
+{
+	/* caller must hold __RSE_rbt_mutex */
+	struct rbn *rbn;
+	rbn = rbt_find(&__RSE_rbt, key);
+	if (!rbn)
+		return NULL;
+	return container_of(rbn, struct __RSE_s, rbn);
+}
+
+static inline
+void __RSE_ins(__RSE_t ent)
+{
+	/* caller must hold __RSE_rbt_mutex */
+	rbt_ins(&__RSE_rbt, &ent->rbn);
+}
+
+static inline
+void __RSE_del(__RSE_t ent)
+{
+	/* caller must hold __RSE_rbt_mutex */
+	rbt_del(&__RSE_rbt, &ent->rbn);
+}
+
 static int stream_subscribe_handler(ldmsd_req_ctxt_t reqc)
 
 {
 	char *stream_name;
 	int cnt;
+	int rc, len;
+	struct sockaddr local_sa;
+	__RSE_t ent;
+	char _buff[sizeof(struct __RSE_key_s) + 256]; /* should be enough for stream name */
+	struct __RSE_key_s *key = (void*)_buff;
 
 	stream_name = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_NAME);
 	if (!stream_name) {
@@ -5736,13 +5896,180 @@ static int stream_subscribe_handler(ldmsd_req_ctxt_t reqc)
 			       "The stream name is missing.");
 		goto send_reply;
 	}
-
-	ldmsd_stream_subscribe(stream_name, stream_republish_cb, reqc->xprt->ldms.ldms);
+	len = snprintf(key->name, 256, "%s", stream_name);
+	if (len >= 256) {
+		reqc->errcode = ENAMETOOLONG;
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+			       "The stream name is too long (%d >= %d).",
+			       len, 256);
+		goto send_reply;
+	}
+	rc = ldms_xprt_sockaddr(reqc->xprt->ldms.ldms, &local_sa, &key->addr,
+				&key->addr_len);
+	if (rc) {
+		ldmsd_log(LDMSD_LWARNING,
+			  "%s:%d:%s ldms_xprt_sockaddr() error: %d\n",
+			  __FILE__, __LINE__, __func__, errno);
+		reqc->errcode = EREMOTEIO;
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+			       "ldms_xprt_sockaddr() error: %d", errno);
+		goto send_reply;
+	}
+	__RSE_rbt_lock();
+	ent = __RSE_find(key);
+	if (ent) {
+		__RSE_rbt_unlock();
+		reqc->errcode = EEXIST;
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+			       "Already subscribed to `%s` stream",
+			       stream_name);
+		goto send_reply;
+	}
+	ent = __RSE_alloc(stream_name, &key->addr, key->addr_len);
+	if (!ent) {
+		__RSE_rbt_unlock();
+		reqc->errcode = ENOMEM;
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+			       "Memory allocation failed");
+		goto send_reply;
+	}
+	ent->client = ldmsd_stream_subscribe(stream_name, stream_republish_cb,
+						reqc->xprt->ldms.ldms);
+	if (!ent->client) {
+		__RSE_rbt_unlock();
+		free(ent);
+		reqc->errcode = errno;
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+			       "ldmsd_stream_subscribe() error: %d", errno);
+		goto send_reply;
+	}
+	__RSE_ins(ent);
 	reqc->errcode = 0;
 	cnt = Snprintf(&reqc->line_buf, &reqc->line_len, "OK");
+	__RSE_rbt_unlock();
 send_reply:
 	ldmsd_send_req_response(reqc, reqc->line_buf);
 	return 0;
+}
+
+static int stream_unsubscribe_handler(ldmsd_req_ctxt_t reqc)
+
+{
+	char *stream_name;
+	int cnt;
+	int rc, len;
+	struct sockaddr local_sa;
+	__RSE_t ent;
+	char _buff[sizeof(struct __RSE_key_s) + 256]; /* should be enough for stream name */
+	struct __RSE_key_s *key = (void*)_buff;
+
+	stream_name = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_NAME);
+	if (!stream_name) {
+		reqc->errcode = EINVAL;
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+			       "The stream name is missing.");
+		goto send_reply;
+	}
+	len = snprintf(key->name, 256, "%s", stream_name);
+	if (len >= 256) {
+		reqc->errcode = ENAMETOOLONG;
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+			       "The stream name is too long (%d >= %d).",
+			       len, 256);
+		goto send_reply;
+	}
+	rc = ldms_xprt_sockaddr(reqc->xprt->ldms.ldms, &local_sa, &key->addr,
+				&key->addr_len);
+	if (rc) {
+		ldmsd_log(LDMSD_LWARNING,
+			  "%s:%d:%s ldms_xprt_sockaddr() error: %d\n",
+			  __FILE__, __LINE__, __func__, errno);
+		reqc->errcode = EREMOTEIO;
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+			       "ldms_xprt_sockaddr() error: %d", errno);
+		goto send_reply;
+	}
+	__RSE_rbt_lock();
+	ent = __RSE_find(key);
+	if (!ent) {
+		__RSE_rbt_unlock();
+		reqc->errcode = ENOENT;
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+			       "`%s` stream not found", stream_name);
+		goto send_reply;
+	}
+	ldmsd_stream_close(ent->client);
+	__RSE_del(ent);
+	free(ent);
+	reqc->errcode = 0;
+	cnt = Snprintf(&reqc->line_buf, &reqc->line_len, "OK");
+	__RSE_rbt_unlock();
+
+send_reply:
+	ldmsd_send_req_response(reqc, reqc->line_buf);
+	return 0;
+}
+
+static int stream_client_dump_handler(ldmsd_req_ctxt_t reqc)
+{
+	int rc;
+	struct ldmsd_req_attr_s attr;
+	char *json;
+
+	/* constructin JSON reply */
+	json = ldmsd_stream_client_dump();
+	if (!json)
+		return errno;
+	rc = linebuf_printf(reqc, "%s", json);
+	free(json);
+	if (rc)
+		return rc;
+
+	/* sending messages */
+	attr.discrim = 1;
+	attr.attr_len = reqc->line_off;
+	attr.attr_id = LDMSD_ATTR_JSON;
+	ldmsd_hton_req_attr(&attr);
+	rc = ldmsd_append_reply(reqc, (char *)&attr, sizeof(attr), LDMSD_REQ_SOM_F);
+	if (rc)
+		return rc;
+	rc = ldmsd_append_reply(reqc, reqc->line_buf, reqc->line_off, 0);
+	if (rc)
+		return rc;
+	attr.discrim = 0;
+	ldmsd_append_reply(reqc, (char *)&attr.discrim, sizeof(uint32_t), LDMSD_REQ_EOM_F);
+	return rc;
+}
+
+void stream_xprt_term(ldms_t x)
+{
+	struct sockaddr local_sa;
+	__RSE_t ent;
+	struct rbn *rbn;
+	char _buff[sizeof(struct __RSE_key_s) + 256] = {};
+	struct __RSE_key_s *key = (void*)_buff;
+	int rc;
+
+	rc = ldms_xprt_sockaddr(x, &local_sa, &key->addr,
+				&key->addr_len);
+	if (rc)
+		return;
+	__RSE_rbt_lock();
+	rbn = rbt_find_lub(&__RSE_rbt, &key);
+	while (rbn) {
+		ent = container_of(rbn, struct __RSE_s, rbn);
+		if (key->addr_len != ent->key.addr_len)
+			break;
+		if (memcmp(&key->addr, &ent->key.addr, key->addr_len))
+			break;
+		/* points rbn to the successor before removing ent */
+		rbn = rbn_succ(rbn);
+		/* delete from the tree */
+		__RSE_del(ent);
+		ldmsd_stream_close(ent->client);
+		__RSE_free(ent);
+	}
+	__RSE_rbt_unlock();
 }
 
 int ldmsd_auth_opt_add(struct attr_value_list *auth_attrs, char *name, char *val)

--- a/ldms/src/ldmsd/ldmsd_request.h
+++ b/ldms/src/ldmsd/ldmsd_request.h
@@ -70,6 +70,7 @@ enum ldmsd_request {
 	LDMSD_PRDCR_SET_REQ,
 	LDMSD_PRDCR_HINT_TREE_REQ,
 	LDMSD_PRDCR_SUBSCRIBE_REQ,
+	LDMSD_PRDCR_UNSUBSCRIBE_REQ,
 	LDMSD_STRGP_ADD_REQ = 0x200,
 	LDMSD_STRGP_DEL_REQ,
 	LDMSD_STRGP_START_REQ,
@@ -150,6 +151,8 @@ enum ldmsd_request {
 	/* Publish/Subscribe Requests */
 	LDMSD_STREAM_PUBLISH_REQ = 0x900, /* Publish data to a stream */
 	LDMSD_STREAM_SUBSCRIBE_REQ,	  /* Subscribe to a stream */
+	LDMSD_STREAM_UNSUBSCRIBE_REQ,	  /* Unsubscribe to a stream */
+	LDMSD_STREAM_CLIENT_DUMP_REQ,	  /* Dump stream client info */
 
 	/* Auth */
 	LDMSD_AUTH_ADD_REQ = 0xa00, /* Add auth domain */

--- a/ldms/src/ldmsd/ldmsd_request_util.c
+++ b/ldms/src/ldmsd/ldmsd_request_util.c
@@ -96,6 +96,7 @@ const struct req_str_id req_str_id_table[] = {
 	{  "prdcr_stop",         LDMSD_PRDCR_STOP_REQ  },
 	{  "prdcr_stop_regex",   LDMSD_PRDCR_STOP_REGEX_REQ  },
 	{  "prdcr_subscribe",    LDMSD_PRDCR_SUBSCRIBE_REQ },
+	{  "prdcr_unsubscribe",  LDMSD_PRDCR_UNSUBSCRIBE_REQ },
 	{  "set_route",          LDMSD_SET_ROUTE_REQ  },
 	{  "setgroup_add",       LDMSD_SETGROUP_ADD_REQ  },
 	{  "setgroup_del",       LDMSD_SETGROUP_DEL_REQ  },
@@ -103,6 +104,7 @@ const struct req_str_id req_str_id_table[] = {
 	{  "setgroup_rm",        LDMSD_SETGROUP_RM_REQ  },
 	{  "start",              LDMSD_PLUGN_START_REQ  },
 	{  "stop",               LDMSD_PLUGN_STOP_REQ  },
+	{  "stream_client_dump", LDMSD_STREAM_CLIENT_DUMP_REQ  },
 	{  "strgp_add",          LDMSD_STRGP_ADD_REQ  },
 	{  "strgp_del",          LDMSD_STRGP_DEL_REQ  },
 	{  "strgp_metric_add",   LDMSD_STRGP_METRIC_ADD_REQ  },
@@ -210,6 +212,7 @@ const char *ldmsd_req_id2str(enum ldmsd_request req_id)
 	case LDMSD_PRDCR_SET_REQ         : return "PRDCR_SET_REQ";
 	case LDMSD_PRDCR_HINT_TREE_REQ   : return "PRDCR_HINT_TREE_REQ";
 	case LDMSD_PRDCR_SUBSCRIBE_REQ   : return "PRDCR_SUBSCRIBE_REQ";
+	case LDMSD_PRDCR_UNSUBSCRIBE_REQ : return "PRDCR_UNSUBSCRIBE_REQ";
 
 	case LDMSD_STRGP_ADD_REQ        : return "STRGP_ADD_REQ";
 	case LDMSD_STRGP_DEL_REQ        : return "STRGP_DEL_REQ";

--- a/ldms/src/ldmsd/ldmsd_stream.h
+++ b/ldms/src/ldmsd/ldmsd_stream.h
@@ -39,6 +39,16 @@ void ldmsd_stream_deliver(const char *stream_name, ldmsd_stream_type_t stream_ty
 
 int ldmsd_stream_response(ldms_xprt_event_t e);
 
+/**
+ * Dump stream clients in JSON.
+ *
+ * The caller is responsible for freeing the returned string.
+ *
+ * \retval s    The stream clients in JSON format.
+ * \retval NULL If there is an error. \c errno is also set in this case.
+ */
+char * ldmsd_stream_client_dump();
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
[x] Manages clients of ldmsd stream republishing service in a
    red-black-tree with `<PEER_ADDR>:<STREAM_NAME>` keys. The clients
    are registered by `LDMSD_STREAM_SUBSCRIBE_REQ`.
    - RECALL: The ldmsd-to-ldmsd stream republishing service
      subscription is driven by `prdcr_subscribe` config command.
[x] `prdcr_unsubscribe` config command to instruct ldmsd to unsubscribe
    the republishing stream from peers.
    [x] ldmsctl
    [x] ldmsd_controller
    [x] Add `LDMSD_STREAM_UNSUBSCRIBE_REQ` request. This is an
        ldmsd-to-ldmsd request to stop the stream republishing.
[x] automatically remove clients of stream republishing service
    (registered by `LDMSD_STREAM_SUBSCRIBE_REQ`) on connection
    termination.
    [x] ldms_xprt_sockaddr() caching: cache the remote/local addresses
	on the success zap_get_name() so that the remote/local addresses
	are still available even after the endpoint became disconnected
	(but not yet destroyed), which is required for the republish
	client key construction. The caching is valid because the
	local/remote addresses are not changed after the endpoint
	becomes connected.
[x] Add `stream_client_dump` config command to dump the current list of
    all stream clients (not just the republishing ones) for debugging
    and test verification.
    [x] ldmsctl
    [x] ldmsd_controller
[x] test: ldmsd_stream_test in ldms-test (covers both manual unsubscribe
    and automatic client removal on disconnection).