### PR TITLE
update ldms-static-tests.sh for new plugin:port:host syntax

### DIFF
--- a/ldms/man/ldms-static-test.man
+++ b/ldms/man/ldms-static-test.man
@@ -194,6 +194,11 @@ XPRT
 .br
 The transport used. It may be specified in the environment to override
 the default 'sock', and it is exported to the executed daemon environment.
+.TP
+HOST
+.br
+The host name used for a specific interface. It may be specified in the environment to override
+the default 'localhost', and it is exported to the executed daemon environment.
 
 .SH NOTES
 Any other variable may be defined and exported for use in the attribute/value

--- a/ldms/scripts/examples/aggl2.2
+++ b/ldms/scripts/examples/aggl2.2
@@ -1,4 +1,4 @@
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=1000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=1000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/aggl2.3
+++ b/ldms/scripts/examples/aggl2.3
@@ -1,4 +1,4 @@
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=1000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=1000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/aggl2.4
+++ b/ldms/scripts/examples/aggl2.4
@@ -1,10 +1,10 @@
 load name=${storename}
 config name=${storename} path=${STOREDIR} altheader=0
 
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=1000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=1000000
 prdcr_start name=localhost2
 
-prdcr_add name=localhost3 host=localhost type=active xprt=${XPRT} port=${port3} interval=1000000
+prdcr_add name=localhost3 host=${HOST} type=active xprt=${XPRT} port=${port3} interval=1000000
 prdcr_start name=localhost3
 
 updtr_add name=allhosts interval=1000000 offset=200000

--- a/ldms/scripts/examples/aggl2simple.2
+++ b/ldms/scripts/examples/aggl2simple.2
@@ -1,4 +1,4 @@
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=1000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=1000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/aggl2simple.3
+++ b/ldms/scripts/examples/aggl2simple.3
@@ -1,6 +1,6 @@
 load name=${storename}
 config name=${storename} path=${STOREDIR} altheader=0
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=1000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=1000000
 prdcr_start name=localhost2
 
 updtr_add name=allhosts interval=1000000 offset=200000

--- a/ldms/scripts/examples/conf_csv.1
+++ b/ldms/scripts/examples/conf_csv.1
@@ -1,7 +1,7 @@
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=2000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=2000000
 prdcr_start name=localhost2
 
-prdcr_add name=localhost3 host=localhost type=active xprt=${XPRT} port=${port3} interval=2000000
+prdcr_add name=localhost3 host=${HOST} type=active xprt=${XPRT} port=${port3} interval=2000000
 prdcr_start name=localhost3
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/conf_file_csv.1
+++ b/ldms/scripts/examples/conf_file_csv.1
@@ -1,7 +1,7 @@
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=2000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=2000000
 prdcr_start name=localhost2
 
-prdcr_add name=localhost3 host=localhost type=active xprt=${XPRT} port=${port3} interval=2000000
+prdcr_add name=localhost3 host=${HOST} type=active xprt=${XPRT} port=${port3} interval=2000000
 prdcr_start name=localhost3
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/csvcheckattrs.2
+++ b/ldms/scripts/examples/csvcheckattrs.2
@@ -1,6 +1,6 @@
 load name=store_csv
 config name=store_csv path=${STOREDIR} altheader=0 bogon=2
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/fail_sampler_procnetdev.2
+++ b/ldms/scripts/examples/fail_sampler_procnetdev.2
@@ -5,7 +5,7 @@ start name=${plugname} interval=1000000 offset=0
 ## load name=store_csv
 ## config name=store_csv path=${STOREDIR} altheader=0
 ## 
-## prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=1000000
+## prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=1000000
 ## prdcr_start name=localhost1
 ## 
 ## updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/filesingle.2
+++ b/ldms/scripts/examples/filesingle.2
@@ -5,7 +5,7 @@ start name=${testname} interval=1000000 offset=0
 load name=store_csv
 config name=store_csv path=${STOREDIR} altheader=0
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=2000000 offset=100000

--- a/ldms/scripts/examples/ibnet.2
+++ b/ldms/scripts/examples/ibnet.2
@@ -1,7 +1,7 @@
 load name=store_csv
 config name=store_csv path=${STOREDIR} altheader=1 typeheader=2 ietfcsv=1 userdata=0
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=5000000 offset=2000000

--- a/ldms/scripts/examples/lnet_stats.3
+++ b/ldms/scripts/examples/lnet_stats.3
@@ -2,10 +2,10 @@ load name=${plugname}
 config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i}
 start name=${plugname} interval=1000000 offset=0
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=1000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=1000000
 prdcr_start name=localhost1
 
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=1000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=1000000
 prdcr_start name=localhost2
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/loadavg.1
+++ b/ldms/scripts/examples/loadavg.1
@@ -5,13 +5,13 @@ start name=${testname} interval=1000000 offset=0
 load name=store_csv
 config name=store_csv path=${STOREDIR} altheader=0
 
-prdcr_add name=localhost4 host=localhost type=active xprt=${XPRT} port=${port4} interval=2000000
+prdcr_add name=localhost4 host=${HOST} type=active xprt=${XPRT} port=${port4} interval=2000000
 prdcr_start name=localhost4
 
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=2000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=2000000
 prdcr_start name=localhost2
 
-prdcr_add name=localhost3 host=localhost type=active xprt=${XPRT} port=${port3} interval=2000000
+prdcr_add name=localhost3 host=${HOST} type=active xprt=${XPRT} port=${port3} interval=2000000
 prdcr_start name=localhost3
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/lustre2_client.3
+++ b/ldms/scripts/examples/lustre2_client.3
@@ -1,7 +1,7 @@
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=1000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=1000000
 prdcr_start name=localhost1
 
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=1000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=1000000
 prdcr_start name=localhost2
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/many.1
+++ b/ldms/scripts/examples/many.1
@@ -1,7 +1,7 @@
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=2000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=2000000
 prdcr_start name=localhost2
 
-prdcr_add name=localhost3 host=localhost type=active xprt=${XPRT} port=${port3} interval=2000000
+prdcr_add name=localhost3 host=${HOST} type=active xprt=${XPRT} port=${port3} interval=2000000
 prdcr_start name=localhost3
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/procnetdev.2
+++ b/ldms/scripts/examples/procnetdev.2
@@ -5,7 +5,7 @@ start name=${testname} interval=1000000 offset=0
 load name=store_csv
 config name=store_csv path=${STOREDIR} altheader=0
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=1000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=1000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/procstat.3
+++ b/ldms/scripts/examples/procstat.3
@@ -2,10 +2,10 @@ load name=${testname}
 config name=${testname} producer=localhost${i} schema=${testname}_auto instance=localhost${i}/${testname}ideviant component_id=${i}
 start name=${testname} interval=1000000 offset=0
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
 prdcr_start name=localhost1
 
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=2000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=2000000
 prdcr_start name=localhost2
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/prolog.jobid.store3
+++ b/ldms/scripts/examples/prolog.jobid.store3
@@ -1,10 +1,10 @@
 load name=store_csv
 config name=store_csv path=${STOREDIR} altheader=0
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
 prdcr_start name=localhost1
 
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=10000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=10000000
 prdcr_start name=localhost2
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/prolog.store2
+++ b/ldms/scripts/examples/prolog.store2
@@ -1,7 +1,7 @@
 load name=store_csv
 config name=store_csv path=${STOREDIR} altheader=1 typeheader=2 ietfcsv=1 userdata=1
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/prolog.store2.sos
+++ b/ldms/scripts/examples/prolog.store2.sos
@@ -1,7 +1,7 @@
 load name=store_sos
 config name=store_sos path=${STOREDIR}
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/prolog.store2_rename
+++ b/ldms/scripts/examples/prolog.store2_rename
@@ -1,7 +1,7 @@
 load name=store_csv
 config name=store_csv path=${STOREDIR} altheader=0 rollover=2 rolltype=1 rename_template=${STOREDIR}/%{HOSTNAME}/%B
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/prolog.store3
+++ b/ldms/scripts/examples/prolog.store3
@@ -1,10 +1,10 @@
 load name=store_csv
 config name=store_csv path=${STOREDIR} altheader=0
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
 prdcr_start name=localhost1
 
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=10000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=10000000
 prdcr_start name=localhost2
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/rabbitkw.1
+++ b/ldms/scripts/examples/rabbitkw.1
@@ -1,7 +1,7 @@
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=2000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=2000000
 prdcr_start name=localhost2
 
-prdcr_add name=localhost3 host=localhost type=active xprt=${XPRT} port=${port3} interval=2000000
+prdcr_add name=localhost3 host=${HOST} type=active xprt=${XPRT} port=${port3} interval=2000000
 prdcr_start name=localhost3
 
 updtr_add name=allhosts interval=1000000 offset=100000
@@ -9,7 +9,7 @@ updtr_prdcr_add name=allhosts regex=.*
 updtr_start name=allhosts
 
 load name=store_rabbitkw
-config name=store_rabbitkw useserver=y routing_key=ldms.$cluster host=localhost port=5672 exchange=amq.topic vhost=/ user=guest pwfile=${AUTHFILE} extraprops=y logmsg=n retry=3 timeout=2000
+config name=store_rabbitkw useserver=y routing_key=ldms.$cluster host=${HOST} port=5672 exchange=amq.topic vhost=/ user=guest pwfile=${AUTHFILE} extraprops=y logmsg=n retry=3 timeout=2000
 
 strgp_add name=rabbit_meminfo plugin=store_rabbitkw schema=meminfo container=bigiron
 strgp_prdcr_add name=rabbit_meminfo regex=.*

--- a/ldms/scripts/examples/rabbitkwl2.1
+++ b/ldms/scripts/examples/rabbitkwl2.1
@@ -1,4 +1,4 @@
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=1000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=1000000
 prdcr_start name=localhost2
 
 updtr_add name=allhosts interval=1000000 offset=200000
@@ -6,8 +6,8 @@ updtr_prdcr_add name=allhosts regex=.*
 updtr_start name=allhosts
 
 load name=store_rabbitkw
-# config name=store_rabbitkw useserver=y routing_key=ldms.kodiak host=localhost port=5672 exchange=amq.topic vhost=/ user=guest pwfile=${AUTHFILE} extraprops=y logmsg=n retry=3 timeout=2000
-config name=store_rabbitkw useserver=y routing_key=ldms.kodiak host=localhost port=5672 exchange=amq.topic vhost=/ user=guest pwfile=${AUTHFILE} extraprops=y logmsg=n
+# config name=store_rabbitkw useserver=y routing_key=ldms.kodiak host=${HOST} port=5672 exchange=amq.topic vhost=/ user=guest pwfile=${AUTHFILE} extraprops=y logmsg=n retry=3 timeout=2000
+config name=store_rabbitkw useserver=y routing_key=ldms.kodiak host=${HOST} port=5672 exchange=amq.topic vhost=/ user=guest pwfile=${AUTHFILE} extraprops=y logmsg=n
 
 strgp_add name=rabbit_meminfo plugin=store_rabbitkw schema=meminfo container=bigiron
 strgp_prdcr_add name=rabbit_meminfo regex=.*

--- a/ldms/scripts/examples/rabbitl2remote.1
+++ b/ldms/scripts/examples/rabbitl2remote.1
@@ -1,4 +1,4 @@
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=1000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=1000000
 prdcr_start name=localhost2
 
 updtr_add name=allhosts interval=1000000 offset=200000
@@ -6,7 +6,7 @@ updtr_prdcr_add name=allhosts regex=.*
 updtr_start name=allhosts
 
 load name=store_rabbitkw
-config name=store_rabbitkw useserver=y routing_key=ldms.kodiak host=localhost port=5672 exchange=amq.topic vhost=/ user=guest pwfile=${AUTHFILE} extraprops=y logmsg=n retry=1 timeout=2000
+config name=store_rabbitkw useserver=y routing_key=ldms.kodiak host=${HOST} port=5672 exchange=amq.topic vhost=/ user=guest pwfile=${AUTHFILE} extraprops=y logmsg=n retry=1 timeout=2000
 
 
 strgp_add name=rabbit_meminfo plugin=store_rabbitkw schema=meminfo container=bigiron

--- a/ldms/scripts/examples/rabbitv3.1
+++ b/ldms/scripts/examples/rabbitv3.1
@@ -1,7 +1,7 @@
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=2000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=2000000
 prdcr_start name=localhost2
 
-prdcr_add name=localhost3 host=localhost type=active xprt=${XPRT} port=${port3} interval=2000000
+prdcr_add name=localhost3 host=${HOST} type=active xprt=${XPRT} port=${port3} interval=2000000
 prdcr_start name=localhost3
 
 updtr_add name=allhosts interval=1000000 offset=100000
@@ -9,7 +9,7 @@ updtr_prdcr_add name=allhosts regex=.*
 updtr_start name=allhosts
 
 load name=store_rabbitv3
-config name=store_rabbitv3 usemeta=y metainterval=3 host=localhost port=5672 exchange=amq.topic vhost=priv user=peter pwfile=${AUTHFILE}
+config name=store_rabbitv3 usemeta=y metainterval=3 host=${HOST} port=5672 exchange=amq.topic vhost=priv user=peter pwfile=${AUTHFILE}
 
 strgp_add name=rabbit_meminfo plugin=store_rabbitv3 schema=meminfo container=bigiron
 strgp_prdcr_add name=rabbit_meminfo regex=.*

--- a/ldms/scripts/examples/rollagain.2
+++ b/ldms/scripts/examples/rollagain.2
@@ -1,7 +1,7 @@
 load name=store_csv
 config name=store_csv path=${STOREDIR} altheader=0 rollover=5 rollagain=10 rolltype=5 rename_template=${STOREDIR}/%{HOSTNAME}/%B
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/sequence_unsupp.2
+++ b/ldms/scripts/examples/sequence_unsupp.2
@@ -6,7 +6,7 @@ load name=store_csv
 #config name=store_csv path=${STOREDIR} altheader=0 container=node1
 config name=store_csv schema=${sampler} path=${STOREDIR} altheader=1 container=node2 id_pos=1 sequence=reverse
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/sequence_unsupp.3
+++ b/ldms/scripts/examples/sequence_unsupp.3
@@ -6,7 +6,7 @@ load name=store_csv
 #config name=store_csv action=init path=${STOREDIR} altheader=0 container=node4
 config name=store_csv schema=${sampler} path=${STOREDIR} altheader=1 container=node5 id_pos=0 sequence=forward
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/sequence_unsupp.4
+++ b/ldms/scripts/examples/sequence_unsupp.4
@@ -6,7 +6,7 @@ load name=store_csv
 #config name=store_csv action=init path=${STOREDIR} altheader=0 container=node7
 config name=store_csv schema=${sampler} path=${STOREDIR} altheader=1 container=node8
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/setclones.2
+++ b/ldms/scripts/examples/setclones.2
@@ -2,7 +2,7 @@
 load name=store_csv
 config name=store_csv path=${STOREDIR} altheader=0
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/shm.3
+++ b/ldms/scripts/examples/shm.3
@@ -1,10 +1,10 @@
 load name=store_csv
 config name=store_csv path=${STOREDIR} altheader=0
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
 prdcr_start name=localhost1
 
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=10000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=10000000
 prdcr_start name=localhost2
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/strict_kill.2
+++ b/ldms/scripts/examples/strict_kill.2
@@ -5,7 +5,7 @@ start name=${testname} interval=1000000 offset=0
 load name=store_csv
 config name=store_csv path=${STOREDIR} altheader=0
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=2000000 offset=100000

--- a/ldms/scripts/examples/variable.3
+++ b/ldms/scripts/examples/variable.3
@@ -1,7 +1,7 @@
 load name=store_csv
 config name=store_csv path=${STOREDIR} altheader=0
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/vg_csv.1
+++ b/ldms/scripts/examples/vg_csv.1
@@ -2,10 +2,10 @@ load name=dstat
 config name=dstat producer=localhost${i} instance=localhost${i}/dstat schema=dstat component_id=${i} udata_default=${i}
 start name=dstat interval=1000000 offset=0
 
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=2000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=2000000
 prdcr_start name=localhost2
 
-prdcr_add name=localhost3 host=localhost type=active xprt=${XPRT} port=${port3} interval=2000000
+prdcr_add name=localhost3 host=${HOST} type=active xprt=${XPRT} port=${port3} interval=2000000
 prdcr_start name=localhost3
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/vg_sos.1
+++ b/ldms/scripts/examples/vg_sos.1
@@ -2,10 +2,10 @@ load name=dstat
 config name=dstat producer=localhost${i} instance=localhost${i}/dstat schema=dstat component_id=${i} udata_default=${i}
 start name=dstat interval=1000000 offset=0
 
-prdcr_add name=localhost2 host=localhost type=active xprt=${XPRT} port=${port2} interval=2000000
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=2000000
 prdcr_start name=localhost2
 
-prdcr_add name=localhost3 host=localhost type=active xprt=${XPRT} port=${port3} interval=2000000
+prdcr_add name=localhost3 host=${HOST} type=active xprt=${XPRT} port=${port3} interval=2000000
 prdcr_start name=localhost3
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/vmstat.2
+++ b/ldms/scripts/examples/vmstat.2
@@ -5,7 +5,7 @@ start name=${testname} interval=1000000 offset=0
 load name=store_csv
 config name=store_csv path=${STOREDIR} altheader=0
 
-prdcr_add name=localhost1 host=localhost type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/xprt_fabric
+++ b/ldms/scripts/examples/xprt_fabric
@@ -1,0 +1,32 @@
+export plugname=meminfo
+portbase=408
+# export XPRT=sock
+# export HOST=localhost
+export XPRT=fabric
+# find the ib0 interface hostname
+export HOST=$(for ia in $(ifconfig -a |grep 'inet ' | awk '{ print $2}'); do grep $ia /etc/hosts |grep ib0 |grep '^[0-9]' ; done | awk '{ print $2}')
+DAEMONS 1 2 3
+LDMSD -p prolog.sampler 1
+#GDB=1
+#VGARGS="--trace-children=yes --track-origins=yes --leak-check=full --show-leak-kinds=all"
+vgon
+LDMSD -p prolog.store2 2
+vgoff
+LDMSD 3
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1 -v
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2 -v
+netstat -alt
+netstat -tonp
+SLEEP 5
+export PORT=413
+LDMS_LS 1 -v
+export PORT=409
+vgoff
+LDMS_LS 1 -v
+vgoff
+SLEEP 5
+KILL_LDMSD 1 2 3
+file_created $STOREDIR/node/$testname
+chown -R baallan.baallan ldmstest

--- a/ldms/scripts/examples/xprt_fabric.1
+++ b/ldms/scripts/examples/xprt_fabric.1
@@ -1,0 +1,2 @@
+
+listen xprt=fabric port=413 host=${HOST}

--- a/ldms/scripts/examples/xprt_fabric.3
+++ b/ldms/scripts/examples/xprt_fabric.3
@@ -1,11 +1,10 @@
 load name=${plugname}
-config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} disks=/dev/sda1
+config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i}
 start name=${plugname} interval=1000000 offset=0
-
 load name=store_csv
-config name=store_csv path=${STOREDIR} altheader=0
+config name=store_csv path=/tmp/stest altheader=1 typeheader=2 ietfcsv=1 userdata=1
 
-prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=1000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=413 interval=10000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/xprt_fabric2
+++ b/ldms/scripts/examples/xprt_fabric2
@@ -1,0 +1,36 @@
+export plugname=meminfo
+portbase=408
+# export XPRT=sock
+# export HOST=localhost
+export XPRT=fabric
+export HOST=$(for ia in $(ifconfig -a |grep 'inet ' | awk '{ print $2}'); do grep $ia /etc/hosts |grep ib0 |grep '^[0-9]' ; done | awk '{ print $2}')
+DAEMONS 1 2 3
+#eth omni mlx
+export LDMSD_EXTRA="-x fabric:420:$(HOSTNAME) -x fabric:421:$HOST"
+LDMSD -p prolog.sampler 1
+#GDB=1
+#VGARGS="--leak-check=full --show-leak-kinds=all"
+#VGARGS="--trace-children=yes --track-origins=yes --leak-check=full --show-leak-kinds=all"
+vgoff
+LDMSD -p prolog.store2 2
+vgoff
+LDMSD 3
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1 -v
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2 -v
+netstat -alt
+netstat -tonp
+SLEEP 5
+export PORT=420
+export HOST=c1xln1
+MESSAGE sock on fab
+LDMS_LS 1 -v
+MESSAGE omni on fab
+export PORT=421
+export HOST=c1xln1-ib0
+LDMS_LS 1 -v
+vgoff
+KILL_LDMSD 1 2 3
+file_created $STOREDIR/node/$testname
+chown -R baallan.baallan ldmstest

--- a/ldms/scripts/examples/xprt_fabric2.1
+++ b/ldms/scripts/examples/xprt_fabric2.1
@@ -1,0 +1,2 @@
+
+listen xprt=fabric port=413 host=${HOST}

--- a/ldms/scripts/examples/xprt_fabric2.3
+++ b/ldms/scripts/examples/xprt_fabric2.3
@@ -1,11 +1,10 @@
 load name=${plugname}
-config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} disks=/dev/sda1
+config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i}
 start name=${plugname} interval=1000000 offset=0
-
 load name=store_csv
-config name=store_csv path=${STOREDIR} altheader=0
+config name=store_csv path=/tmp/stest altheader=1 typeheader=2 ietfcsv=1 userdata=1
 
-prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=1000000
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=413 interval=10000000
 prdcr_start name=localhost1
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/ldms-static-test.sh.in
+++ b/ldms/scripts/ldms-static-test.sh.in
@@ -108,7 +108,12 @@ if test -z "$2"; then
 fi
 export TESTDIR
 
+if test -z "$HOST"; then
+	# used for ldms_ls
+	export HOST=localhost
+fi
 if test -z "$XPRT"; then
+	# used for ldms_ls and ldmsd
 	export XPRT=sock
 fi
 declare -a ports
@@ -219,15 +224,19 @@ function LDMSD {
 				XVG=$VG
 			fi
 			if test -z "$VGARGS"; then
-				XVGARGS="-v --trace-children=yes --log-file=${LOGDIR}/vg.$i.%p"
+				XVGARGS="-v --log-file=${LOGDIR}/vg.$i.%p"
 			else
-				XVGARGS="-v --trace-children=yes --log-file=${LOGDIR}/vg.$i.%p $VGARGS"
+				XVGARGS="-v --log-file=${LOGDIR}/vg.$i.%p $VGARGS"
 			fi
 			wrap="$XVG $XVGARGS"
 		else
 			wrap=""
 		fi
 		echo starting daemon $i
+		# set -x
+		if test -n "$HOST"; then
+			XPRTHOST=":$HOST"
+		fi
 		if test -f $input.$i -a -r $input.$i; then
 			echo "# generated from $input" > $LDMSD_RUN/conf.$i
 			for lf in $loopprologs; do
@@ -251,27 +260,35 @@ function LDMSD {
 			echo "# generated from $input.$i" >> $LDMSD_RUN/conf.$i
 			cat $input.$i >> $LDMSD_RUN/conf.$i
 			clonefile=$LDMSD_RUN/conf.$i
-			$wrap ldmsd.${ports[$i]} \
-				-x ${XPRT}:${ports[$i]} \
-				-c $LDMSD_RUN/conf.$i \
-				-l ${LOGDIR}/$i.txt \
-				-v DEBUG $LDMSD_EXTRA \
-				-r $LDMSD_PIDFILE.$i
+			env > $LDMSD_RUN/env.$i
+			if test -n "$GDB"; then
+				echo "run -x ${XPRT}:${ports[$i]}:${XPRTHOST} -c $LDMSD_RUN/conf.$i -l ${LOGDIR}/$i.txt -v DEBUG $LDMSD_EXTRA -r $LDMSD_PIDFILE.$i"
+				gdb ldmsd.${ports[$i]}
+			else
+				$wrap ldmsd.${ports[$i]} \
+					-x ${XPRT}:${ports[$i]}${XPRTHOST} \
+					-c $LDMSD_RUN/conf.$i \
+					-l ${LOGDIR}/$i.txt \
+					-v DEBUG $LDMSD_EXTRA \
+					-r $LDMSD_PIDFILE.$i
+			fi
 		else
 			if test -z "$clonefile"; then
 				echo MISSING input file for DAEMON $i
 			fi
 			if test -f $clonefile -a $cloneinput = "1"; then
 				cp $clonefile $LDMSD_RUN/conf.$i
+				env > $LDMSD_RUN/env.$i
 				$wrap ldmsd.${ports[$i]} \
-					-x ${XPRT}:${ports[$i]} \
+					-x ${XPRT}:${ports[$i]}${XPRTHOST} \
 					-c $LDMSD_RUN/conf.$i \
 					-l ${LOGDIR}/$i.txt \
 					-v DEBUG $LDMSD_EXTRA \
 					-r $LDMSD_PIDFILE.$i
 			else
 				echo IDLE DAEMON $i
-				ldmsd.${ports[$i]} -x ${XPRT}:${ports[$i]} \
+				env > $LDMSD_RUN/env.$i
+				ldmsd.${ports[$i]} -x ${XPRT}:${ports[$i]}${XPRTHOST} \
 					-l ${LOGDIR}/$i.txt \
 					-v DEBUG \
 					-r $LDMSD_PIDFILE.$i
@@ -304,12 +321,16 @@ function LDMS_LS {
 	for i in $nodes; do
 		if test "$usevg" = "1"; then
 			if test -z "$VG"; then
-				VG=valgrind
+				XVG=valgrind
+			else
+				XVG=$VG
 			fi
 			if test -z "$VGARGS"; then
-				VGARGS="-v --log-file=${LOGDIR}/vgls.$i.%p"
+				XVGARGS="-v --log-file=${LOGDIR}/vgls.$i.%p"
+			else
+				XVGARGS="-v --log-file=${LOGDIR}/vgls.$i.%p $VGARGS"
 			fi
-			wrap="$VG $VGARGS"
+			wrap="$XVG $XVGARGS"
 		else
 			wrap=""
 		fi
@@ -318,7 +339,13 @@ function LDMS_LS {
 			bypass=1
 			break;
 		fi
-		$wrap ldms_ls  -h localhost -x sock -p ${ports[$i]} $*
+		if test -n "$PORT"; then
+			iport=$PORT
+		else
+			iport=${ports[$i]}
+		fi
+		echo "ldms_ls  -h $HOST -x $XPRT -p $iport $*"
+		$wrap ldms_ls  -h $HOST -x $XPRT -p $iport $*
 	done
 }
 # KILL_LDMSD num list


### PR DESCRIPTION
ldms_ls and ldmsd require host in some cases of transport specification,
particularly when the fabric transport is in use.

This commit adds xprt specification tests and updates the driver
and scripts to respect a user defined HOST variable in test scripting
instead of assuming localhost.