### PR TITLE
Consolidate sampler default authentication values

### DIFF
--- a/ldms/man/ldmsctl.man
+++ b/ldms/man/ldmsctl.man
@@ -1,4 +1,4 @@
-.\" Manpage for ldmsctl
+\" Manpage for ldmsctl
 .\" Contact ovis-help@ca.sandia.gov to correct errors or typos.
 .TH man 8 "19 Nov 2019" "v4.3" "ldmsctl man page"
 
@@ -151,7 +151,7 @@ The group id of the set's owner. The default is the returned value of getegid().
 .TP
 .BI [perm " perm"]
 .br
-The sampler plugin instance access permission. The default is 0777.
+The sampler plugin instance access permission. The default is 0440.
 .RE
 .RE
 

--- a/ldms/man/ldmsd_controller.man
+++ b/ldms/man/ldmsd_controller.man
@@ -151,7 +151,7 @@ The group id of the set's owner. The default is the returned value of getegid().
 .TP
 .BI [perm " perm"]
 .br
-The sampler plugin instance access permission. The default is 0777.
+The sampler plugin instance access permission. The default is 0440.
 .RE
 .RE
 

--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -1172,7 +1172,7 @@ ldms_set_t ldms_set_new_with_auth(const char *instance_name,
 
 ldms_set_t ldms_set_new(const char *instance_name, ldms_schema_t schema)
 {
-	return ldms_set_new_with_auth(instance_name, schema, geteuid(), getegid(), 0777);
+	return ldms_set_new_with_auth(instance_name, schema, geteuid(), getegid(), 0440);
 }
 
 int ldms_set_config_auth(ldms_set_t set, uid_t uid, gid_t gid, mode_t perm)

--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -1205,14 +1205,32 @@ uint32_t ldms_set_uid_get(ldms_set_t s)
 	return __le32_to_cpu(s->set->meta->uid);
 }
 
+int ldms_set_uid_set(ldms_set_t s, uid_t uid)
+{
+	s->set->meta->uid = __cpu_to_le32(uid);
+        return 0;
+}
+
 uint32_t ldms_set_gid_get(ldms_set_t s)
 {
 	return __le32_to_cpu(s->set->meta->gid);
 }
 
+int ldms_set_gid_set(ldms_set_t s, gid_t gid)
+{
+	s->set->meta->gid = __cpu_to_le32(gid);
+        return 0;
+}
+
 uint32_t ldms_set_perm_get(ldms_set_t s)
 {
 	return __le32_to_cpu(s->set->meta->perm);
+}
+
+int ldms_set_perm_set(ldms_set_t s, mode_t perm)
+{
+	s->set->meta->perm = __cpu_to_le32(perm);
+        return 0;
 }
 
 extern uint32_t ldms_set_meta_sz_get(ldms_set_t s)

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -1147,6 +1147,15 @@ extern uint32_t ldms_set_card_get(ldms_set_t s);
 uint32_t ldms_set_uid_get(ldms_set_t s);
 
 /**
+ * \brief Set the UID of the LDMS set.
+ * \param s The set handle.
+ * \param uid The UID to set
+ * \retval errno If failed.
+ * \retval 0     If succeeded.
+ */
+int ldms_set_uid_set(ldms_set_t s, uid_t uid);
+
+/**
  * \brief Retreive the GID of the LDMS set.
  * \param s The set handle.
  * \retval gid The GID of the set.
@@ -1154,11 +1163,29 @@ uint32_t ldms_set_uid_get(ldms_set_t s);
 uint32_t ldms_set_gid_get(ldms_set_t s);
 
 /**
+ * \brief Set the GID of the LDMS set.
+ * \param s The set handle.
+ * \param uid The GID to set
+ * \retval errno If failed.
+ * \retval 0     If succeeded.
+ */
+int ldms_set_gid_set(ldms_set_t s, gid_t gid);
+
+/**
  * \brief Retreive the permission of the LDMS set.
  * \param s The set handle.
  * \retval perm The permission of the set.
  */
 uint32_t ldms_set_perm_get(ldms_set_t s);
+
+/**
+ * \brief Set the permissions of the LDMS set.
+ * \param s The set handle.
+ * \param perm The UNIX mode_t bits (see chmod)
+ * \retval errno If failed.
+ * \retval 0     If succeeded.
+ */
+int ldms_set_perm_set(ldms_set_t s, mode_t perm);
 
 /**
  * \brief Get the size in bytes of the set's meta data

--- a/ldms/src/sampler/app_sampler/app_sampler.c
+++ b/ldms/src/sampler/app_sampler/app_sampler.c
@@ -1240,14 +1240,12 @@ int __handle_task_init(app_sampler_inst_t inst, json_entity_t data)
 	if (!app_set)
 		return ENOMEM;
 	app_set->task_pid = task_pid->value.int_;
-	set = ldms_set_new_with_auth(setname, inst->base_data->schema,
-				     inst->base_data->uid,
-				     inst->base_data->gid,
-				     inst->base_data->perm);
+        set = ldms_set_new(setname, inst->base_data->schema);
 	if (!set) {
 		free(app_set);
 		return errno;
 	}
+        base_auth_set(&inst->base_data->auth, set);
 	ldms_metric_set_u64(set, BASE_JOB_ID, job_id->value.int_);
 	ldms_metric_set_u64(set, BASE_COMPONENT_ID, inst->base_data->component_id);
 	ldms_metric_set_u64(set, inst->task_rank_idx, task_rank->value.int_);

--- a/ldms/src/sampler/examples/synthetic/synthetic.c
+++ b/ldms/src/sampler/examples/synthetic/synthetic.c
@@ -110,7 +110,7 @@ static ldms_set_t clone_metric_set(base_data_t base, uint64_t k)
 	ldms_metric_set_u64(c, BASE_COMPONENT_ID, base->component_id);
 	ldms_metric_set_u64(c, BASE_JOB_ID, 0);
 	ldms_metric_set_u64(c, BASE_APP_ID, 0);
-	ldms_set_config_auth(c, base->uid, base->gid, base->perm);
+	base_auth_set(&base->auth, c);
 	rc = ldms_set_publish(c);
 	if (rc) {
 		ldms_set_delete(c);

--- a/ldms/src/sampler/papi/papi_sampler.c
+++ b/ldms/src/sampler/papi/papi_sampler.c
@@ -267,12 +267,11 @@ static int create_metric_set(job_data_t job)
 	snprintf(job->instance_name, 256, "%s/%s/%lu",
 		 job->base->producer_name, job->schema_name,
 		 job->job_id);
-	job->set = ldms_set_new_with_auth(job->instance_name, schema,
-					  job->base->uid, job->base->gid,
-					  job->base->perm);
+	job->set = ldms_set_new(job->instance_name, schema);
 	if (!job->set)
 		goto err;
 
+	base_auth_set(&job->base->auth, job->set);
 	ldms_set_producer_name_set(job->set, job->base->producer_name);
 	ldms_metric_set_u64(job->set, job->job_id_mid, job->job_id);
 	ldms_metric_set_u64(job->set, job->comp_id_mid, job->base->component_id);


### PR DESCRIPTION
We modify the sampler code to eliminate the many different hard coded
sampler permission defaults, and instead inherit the default consistently
from ldms_set_new().

Also change the the default permissions from the too-permissive default
of 0777 to a more secure 0440.

This consolidation work is useful on its own as refactoring (to eliminate redundant
hard coded defaults), but it also lays the ground work for introducing 
global defaults for sampler uid, gid, and perm that can be set once at the ldmsd
level instead of having to repeat the configuration over and over again for each
smapler plugin in the configuration.

We do still preserve the capability to individually set uid/gid/perm values per
plugins if so desired.
