### PR TITLE
Make the python & cython autoconf checks optional by default

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -12,8 +12,6 @@ jobs:
 
     steps:
     - run: sudo apt install gettext
-    - name: cython
-      run: sudo pip3 install Cython
     - uses: actions/checkout@v2
     # actions/checkout@v2 breaks annotated tags by converting them into
     # lightweight tags, so we need to force fetch the tag again

--- a/.github/workflows/test-make-dist.yaml
+++ b/.github/workflows/test-make-dist.yaml
@@ -13,8 +13,6 @@ jobs:
 
     steps:
     - run: sudo apt install gettext
-    - name: cython
-      run: sudo pip3 install Cython
     - uses: actions/checkout@v2
     - name: autogen
       run: sh autogen.sh

--- a/configure.ac
+++ b/configure.ac
@@ -43,9 +43,6 @@ AC_ARG_VAR([BISON], [bison command])
 AC_CHECK_PROG([BISON], [bison -y], [bison -y], [no])
 AS_IF([test "x$BISON" = "xno"], [AC_MSG_ERROR([bison not found])])
 
-dnl check for python interpreter
-AM_PATH_PYTHON([3.6])
-
 dnl Checks for programs
 AC_PROG_CXX
 dnl Checks for typedefs, structures, and compiler characteristics.
@@ -401,13 +398,6 @@ AC_SUBST(OVIS_AUTH_LIBS)
 LDMSD_PLUGIN_LIBPATH=${pkglibdir}
 AC_SUBST(LDMSD_PLUGIN_LIBPATH)
 
-dnl making --disable-python an alias of --disable-ldms-python
-dnl ENABLE_LDMS_PYTHON_TRUE only if neither --disable-python nor
-dnl --disable-ldms-python are given.
-OPTION_DEFAULT_ENABLE([ldms-python], [ENABLE_LDMS_PYTHON])
-OPTION_DEFAULT_ENABLE([python], [ENABLE_PYTHON_OPT])
-AM_CONDITIONAL([ENABLE_PYTHON], [test -z "${ENABLE_LDMS_PYTHON_TRUE}" -a -z "${ENABLE_PYTHON_OPT_TRUE}"])
-
 dnl Check for pthread support
 AC_CHECK_LIB(pthread, pthread_mutex_init, [],
     AC_MSG_ERROR([pthread library not found.  ldms requires libpthread.]))
@@ -551,31 +541,44 @@ if test -z "$ENABLE_SOS_TRUE"; then
 	fi
 fi
 
-AC_ARG_VAR([CYTHON], [Cython compiler command])
-dnl CYTHON_CHECK(CYTHON_MIN_VERSION, PYTHON_VERSION)
-AC_DEFUN([CYTHON_CHECK],
-[cython_min_version=$1
- python_version=$2
- AC_CACHE_CHECK([for a version of Cython >= ${cython_min_version}],
-		[ac_cv_path_CYTHON],
-		[AC_PATH_PROGS_FEATURE_CHECK([CYTHON],
-			[cython-${python_version} cython${python_version} cython],
-			[cython_version=$(${ac_path_CYTHON} --version 2>&1 | sed -e 's/.*\s//')
-			 AX_COMPARE_VERSION([${cython_version}],[ge],[$cython_min_version],
-			[ac_cv_path_CYTHON=$ac_path_CYTHON ac_path_CYTHON_found=:])],
-			[AC_MSG_ERROR([not found])])])
- AC_SUBST([CYTHON], [$ac_cv_path_CYTHON])
-])
+AC_ARG_ENABLE([python],
+	[AS_HELP_STRING([--disable-python], [disable the LDMS python API])],
+	[want_python=$enableval],
+	[want_python="check"])
+dnl --disable-ldms-python is deprecated, and we should remove it in 5.X
+AC_ARG_ENABLE([ldms-python],
+	[AS_HELP_STRING([--disable-ldms-python], [disable the LDMS python API (deprecated)])],
+	[want_python=$enableval])
 
-dnl ldms-python API's and programs
-AS_IF([test "x$enable_python" != xno], [
-	AX_PYTHON_DEVEL([>='3.6'])
-	pkgpythondir="${pythondir}/ovis_ldms"
-	pkgpyexecdir="${pkgpythondir}"
-	AX_PYTHON_MODULE_VERSION(["argparse"], 1.1, "python")
-	CYTHON_CHECK([0.25], $PYTHON_VERSION)
+AC_ARG_VAR([CYTHON], [Cython compiler command])
+
+dnl ldms's python APIs and programs
+dnl We make the assumption that if AM_PATH_PYTHON succeeds, that AX_PYTHON_DEVEL
+dnl is very likely to succeed as well.
+python_found=false
+cython_found=false
+AS_IF([test "x$want_python" != xno], [
+	AM_PATH_PYTHON([3.6],
+		[AX_PYTHON_DEVEL([>='3.6'])
+		 pkgpythondir="${pythondir}/ovis_ldms"
+		 pkgpyexecdir="${pkgpythondir}"
+		 AX_PYTHON_MODULE_VERSION(["argparse"], 1.1, "python")
+		 python_found=true
+		 CYTHON_CHECK([0.25], [$PYTHON_VERSION],
+		 	[cython_found=true], [cython_found=false])],
+		[python_found=false
+		 cython_found=false])
+
+	AS_IF([test "$python_found" = false],
+		[AS_IF([test "x$want_python" = xyes],
+			[AC_MSG_ERROR([python not found])],
+			[AC_MSG_WARN([python not found])])])
+	AS_IF([test "$cython_found" = false],
+		[AS_IF([test "x$want_python" = xyes],
+			[AC_MSG_ERROR([cython not found])],
+			[AC_MSG_WARN([cython not found])])])
 ])
-AM_CONDITIONAL([HAVE_PYTHON], [test "$PYTHON" != :])
+AM_CONDITIONAL([ENABLE_PYTHON], [test "$python_found" = true -a "$cython_found" = true])
 
 OPTION_WITH_PORT([LDMSD],[411])
 

--- a/ldms/python/.gitignore
+++ b/ldms/python/.gitignore
@@ -1,0 +1,2 @@
+/ldms_pyx.c
+/cython_debug

--- a/ldms/python/Makefile.am
+++ b/ldms/python/Makefile.am
@@ -22,10 +22,13 @@ ldms_la_CFLAGS = -g -O0  $(PY_INCLUDES) $(PYTHON_CPPFLAGS)
 ldms_la_LDFLAGS = $(PYTHON_LDFLAGS) -module -shared
 ldms_la_LIBADD = $(top_builddir)/ldms/src/core/libldms.la
 
-
-
 $(LDMS_PYX_C): ldms.pyx ldms.pxd
 	echo PYTHON_LDFLAGS are "$(PYTHON_LDFLAGS)"
 	$(CYTHON) -3 --directive language_level=3 --fast-fail --gdb -I $(srcdir) $< -o $@
 
 SUBDIRS = ldmsd cmds
+
+CLEANFILES = $(LDMS_PYX_C)
+
+clean-local:
+	-rm -rf cython_debug

--- a/m4/cython_check.m4
+++ b/m4/cython_check.m4
@@ -1,0 +1,37 @@
+# SYNOPSIS
+#
+#   CYTHON_CHECK([CYTHON_MIN_VERSION], [PYTHON_VERSION], [action-if-found], [action-if-not-found])
+#
+# DESCRIPTION
+#
+#   Look for variations on the cython binary name, including ones
+#   that contain the PYTHON_VESRION parameter. For instance,
+#   if PYTHON_VERSION is 3.6, look for cython-3.6, cython3.6, and cython
+#   in that order. Each found binary is feature checked to determine
+#   if its Cython version is greater than or equal to the supplied
+#   CYTHON_MIN_VESRION parameter. The serach stops on the first binary
+#   that meets this critia.
+#
+#   If this macro is successful, It will AC_SUBST the variable CYTHON
+#   with the full path to the discovered binary. Also, "action-if-found"
+#   is executed if supplied. If the macro fails to find cython,
+#   "action-if-not-found" is executed if supplied.
+
+AC_DEFUN([CYTHON_CHECK],[
+ cython_min_version=$1
+ python_version=$2
+ found=false
+ AC_CACHE_CHECK([for a version of Cython >= ${cython_min_version}],
+               [ac_cv_path_CYTHON],
+               [AC_PATH_PROGS_FEATURE_CHECK([CYTHON],
+                       [cython-${python_version} cython${python_version} cython],
+                       [cython_version=$(${ac_path_CYTHON} --version 2>&1 | sed -e 's/.*\s//')
+                        AX_COMPARE_VERSION([${cython_version}],[ge],[$cython_min_version],
+                       [ac_cv_path_CYTHON=$ac_path_CYTHON ac_path_CYTHON_found=:
+		        found=true])],
+                       [found=false])])
+ AS_IF([test "$found" = "true"],
+	[AC_SUBST([CYTHON], [$ac_cv_path_CYTHON])
+	 m4_ifnblank([$3],[$3],[[:]])],
+	[m4_ifnblank([$4],[$4],[[:]])])
+])


### PR DESCRIPTION
Make the python & cython autoconf checks optional by default.
Also allow python & cython to be required with --enable-python,
and disabled with --disable-python.

It turns out that the AX_PYTHON_DEVEL macro is dependent on the
AM_PATH_PYTHON macro. While the AX_PYTHON_DEVEL macro does not
have action-if-found/-not-found options, the AM_PATH_PYTHON macro
does. While it this still allows that AM_PATH_PYTHON can succeed
and AX_PYTHON_DEVEL can fail, in most instances this won't be
the case.

The CYTHON_CHECK macro is upgraded to have action-if-found and
action-if-not-found options. Also the macro is moved into its
own file in the m4 directory.

Since the cython check is now conditional, we remove the special
cython handling from the make dist and create release workflows.