### PR TITLE
Change Cython minimum version requirement to 0.25

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -553,7 +553,7 @@ fi
 
 dnl ldms-python API's and programs
 AC_ARG_VAR([CYTHON], [The Cython program])
-CYTHON_MIN_VER="0.28.5"
+CYTHON_MIN_VER="0.25"
 CYTHON_MSG="
 
     Please install Cython ver >= ${CYTHON_MIN_VER}. You may install Cython from


### PR DESCRIPTION
Previous Cython minimum version requirement was obtained from a testing
with `python36-Cython` RHEL7 epel package. After multiple build with
various version of Cython, version 0.25 was found to be the actual
minimum requirement. Cython 0.24 could not compile ldms.pyx.