### PR TITLE
Improve autoconf cython test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -551,43 +551,30 @@ if test -z "$ENABLE_SOS_TRUE"; then
 	fi
 fi
 
+AC_ARG_VAR([CYTHON], [Cython compiler command])
+dnl CYTHON_CHECK(CYTHON_MIN_VERSION, PYTHON_VERSION)
+AC_DEFUN([CYTHON_CHECK],
+[cython_min_version=$1
+ python_version=$2
+ AC_CACHE_CHECK([for a version of Cython >= ${cython_min_version}],
+		[ac_cv_path_CYTHON],
+		[AC_PATH_PROGS_FEATURE_CHECK([CYTHON],
+			[cython-${python_version} cython${python_version} cython],
+			[cython_version=$(${ac_path_CYTHON} --version 2>&1 | sed -e 's/.*\s//')
+			 AX_COMPARE_VERSION([${cython_version}],[ge],[$cython_min_version],
+			[ac_cv_path_CYTHON=$ac_path_CYTHON ac_path_CYTHON_found=:])],
+			[AC_MSG_ERROR([not found])])])
+ AC_SUBST([CYTHON], [$ac_cv_path_CYTHON])
+])
+
 dnl ldms-python API's and programs
-AC_ARG_VAR([CYTHON], [The Cython program])
-CYTHON_MIN_VER="0.25"
-CYTHON_MSG="
-
-    Please install Cython ver >= ${CYTHON_MIN_VER}. You may install Cython from
-    your distribution package manager, but we recommend installing it via pip3
-    (\`pip3 install Cython\`) to get the latest version of Cython. Some
-    distribution package (e.g. python36-Cython from epel 7) may install cython
-    program in cython<VER> form (e.g. /bin/cython3.6). In such case,
-    you may need to set 'CYTHON=/path/to/cython'.
-
-"
-if test -z "$ENABLE_PYTHON_TRUE"; then
+AS_IF([test "x$enable_python" != xno], [
 	AX_PYTHON_DEVEL([>='3.6'])
 	pkgpythondir="${pythondir}/ovis_ldms"
 	pkgpyexecdir="${pkgpythondir}"
 	AX_PYTHON_MODULE_VERSION(["argparse"], 1.1, "python")
-
-	if test -z "${CYTHON}"; then
-		dnl CYTHON= not specified
-		AC_PATH_PROGS([CYTHON], [cython cython3 cython3.6 cython-3.8], [no])
-		if test "${CYTHON}" = "no"; then
-			AC_MSG_ERROR([cython program not found. ${CYTHON_MSG}])
-		fi
-	elif test '!' -x "${CYTHON}"; then
-		dnl CYTHON= specified, but not executable or not found
-		AC_MSG_ERROR([The specified cython program "${CYTHON}" is not found or not executable.])
-	fi
-	AC_MSG_NOTICE(Using cython: ${CYTHON})
-	dnl cython version check
-	CYTHON_VER=$(${CYTHON} --version 2>&1 | sed -e 's/.*\s//')
-	AC_MSG_NOTICE(Cython version: ${CYTHON_VER})
-	LE_VER=$(echo -e "${CYTHON_VER}\n${CYTHON_MIN_VER}"| sort -V|head -n1)
-	test "$LE_VER" == "$CYTHON_MIN_VER" || \
-		AC_MSG_ERROR(Cython ${CYTHON_VER} is too old. $CYTHON_MSG)
-fi
+	CYTHON_CHECK([0.25], $PYTHON_VERSION)
+])
 AM_CONDITIONAL([HAVE_PYTHON], [test "$PYTHON" != :])
 
 OPTION_WITH_PORT([LDMSD],[411])

--- a/configure.ac
+++ b/configure.ac
@@ -553,7 +553,7 @@ fi
 
 dnl ldms-python API's and programs
 AC_ARG_VAR([CYTHON], [The Cython program])
-CYTHON_MIN_VER="0.28.5"
+CYTHON_MIN_VER="0.25"
 CYTHON_MSG="
 
     Please install Cython ver >= ${CYTHON_MIN_VER}. You may install Cython from

--- a/m4/ax_compare_version.m4
+++ b/m4/ax_compare_version.m4
@@ -1,0 +1,177 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_compare_version.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_COMPARE_VERSION(VERSION_A, OP, VERSION_B, [ACTION-IF-TRUE], [ACTION-IF-FALSE])
+#
+# DESCRIPTION
+#
+#   This macro compares two version strings. Due to the various number of
+#   minor-version numbers that can exist, and the fact that string
+#   comparisons are not compatible with numeric comparisons, this is not
+#   necessarily trivial to do in a autoconf script. This macro makes doing
+#   these comparisons easy.
+#
+#   The six basic comparisons are available, as well as checking equality
+#   limited to a certain number of minor-version levels.
+#
+#   The operator OP determines what type of comparison to do, and can be one
+#   of:
+#
+#    eq  - equal (test A == B)
+#    ne  - not equal (test A != B)
+#    le  - less than or equal (test A <= B)
+#    ge  - greater than or equal (test A >= B)
+#    lt  - less than (test A < B)
+#    gt  - greater than (test A > B)
+#
+#   Additionally, the eq and ne operator can have a number after it to limit
+#   the test to that number of minor versions.
+#
+#    eq0 - equal up to the length of the shorter version
+#    ne0 - not equal up to the length of the shorter version
+#    eqN - equal up to N sub-version levels
+#    neN - not equal up to N sub-version levels
+#
+#   When the condition is true, shell commands ACTION-IF-TRUE are run,
+#   otherwise shell commands ACTION-IF-FALSE are run. The environment
+#   variable 'ax_compare_version' is always set to either 'true' or 'false'
+#   as well.
+#
+#   Examples:
+#
+#     AX_COMPARE_VERSION([3.15.7],[lt],[3.15.8])
+#     AX_COMPARE_VERSION([3.15],[lt],[3.15.8])
+#
+#   would both be true.
+#
+#     AX_COMPARE_VERSION([3.15.7],[eq],[3.15.8])
+#     AX_COMPARE_VERSION([3.15],[gt],[3.15.8])
+#
+#   would both be false.
+#
+#     AX_COMPARE_VERSION([3.15.7],[eq2],[3.15.8])
+#
+#   would be true because it is only comparing two minor versions.
+#
+#     AX_COMPARE_VERSION([3.15.7],[eq0],[3.15])
+#
+#   would be true because it is only comparing the lesser number of minor
+#   versions of the two values.
+#
+#   Note: The characters that separate the version numbers do not matter. An
+#   empty string is the same as version 0. OP is evaluated by autoconf, not
+#   configure, so must be a string, not a variable.
+#
+#   The author would like to acknowledge Guido Draheim whose advice about
+#   the m4_case and m4_ifvaln functions make this macro only include the
+#   portions necessary to perform the specific comparison specified by the
+#   OP argument in the final configure script.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Tim Toolan <toolan@ele.uri.edu>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 13
+
+dnl #########################################################################
+AC_DEFUN([AX_COMPARE_VERSION], [
+  AC_REQUIRE([AC_PROG_AWK])
+
+  # Used to indicate true or false condition
+  ax_compare_version=false
+
+  # Convert the two version strings to be compared into a format that
+  # allows a simple string comparison.  The end result is that a version
+  # string of the form 1.12.5-r617 will be converted to the form
+  # 0001001200050617.  In other words, each number is zero padded to four
+  # digits, and non digits are removed.
+  AS_VAR_PUSHDEF([A],[ax_compare_version_A])
+  A=`echo "$1" | sed -e 's/\([[0-9]]*\)/Z\1Z/g' \
+                     -e 's/Z\([[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/[[^0-9]]//g'`
+
+  AS_VAR_PUSHDEF([B],[ax_compare_version_B])
+  B=`echo "$3" | sed -e 's/\([[0-9]]*\)/Z\1Z/g' \
+                     -e 's/Z\([[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/Z\([[0-9]][[0-9]][[0-9]]\)Z/Z0\1Z/g' \
+                     -e 's/[[^0-9]]//g'`
+
+  dnl # In the case of le, ge, lt, and gt, the strings are sorted as necessary
+  dnl # then the first line is used to determine if the condition is true.
+  dnl # The sed right after the echo is to remove any indented white space.
+  m4_case(m4_tolower($2),
+  [lt],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort -r | sed "s/x${A}/false/;s/x${B}/true/;1q"`
+  ],
+  [gt],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort | sed "s/x${A}/false/;s/x${B}/true/;1q"`
+  ],
+  [le],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort | sed "s/x${A}/true/;s/x${B}/false/;1q"`
+  ],
+  [ge],[
+    ax_compare_version=`echo "x$A
+x$B" | sed 's/^ *//' | sort -r | sed "s/x${A}/true/;s/x${B}/false/;1q"`
+  ],[
+    dnl Split the operator from the subversion count if present.
+    m4_bmatch(m4_substr($2,2),
+    [0],[
+      # A count of zero means use the length of the shorter version.
+      # Determine the number of characters in A and B.
+      ax_compare_version_len_A=`echo "$A" | $AWK '{print(length)}'`
+      ax_compare_version_len_B=`echo "$B" | $AWK '{print(length)}'`
+
+      # Set A to no more than B's length and B to no more than A's length.
+      A=`echo "$A" | sed "s/\(.\{$ax_compare_version_len_B\}\).*/\1/"`
+      B=`echo "$B" | sed "s/\(.\{$ax_compare_version_len_A\}\).*/\1/"`
+    ],
+    [[0-9]+],[
+      # A count greater than zero means use only that many subversions
+      A=`echo "$A" | sed "s/\(\([[0-9]]\{4\}\)\{m4_substr($2,2)\}\).*/\1/"`
+      B=`echo "$B" | sed "s/\(\([[0-9]]\{4\}\)\{m4_substr($2,2)\}\).*/\1/"`
+    ],
+    [.+],[
+      AC_WARNING(
+        [invalid OP numeric parameter: $2])
+    ],[])
+
+    # Pad zeros at end of numbers to make same length.
+    ax_compare_version_tmp_A="$A`echo $B | sed 's/./0/g'`"
+    B="$B`echo $A | sed 's/./0/g'`"
+    A="$ax_compare_version_tmp_A"
+
+    # Check for equality or inequality as necessary.
+    m4_case(m4_tolower(m4_substr($2,0,2)),
+    [eq],[
+      test "x$A" = "x$B" && ax_compare_version=true
+    ],
+    [ne],[
+      test "x$A" != "x$B" && ax_compare_version=true
+    ],[
+      AC_WARNING([invalid OP parameter: $2])
+    ])
+  ])
+
+  AS_VAR_POPDEF([A])dnl
+  AS_VAR_POPDEF([B])dnl
+
+  dnl # Execute ACTION-IF-TRUE / ACTION-IF-FALSE.
+  if test "$ax_compare_version" = "true" ; then
+    m4_ifvaln([$4],[$4],[:])dnl
+    m4_ifvaln([$5],[else $5])dnl
+  fi
+]) dnl AX_COMPARE_VERSION


### PR DESCRIPTION
This version packs the cython test into a function.

The major change is that this version looks for variations on the
cython binary name that contain the python version string that
we detected. That way we don't need to hard code various python
version suffixes for cython. Also, we avoid the issue that there
may potentially be multiple different cython's installed for
multiple versions of Python at the same time (e.g. cython3.6 and
cython3.8 at the same time). This patch makes sure that we don't
pick the cython for the wrong version of python.

Also we run the cython version check in the feature check for
each cython that we find, not just the first one. That is minor
improvement as well.
