### PR TITLE
Amend LDMS Cython error type

### DIFF
--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -1947,7 +1947,7 @@ cdef class Xprt(object):
                 this function will just be blocked indefinitely.
         """
         if self._conn_cb:
-            raise TypeError("Bad `Xprt.recv()` call. "
+            raise ValueError("Bad `Xprt.recv()` call. "
                     "The callback has been supplied to `connect()`. "
                     "The message will be delivered asynchronously via the "
                     "callback function.")


### PR DESCRIPTION
This patch changes `TypeError` to `ValueError` per @tom95858 code review
in #428. @narategithub forgot to add `-a` when he did `git --amend`.