### PR TITLE
fix test_util.c nits (add sentinel warning, sleep demo)

### DIFF
--- a/lib/src/ovis_util/test_util.c
+++ b/lib/src/ovis_util/test_util.c
@@ -19,6 +19,7 @@ void test_str_repl_cmd()
 	__test_str_repl_cmd("verb opt=$(hostname) opt2=$(hostname)");
 	__test_str_repl_cmd("verb opt=$(echo $PPID) opt2=$(hostname)");
 	__test_str_repl_cmd("verb opt=$(hostname)/bal haha");
+	__test_str_repl_cmd("verb opt=$(sleep 3) opt2=$(hostname)");
 }
 
 void test_av()
@@ -104,7 +105,7 @@ int main(int argc, char **argv)
 		errcnt++;
 	}
 
-	rc = ovis_join_buf(NULL,0,NULL); // empty list
+	rc = ovis_join_buf(NULL,0,NULL,NULL); // empty list
 	if (!rc)  {
 		printf("error 5: ovis_join_buf(NULL,0,NULL) returned something.\n");
 		errcnt++;
@@ -117,21 +118,8 @@ int main(int argc, char **argv)
 			rc, strerror(rc));
 		errcnt++;
 	}
-
-	printf("expect crash soon\n");
-	r = ovis_join(NULL,s1,s2,s3); // unterminated list
-	if (r) {
-		printf("error 7: ovis_join(NULL,s1,s2,s3) returned something\n");
-		printf("error 7: %s\n", r);
-		errcnt++;
-	}
-	free(r);
-
-	rc = ovis_join_buf(NULL,0,s1,s2,s3); // unterminated list
-	if (!rc)  {
-		printf("error 8: ovis_join_buf(NULL,0,s1,s2,s3) returned something.\n");
-		errcnt++;
-	}
+	/* do not test for unterminated list. compiler warning from attribute sentinel
+ 	* warns the user about those. */
 
 	if (errcnt)
 		return 1;

--- a/lib/src/ovis_util/util.c
+++ b/lib/src/ovis_util/util.c
@@ -611,7 +611,7 @@ pid_t ovis_execute(const char *command)
 
 #define DSTRING_USE_SHORT
 #include "dstring.h"
-char *ovis_join(char *pathsep, ...)
+__attribute__ ((sentinel)) char *ovis_join(char *pathsep, ...)
 {
 	va_list ap;
 	char *result = NULL;
@@ -644,7 +644,7 @@ char *ovis_join(char *pathsep, ...)
 	return result;
 }
 
-int ovis_join_buf(char *buf, size_t buflen, char *pathsep, ...)
+__attribute__ ((sentinel)) int ovis_join_buf(char *buf, size_t buflen, char *pathsep, ...)
 {
 	int rc = 0;
 	va_list ap;

--- a/lib/src/ovis_util/util.h
+++ b/lib/src/ovis_util/util.h
@@ -215,7 +215,7 @@ pid_t ovis_execute(const char *command);
  * Example: ovis_join("\\","c:\\root", "file.txt", NULL);
  * \return The resulting string caller must free, or NULL if fail(see errno).
  */
-char *ovis_join(char *joiner, ...);
+__attribute__ ((sentinel)) char *ovis_join(char *joiner, ...);
 
 /**
  * \brief Fill array by joining parts.
@@ -227,7 +227,7 @@ char *ovis_join(char *joiner, ...);
  * Example: ovis_join_buf(buf, 256, "\\","c:\\root", "file.txt", NULL);
  * \return 0 if successful, or errno if input problem detected.
  */
-int ovis_join_buf(char *buf, size_t buflen, char *joiner, ...);
+__attribute__ ((sentinel)) int ovis_join_buf(char *buf, size_t buflen, char *joiner, ...);
 
 /**
  * \brief A convenient function checking if the given \a path exists.


### PR DESCRIPTION
This update allows test_util to run to completion, puts in a test for sleep and other program calls in $( ) popen expansion, and puts in a compiler warning for ovis_join operations which are not null-terminated as required by the header descriptoin.