### PR TITLE
Introduce a build test workflow using a custom CentOS7 container

### DIFF
--- a/.github/workflows/build-test-centos7.yaml
+++ b/.github/workflows/build-test-centos7.yaml
@@ -1,0 +1,19 @@
+name: Build Test - CentOS7
+
+on:
+  push:
+    branches: [ OVIS-4 ]
+  pull_request:
+    branches: [ OVIS-4 ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    container:
+        image: morrone/centos7-ldms-build:latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: sh autogen.sh
+    - run: ./configure
+    - run: make
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,8 @@ config.h
 config.log
 Makefile
 Makefile.in
-configure
-build*
+/configure
+/build*
 /config.h.in
 /config.status
 /ovis-ldms-config.h


### PR DESCRIPTION
This is a first simple build test for ovis/ldms that uses a CentOS7 container that I created and pushed to Docker Hub.

The test just does autogen, configure, and make. We can expand on this over time, expanding this flow and perhaps adding
other build/test workflows as needed. But this perhaps will server as a good starting point for testing builds.

The logic to employ a container in the github workflow is really simple. We just add the following to the job:

```
    container:
        image: morrone/centos7-ldms-build:latest
```

This workflow uses an image that I created using the following Dockerfile:

```
FROM centos:7
RUN yum install -y epel-release && yum update -y && yum install -y \
autoconf \
automake \
libtool \
make \
bison \
flex \
gettext-devel \
libevent-devel \
openssl-devel \
python3-devel \
python36-Cython
```

Eventually the ovis team may wish to set up its own Docker Hub account and containers. But I am happy to maintain this particular container for now. I will at least make sure to not put a broken "latest" tag up for that container, so it should be safe to land this workflow.
