### PR TITLE
Fix double-free when LDMS lookup yields multiple sets

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2340,7 +2340,8 @@ static void handle_rendezvous_lookup(zap_ep_t zep, zap_event_t ev,
 		pthread_mutex_lock(&x->lock);
 		goto callback_with_lock;
 	}
-	__ldms_free_ctxt(x, ctxt);
+	if (!lm->lookup.more)
+		__ldms_free_ctxt(x, ctxt);
 	return;
 
  callback:


### PR DESCRIPTION
In some lookup mode, e.g. LOOKUP_RE and LOOKU_BY_SCHEMA, there can be
multiple sets resulting from the lookup operation. The lookup requesting
side shall expect multiple rendezvous messages from this one lookup
request. However, on the requesting side, the lookup request context was
prematurely freed after the first rendezvous message was received, and
the same ctxt was double-freed in the second rendezvous, and so-on.

The `lookup.more` flag in the rendezvous message tells the requesting
side if this is the last rendezvous messgae. It shall be checked, and
the lookup context shall not be freed if more rendezvous messages are
expected.