### PR TITLE
Build system cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ missing
 compile
 py-compile
 /stamp-h1
+/SHA.txt
 
 aclocal.m4
 libtool.m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,8 +48,6 @@ OPV=-$(PACKAGE_VERSION)
 banned:
 	(cd ldms; make banned)
 
-clean-local:
-
 install-data-hook:
 if ENABLE_NOLA
 	$(abs_top_srcdir)/util/nola.sh $(DESTDIR)$(libdir) > nola.log
@@ -65,15 +63,6 @@ if ENABLE_NOLA
 	$(abs_top_srcdir)/util/nola.sh $(DESTDIR)$(libdir) > nola.third-plugins.log
 endif
 endif
-
-install-exec-local:
-	if test -d libevent-2.0.21-stable/lib/ovis-ldms/lib; then \
-		$(MKDIR_P) $(DESTDIR)$(libdir)/ovis-libevent ; \
-		cp -a libevent-2.0.21-stable/lib/ovis-ldms/lib/* $(DESTDIR)$(libdir)/ovis-libevent/ ;\
-		sed -i -e 's%LD_LIBRARY_PATH=.*%LD_LIBRARY_PATH=${libdir}/ovis-libevent:$$LD_LIBRARY_PATH%' \
-			$(DESTDIR)$(bindir)/*.sh ; \
-		/bin/rm -rf $(DESTDIR)$(libdir)/ovis-libevent/pkgconfig ; \
-	fi
 
 SHA.txt:
 	COMMIT=`git rev-parse HEAD 2>/dev/null`; \

--- a/ldms/Makefile.am
+++ b/ldms/Makefile.am
@@ -29,6 +29,8 @@ test/failover-simple/agg1.sh \
 test/failover-simple/agg2.sh \
 test/failover-simple/sampler.sh
 
+docversiondir=$(docdir)$(OPV)
+docversion_DATA=AUTHORS COPYING
 
 install-exec-hook:
 	@echo "*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#"
@@ -82,10 +84,6 @@ endif
 .PHONY: $(PHONY_doc) $(PHONY_dox)
 
 install-data-local: install-dox
-	$(MKDIR_P) $(DESTDIR)$(docdir)$(OPV)
-	for f in AUTHORS COPYING ; do \
-		$(INSTALL_DATA) ${srcdir}/$$f $(DESTDIR)$(docdir)$(OPV); \
-	done
 
 PEDIGREE = $(DESTDIR)/$(bindir)/ldms-pedigree
 
@@ -116,8 +114,5 @@ SHA.txt:
 
 uninstall-hook:
 	rm $(PEDIGREE)
-	for f in AUTHORS COPYING ; do \
-		rm $(DESTDIR)$(docdir)$(OPV)/$$f; \
-	done
 
 clean-local:

--- a/ldms/etc/.gitignore
+++ b/ldms/etc/.gitignore
@@ -1,0 +1,5 @@
+/ldms.plugstack.env
+/ldmsd.aggregator.env
+/ldmsd.kokkos.env
+/ldmsd.sampler.env
+/papi-sampler.env

--- a/ldms/etc/Makefile.am
+++ b/ldms/etc/Makefile.am
@@ -14,62 +14,32 @@ SUBDIRS += systemd
 
 do_subst = @LDMS_SUBST_RULE@
 
-EXTRA_DIST = ldmsauth.conf \
-	     sampler.conf \
-	     papi-sampler.conf \
-	     kokkos.conf \
-	     sampler.conf.cray_xc.example \
-	     aggregator.conf \
-	     aggregator.conf.cray_xc.example \
-	     ldmsd.aggregator.env.in \
-	     ldmsd.aggregator.env.cray_xc.example \
-	     ldmsd.sampler.env.in \
-	     ldmsd.sampler.env.cray_xc.example \
-	     ldmsd.kokkos.env.in \
-	     papi-sampler.env.in \
-	     ldms.plugstack.env.in \
-	     ldms.cfg
+BUILT_FILES = \
+	ldmsd.sampler.env \
+	ldmsd.aggregator.env \
+	ldmsd.kokkos.env \
+	papi-sampler.env \
+	ldms.plugstack.env
+BUILT_FILES_SRC = $(BUILT_FILES:=.in)
 
-ENV_FILES = $(builddir)/ldmsd.sampler.env \
-	    $(builddir)/ldmsd.aggregator.env \
-	    $(builddir)/ldmsd.kokkos.env \
-	    $(builddir)/papi-sampler.env \
-	    $(builddir)/ldms.plugstack.env
+EXTRA_DIST=$(BUILT_FILES_SRC)
 
-EXAMPLE_FILES = $(srcdir)/aggregator.conf.cray_xc.example \
-		$(srcdir)/sampler.conf.cray_xc.example \
-		$(srcdir)/ldmsd.aggregator.env.cray_xc.example \
-		$(srcdir)/ldmsd.sampler.env.cray_xc.example
+sysconfldmsdir=$(sysconfdir)/ldms
+dist_sysconfldms_DATA= \
+	aggregator.conf.cray_xc.example \
+	sampler.conf.cray_xc.example \
+	ldmsd.aggregator.env.cray_xc.example \
+	ldmsd.sampler.env.cray_xc.example \
+	ldmsauth.conf \
+	ldms.cfg \
+	sampler.conf \
+	papi-sampler.conf \
+	aggregator.conf \
+	kokkos.conf
+nodist_sysconfldms_DATA=$(BUILT_FILES)
 
 $(builddir)/%.env: $(srcdir)/%.env.in
 	$(do_subst) < $< > $@
 
-CONF_DIR = $(DESTDIR)$(sysconfdir)/ldms
-
-# These are ldms-specific config
-install-data-local: $(ENV_FILES)
-	$(MKDIR_P) $(CONF_DIR)
-	$(INSTALL_DATA) $(ENV_FILES) $(CONF_DIR)/
-	$(INSTALL) -m 600 $(srcdir)/ldmsauth.conf $(CONF_DIR)
-	$(INSTALL_DATA) $(srcdir)/ldms.cfg $(CONF_DIR)
-	$(INSTALL_DATA) $(srcdir)/sampler.conf $(CONF_DIR)
-	$(INSTALL_DATA) $(srcdir)/papi-sampler.conf $(CONF_DIR)
-	$(INSTALL_DATA) $(srcdir)/aggregator.conf $(CONF_DIR)
-	$(INSTALL_DATA) $(srcdir)/kokkos.conf $(CONF_DIR)
-	$(INSTALL_DATA) $(EXAMPLE_FILES) $(CONF_DIR)/
-
-uninstall-local:
-	rm -f $(CONF_DIR)/ldmsd.aggregator.env
-	rm -f $(CONF_DIR)/ldmsd.sampler.env
-	rm -f $(CONF_DIR)/ldmsd.kokkos.env
-	rm -f $(CONF_DIR)/ldmsauth.conf
-	rm -f $(CONF_DIR)/sampler.conf
-	rm -f $(CONF_DIR)/papi-sampler.conf
-	rm -f $(CONF_DIR)/aggregator.conf
-	rm -f $(CONF_DIR)/kokkos.conf
-	rm -f $(CONF_DIR)/ldms.cfg
-	rm -f $(CONF_DIR)/ldms.plugstack.env
-	rm -f $(CONF_DIR)/aggregator.conf.cray_xc.example
-	rm -f $(CONF_DIR)/sampler.conf.cray_xc.example
-	rm -f $(CONF_DIR)/ldmsd.aggregator.env.cray_xc.example
-	rm -f $(CONF_DIR)/ldmsd.sampler.env.cray_xc.example
+install-data-hook:
+	 chmod 600 $(DESTDIR)$(sysconfldmsdir)/ldmsauth.conf

--- a/ldms/etc/systemd/.gitignore
+++ b/ldms/etc/systemd/.gitignore
@@ -1,0 +1,4 @@
+/ldmsd.aggregator.service
+/ldmsd.kokkos.service
+/ldmsd.sampler.service
+/papi-sampler.service

--- a/ldms/etc/systemd/Makefile.am
+++ b/ldms/etc/systemd/Makefile.am
@@ -2,25 +2,17 @@ SYSTEMD_DIR = $(DESTDIR)$(sysconfdir)/systemd/system
 
 do_subst = @LDMS_SUBST_RULE@
 
-SVC_FILES = $(builddir)/ldmsd.sampler.service \
-	    $(builddir)/ldmsd.aggregator.service \
-	    $(builddir)/ldmsd.kokkos.service \
-	    $(builddir)/papi-sampler.service
+BUILT_FILES = \
+	ldmsd.sampler.service \
+	ldmsd.aggregator.service \
+	ldmsd.kokkos.service \
+	papi-sampler.service
+BUILT_FILES_SRC = $(BUILT_FILES:=.in)
+
+EXTRA_DIST = $(BUILT_FILES_SRC)
+
+sysconfsystemdsystemdir=$(sysconfdir)/systemd/system
+nodist_sysconfsystemdsystem_DATA=$(BUILT_FILES)
 
 $(builddir)/%.service: $(srcdir)/%.service.in
 	$(do_subst) < $< > $@
-
-EXTRA_DIST = ldmsd.aggregator.service.in \
-	     ldmsd.sampler.service.in \
-	     ldmsd.kokkos.service.in \
-	     papi-sampler.service.in
-
-install-data-local: $(SVC_FILES)
-	$(MKDIR_P) $(SYSTEMD_DIR)
-	$(INSTALL_DATA) $(SVC_FILES) $(SYSTEMD_DIR)/
-
-uninstall-local:
-	rm -f $(SYSTEMD_DIR)/ldmsd.sampler.service
-	rm -f $(SYSTEMD_DIR)/ldmsd.aggregator.service
-	rm -f $(SYSTEMD_DIR)/ldmsd.kokkos.service
-	rm -f $(SYSTEMD_DIR)/papi-sampler.service

--- a/ldms/man/Makefile.am
+++ b/ldms/man/Makefile.am
@@ -49,9 +49,6 @@ Plugin_syspapi_sampler.man \
 Plugin_app_sampler.man \
 Plugin_store_app.man
 
-
-
-
 if ENABLE_SLURMTEST
 dist_man8_MANS += pll-ldms-static-test.man
 endif
@@ -63,5 +60,4 @@ dist_man7_MANS += Plugin_store_rabbitkw.man
 ldmsd_exits.man: $(srcdir)/../src/ldmsd/ldmsd.c $(srcdir)/../src/ldmsd/ldmsd_config.c
 	$(srcdir)/make_exits_man.sh $(srcdir)/../src/ldmsd/ldmsd.c $(srcdir)/../src/ldmsd/ldmsd_config.c > ldmsd_exits.man
 
-clean-local:
-	$(RM) ldmsd_exits.man
+CLEANFILES=ldmsd_exits.man

--- a/ldms/src/.gitignore
+++ b/ldms/src/.gitignore
@@ -1,0 +1,3 @@
+/ovis-ldms-configure-args
+/ovis-ldms-configure-env
+/ovis-ldms-configvars.sh

--- a/ldms/src/Makefile.am
+++ b/ldms/src/Makefile.am
@@ -1,17 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS =
-EXTRA_DIST=ovis-ldms-configvars.sh.in
-CLEANFILES = ovis-ldms-configvars.sh
-VERSION=@VERSION@
-
-ac_configure_args=@ac_configure_args@
-
-do_subst = @LDMS_SUBST_RULE@
-
-%.sh: %.sh.in
-	$(do_subst) < $< > $@
-	chmod 755 $@
-
 SUBDIRS += third-plugins
 SUBDIRS += core
 SUBDIRS += ldmsd
@@ -34,24 +22,32 @@ endif
 
 SUBDIRS += contrib
 
-distclean-local:
-	-rm ovis-ldms-configure-args
-	-rm ovis-ldms-configure-env
+ac_configure_args=@ac_configure_args@
 
-ovis-ldms-configure-args: Makefile
-	for i in @ac_configure_args@; do \
-		(echo -n $$i |sed -E 's/(=)(.*)$$/="\2"/' | sed -e s/^\'// -e s/\'$$// ) | grep -v '^--' >> ovis-ldms-configure-env; \
-		(echo -n \'$$i |sed -E 's/(=)(.*)$$/="\2"/' && echo \') | grep -v srcdir | grep '^.--' >> ovis-ldms-configure-args; \
-	done
+do_subst = @LDMS_SUBST_RULE@
 
-install-data-hook: ovis-ldms-configvars.sh ovis-ldms-configure-args
-	$(MKDIR_P) $(DESTDIR)$(libdir)
-	$(MKDIR_P) $(DESTDIR)$(pkglibdir)
-	$(INSTALL) -m 755 ovis-ldms-configvars.sh $(DESTDIR)$(libdir)
-	$(INSTALL) -m 644 ovis-ldms-configure-args $(DESTDIR)$(pkglibdir)
-	$(INSTALL) -m 644 ovis-ldms-configure-env $(DESTDIR)$(pkglibdir)
+%.sh: %.sh.in
+	$(do_subst) < $< > $@
+	chmod 755 $@
 
-uninstall-hook:
-	rm $(DESTDIR)$(libdir)/ovis-ldms-configvars.sh
-	rm $(DESTDIR)$(pkglibdir)/ovis-ldms-configure-env
-	rm $(DESTDIR)$(pkglibdir)/ovis-ldms-configure-args
+ovis-ldms-configure-args:
+	-for i in @ac_configure_args@; do \
+		(echo -n \'$$i |sed -E 's/(=)(.*)$$/="\2"/' && echo \') | grep -v srcdir | grep '^.--' >> $@; \
+	done ; \
+	/bin/true
+
+ovis-ldms-configure-env:
+	-for i in @ac_configure_args@; do \
+		(echo -n $$i |sed -E 's/(=)(.*)$$/="\2"/' | sed -e s/^\'// -e s/\'$$// ) | grep -v '^--' >> $@; \
+	done ; \
+	/bin/true
+
+# override libdir sanity checks
+mylibdir = $(libdir)
+mylib_SCRIPTS = ovis-ldms-configvars.sh
+
+EXTRA_DIST = ovis-ldms-configvars.sh.in
+
+# override pkglibdir sanity checks
+mypkglibdir = $(pkglibdir)
+mypkglib_DATA = ovis-ldms-configure-args ovis-ldms-configure-env

--- a/ldms/src/core/Makefile.am
+++ b/ldms/src/core/Makefile.am
@@ -20,9 +20,3 @@ libldms_la_LIBADD = -ldl -lpthread $(top_builddir)/lib/src/coll/libcoll.la \
 		    $(top_builddir)/lib/src/zap/libzap.la
 
 lib_LTLIBRARIES += libldms.la
-
-install-data-hook:
-#	cp $(top_builddir)/scripts/ldmsd /etc/init.d/ldmsd
-#	cp $(top_builddir)/scripts/schedstatd /etc/init.d/schedstatd
-#	cp $(top_builddir)/scripts/meminfod /etc/init.d/meminfod
-#	cp $(top_builddir)/scripts/sysclassibd /etc/init.d/sysclassibd

--- a/ldms/src/sampler/aries_mmr/aries_mmr_set_configs/Makefile.am
+++ b/ldms/src/sampler/aries_mmr/aries_mmr_set_configs/Makefile.am
@@ -1,4 +1,4 @@
-EXTRA_DIST = \
+MMR_FILES = \
 	metric_set_nic \
 	metric_set_rtr_0 \
 	metric_set_rtr_0_1_c \
@@ -27,42 +27,5 @@ EXTRA_DIST = \
 	metric_set_rtr_3_4_c \
 	metric_set_rtr_3_4_s
 
-
-MMR_FILES = \
-	$(srcdir)/metric_set_nic \
-	$(srcdir)/metric_set_rtr_0 \
-	$(srcdir)/metric_set_rtr_0_1_c \
-	$(srcdir)/metric_set_rtr_0_1_s \
-	$(srcdir)/metric_set_rtr_0_2_c \
-	$(srcdir)/metric_set_rtr_0_2_s \
-	$(srcdir)/metric_set_rtr_1 \
-	$(srcdir)/metric_set_rtr_1_1_c \
-	$(srcdir)/metric_set_rtr_1_1_s \
-	$(srcdir)/metric_set_rtr_1_2_c \
-	$(srcdir)/metric_set_rtr_1_2_s \
-	$(srcdir)/metric_set_rtr_2 \
-	$(srcdir)/metric_set_rtr_2_1_c \
-	$(srcdir)/metric_set_rtr_2_2_c \
-	$(srcdir)/metric_set_rtr_2_2_s \
-	$(srcdir)/metric_set_rtr_3 \
-	$(srcdir)/metric_set_rtr_3_1_c \
-	$(srcdir)/metric_set_rtr_3_2_c \
-	$(srcdir)/metric_set_rtr_3_2_s \
-	$(srcdir)/metric_set_rtr_0_4_c \
-	$(srcdir)/metric_set_rtr_0_4_s \
-	$(srcdir)/metric_set_rtr_1_4_c \
-	$(srcdir)/metric_set_rtr_1_4_s \
-	$(srcdir)/metric_set_rtr_2_4_c \
-	$(srcdir)/metric_set_rtr_2_4_s \
-	$(srcdir)/metric_set_rtr_3_4_c \
-	$(srcdir)/metric_set_rtr_3_4_s
-
-
-OPV=-$(PACKAGE_VERSION)
-MMR_DIR = $(docdir)$(OPV)/examples/aries_mmr_set_configs
-install-data-local: $(MMR_FILES)
-	$(MKDIR_P) $(MMR_DIR)
-	$(INSTALL_DATA) $(MMR_FILES) $(MMR_DIR)/
-
-uninstall-local:
-	rm -rf $(MMR_DIR)
+docversionexamplesdir=$(docdir)-$(PACKAGE_VERSION)/examples/aries_mmr_set_configs
+dist_docversionexamples_DATA = $(MMR_FILES)

--- a/ldms/src/sampler/hello_stream/Makefile.am
+++ b/ldms/src/sampler/hello_stream/Makefile.am
@@ -33,25 +33,12 @@ hello_cat_publisher_LDADD = $(COMMON_LIBADD) \
 hello_cat_publisher_LDFLAGS = $(AM_LDFLAGS) -pthread
 dist_man7_MANS += hello_cat_publisher.man
 
-
 SUBDIRS = stream_configs
 
-HELLO_EXTRA_FILES = parser.pl
-SRC_HELLO_EXTRA_FILES = $(addprefix $(srcdir)/,$(HELLO_EXTRA_FILES))
-
-OPV=-$(PACKAGE_VERSION)
-HELLO_DIR = $(docdir)$(OPV)/examples/hello_sampler_util
-install-data-local: $(SRC_HELLO_EXTRA_FILES)
-	$(MKDIR_P) $(DESTDIR)$(HELLO_DIR)
-	$(INSTALL) $(SRC_HELLO_EXTRA_FILES) $(DESTDIR)$(HELLO_DIR)/
-
-uninstall-local:
-	for i in $(HELLO_EXTRA_FILES); do \
-		rm -rf $(DESTDIR)$(HELLO_DIR)/$$i; \
-	done
+docversionexamplesdir = $(docdir)-$(PACKAGE_VERSION)/examples/hello_sampler_util
+dist_docversionexamples_DATA = parser.pl
 
 endif
 
-
 EXTRA_DIST = \
-	parser.pl hello_publisher.man hello_cat_publisher.man Plugin_hello_sampler.man
+	hello_publisher.man hello_cat_publisher.man Plugin_hello_sampler.man

--- a/ldms/src/sampler/hello_stream/stream_configs/Makefile.am
+++ b/ldms/src/sampler/hello_stream/stream_configs/Makefile.am
@@ -1,29 +1,10 @@
 
 if ENABLE_HELLO_STREAM
 
-
-STREAM_FILES = \
+docversionexamplesdir = $(docdir)-$(PACKAGE_VERSION)/examples/hello_sampler_util/stream_configs
+dist_docversionexamples_DATA = \
 	hello_stream1.conf \
 	hello_stream_store.conf \
 	README
-SRC_STREAM_FILES = $(addprefix $(srcdir)/,$(STREAM_FILES))
-
-OPV=-$(PACKAGE_VERSION)
-HELLO_CONF_DIR = $(docdir)$(OPV)/examples/hello_sampler_util/stream_configs
-install-data-local: $(SRC_STREAM_FILES)
-	$(MKDIR_P) $(DESTDIR)$(HELLO_CONF_DIR)
-	$(INSTALL_DATA) $(SRC_STREAM_FILES) $(DESTDIR)$(HELLO_CONF_DIR)/
-
-
-uninstall-local:
-	for i in $(STREAM_FILES); do \
-		rm -rf $(DESTDIR)$(HELLO_CONF_DIR)/$$i; \
-	done
-
 
 endif
-
-EXTRA_DIST = \
-	hello_stream1.conf \
-	hello_stream_store.conf \
-	README

--- a/ldms/src/test/.gitignore
+++ b/ldms/src/test/.gitignore
@@ -1,0 +1,3 @@
+/ldms-run-static-tests.sh
+/ldms-static-test-bypass
+/ldms-static-test-list.sh

--- a/ldms/src/test/Makefile.am
+++ b/ldms/src/test/Makefile.am
@@ -39,16 +39,10 @@ test_metric_SOURCES = test_metric.c
 test_metric_LDADD = -lldms
 test_metric_LDFLAGS = $(AM_LDFLAGS) -pthread -lm
 
-install-data-hook: 
-	$(MKDIR_P) $(DESTDIR)$(pkglibdir)
-	$(INSTALL) -m 644 ldms-static-test-list.sh $(DESTDIR)$(pkglibdir)
-	$(INSTALL) -m 755 ldms-run-static-tests.sh $(DESTDIR)$(pkglibdir)
-	$(INSTALL) -m 644 ldms-static-test-bypass $(DESTDIR)$(pkglibdir)
-
-uninstall-hook:
-	rm $(DESTDIR)$(pkglibdir)/ldms-static-test-list.sh
-	rm $(DESTDIR)$(pkglibdir)/ldms-run-static-tests.sh
-	rm $(DESTDIR)$(pkglibdir)/ldms-static-test-bypass
+# override pkglib sanity checks
+mypkglibdir = $(pkglibdir)
+mypkglib_SCRIPTS = ldms-run-static-tests.sh
+mypkglib_DATA = ldms-static-test-list.sh ldms-static-test-bypass
 
 installcheck-local: 
 	ldms-run-static-tests.sh

--- a/lib/etc/ld.so.conf.d/.gitignore
+++ b/lib/etc/ld.so.conf.d/.gitignore
@@ -1,0 +1,1 @@
+/ovis-ld-so.conf

--- a/lib/etc/ld.so.conf.d/Makefile.am
+++ b/lib/etc/ld.so.conf.d/Makefile.am
@@ -5,9 +5,5 @@ do_subst = @LDMS_SUBST_RULE@
 ovis-ld-so.conf: ovis-ld-so.conf.in
 	$(do_subst) < $< > $@
 
-install-data-local: ovis-ld-so.conf
-	$(MKDIR_P) $(DESTDIR)/$(sysconfdir)/ld.so.conf.d/
-	$(INSTALL_DATA) $(builddir)/ovis-ld-so.conf $(DESTDIR)/$(sysconfdir)/ld.so.conf.d/
-
-uninstall-local:
-	rm -f $(DESTDIR)/$(sysconfdir)/ld.so.conf.d/ovis-ld-so.conf
+sysconfldsodir = $(sysconfdir)/ld.so.conf.d
+sysconfldso_DATA = ovis-ld-so.conf

--- a/lib/etc/ovis/.gitignore
+++ b/lib/etc/ovis/.gitignore
@@ -1,0 +1,1 @@
+/set-ovis-variables.sh

--- a/lib/etc/ovis/Makefile.am
+++ b/lib/etc/ovis/Makefile.am
@@ -1,17 +1,14 @@
-EXTRA_DIST = ovis-functions.sh \
-	     set-ovis-variables.sh.in
 
 do_subst = @LDMS_SUBST_RULE@
 
 set-ovis-variables.sh: set-ovis-variables.sh.in
 	$(do_subst) < $< > $@
 
-install-data-local: set-ovis-variables.sh
-	$(MKDIR_P) $(DESTDIR)/$(sysconfdir)/ovis
-	$(MKDIR_P) $(DESTDIR)/$(sysconfdir)/profile.d
-	$(INSTALL_SCRIPT) set-ovis-variables.sh $(DESTDIR)/$(sysconfdir)/profile.d
-	$(INSTALL_DATA) $(srcdir)/ovis-functions.sh $(DESTDIR)/$(sysconfdir)/ovis
+sysconfovisdir = $(sysconfdir)/ovis
+dist_sysconfovis_DATA = ovis-functions.sh
 
-uninstall-local:
-	rm -f $(DESTDIR)/$(sysconfdir)/profile.d/set-ovis-variables.sh
-	rm -f $(DESTDIR)/$(sysconfdir)/ovis/ovis-functions.sh
+sysconfprofiledir = $(sysconfdir)/profile.d
+sysconfprofile_DATA = set-ovis-variables.sh
+
+EXTRA_DIST = set-ovis-variables.sh.in
+

--- a/lib/src/.gitignore
+++ b/lib/src/.gitignore
@@ -1,0 +1,1 @@
+/ovis-lib-configvars.sh

--- a/lib/src/Makefile.am
+++ b/lib/src/Makefile.am
@@ -44,9 +44,6 @@ endif
 
 SUBDIRS += ovis_json
 
-install-data-hook: ovis-lib-configvars.sh
-	$(MKDIR_P) $(DESTDIR)$(libdir)
-	$(INSTALL) -m 755 ovis-lib-configvars.sh $(DESTDIR)$(libdir)
-
-uninstall-hook:
-	rm $(DESTDIR)$(libdir)/ovis-lib-configvars.sh
+# override libdir sanity checks
+mylibdir = $(libdir)
+mylib_SCRIPTS = ovis-lib-configvars.sh

--- a/lib/src/coll/Makefile.am
+++ b/lib/src/coll/Makefile.am
@@ -44,11 +44,3 @@ test_idx_SOURCES = idx.c
 test_idx_CFLAGS = -DIDX_TEST
 
 endif
-
-#install-exec-hook:
-#	echo $(libdir) > $(libcoll_conf)
-#	ldconfig
-#
-#uninstall-local:
-#	rm -f $(libcoll_conf)
-#	ldconfig

--- a/lib/src/mmalloc/Makefile.am
+++ b/lib/src/mmalloc/Makefile.am
@@ -10,11 +10,3 @@ libmmallocincludedir = $(includedir)/mmalloc
 libmmalloc_conf = /etc/ld.so.conf.d/libmmalloc.conf
 lib_LTLIBRARIES += libmmalloc.la
 endif
-
-#install-exec-hook:
-#	echo $(libdir) > $(libmmalloc_conf)
-#	ldconfig
-#
-#uninstall-local:
-#	rm -f $(libmmalloc_conf)
-#	ldconfig

--- a/lib/src/ovis_auth/Makefile.am
+++ b/lib/src/ovis_auth/Makefile.am
@@ -1,4 +1,3 @@
-EXTRA_DIST=ovis-auth.sh.in
 lib_LTLIBRARIES =
 
 AM_CFLAGS = -I$(srcdir)/../ -I..
@@ -10,9 +9,6 @@ libovis_auth_conf = /etc/ld.so.conf.d/libovis_auth.conf
 libovis_auth_la_LIBADD = @LDFLAGS_GETTIME@ @OPENSSL_LIBS@
 lib_LTLIBRARIES += libovis_auth.la
 
-install-data-hook:
-	$(MKDIR_P) $(DESTDIR)$(pkglibdir)
-	$(INSTALL) -m 755 ovis-auth.sh $(DESTDIR)$(pkglibdir)
-
-uninstall-hook:
-	rm $(DESTDIR)$(pkglibdir)/ovis-auth.sh
+# override pkglib sanity checks
+mypkglibdir = $(pkglibdir)
+mypkglib_SCRIPTS = ovis-auth.sh

--- a/lib/src/ovis_ctrl/Makefile.am
+++ b/lib/src/ovis_ctrl/Makefile.am
@@ -10,11 +10,3 @@ libovis_ctrlincludedir = $(includedir)/ovis_ctrl
 libovis_ctrl_conf = /etc/ld.so.conf.d/libovis_ctrl.conf
 lib_LTLIBRARIES += libovis_ctrl.la
 endif
-
-#install-exec-hook:
-#	echo $(libdir) > $(libovis_ctrl_conf)
-#	ldconfig
-#
-#uninstall-local:
-#	rm -f $(libovis_ctrl_conf)
-#	ldconfig

--- a/lib/src/ovis_json/Makefile.am
+++ b/lib/src/ovis_json/Makefile.am
@@ -9,8 +9,7 @@ AM_YFLAGS = -d
 
 EXTRA_DIST = ovis_json_lexer.l ovis_json_parser.y
 
-clean-local:
-	$(RM) ovis_json_parser.h ovis_json_parser.c ovis_json_lexer.c
+CLEANFILES = ovis_json_parser.h ovis_json_parser.c ovis_json_lexer.c
 
 ovis_json_parser.c: ovis_json_parser.h ovis_json.h
 

--- a/util/sample_init_scripts/genders/systemd/services/.gitignore
+++ b/util/sample_init_scripts/genders/systemd/services/.gitignore
@@ -1,0 +1,2 @@
+/ldmsd.service
+/ldmsd@.service


### PR DESCRIPTION
Eliminate many unnecessary uses of install-data-local, install-exec-local, clean-local, and related. Replace them with normal automake mechanisms.

Also add more .gitignore entries for build-time files.