### PR TITLE
`ldms_init()` returns errno for consistency

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -939,8 +939,9 @@ uint32_t __ldms_set_size_get(struct ldms_set *s)
 int ldms_init(size_t max_size)
 {
 	size_t grain = LDMS_GRAIN_MMALLOC;
-	if (mm_init(max_size, grain))
-		return -1;
+	int rc = mm_init(max_size, grain); /* mm_init() returns errno */
+	if (rc)
+		return rc;
 	return 0;
 }
 

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -194,7 +194,8 @@ typedef struct ldms_schema_s *ldms_schema_t;
  *
  *  Pre-allocate a memory region for metric sets
  *  \param max_size The maximum size of the pre-allocated memory
- *  \return 0 on success
+ *  \retval 0     If success
+ *  \retval errno If error
  */
 int ldms_init(size_t max_size);
 


### PR DESCRIPTION
`ldms_init()` returned `-1` on error, which is inconsistent to other
ldms interfaces. It shall return `errno` for consistency.