### PR TITLE
add pre-push test to verify make dist does not depend on cython

### DIFF
--- a/.github/workflows/test-make-dist-nocython.yaml
+++ b/.github/workflows/test-make-dist-nocython.yaml
@@ -1,0 +1,22 @@
+name: Test "make dist r7"
+
+on:
+  push:
+    branches: [ OVIS-4 ]
+  pull_request:
+    branches: [ OVIS-4 ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - run: sudo apt install gettext
+    - uses: actions/checkout@v2
+    - name: autogen
+      run: sh autogen.sh
+    - name: configure
+      run: ./configure
+    - name: make dist
+      run: make dist


### PR DESCRIPTION
This action file (when connected) will verify that 'make dist' is not broken for rhel7/vanilla toss3.