### PR TITLE
Fix zap_ugni GNI_SubscribeErrors error in non-privileged mode

### DIFF
--- a/lib/src/zap/ugni/zap_ugni.c
+++ b/lib/src/zap/ugni/zap_ugni.c
@@ -1283,7 +1283,7 @@ static void *error_thread_proc(void *args)
 		GNI_ERRMASK_TRANSIENT |
 		GNI_ERRMASK_INFORMATIONAL;
 
-	status = GNI_SubscribeErrors(NULL, 0, err, 64, &err_hndl);
+	status = GNI_SubscribeErrors(_dom.nic, 0, err, 64, &err_hndl);
 	/* Test for subscription to error events */
 	if (status != GNI_RC_SUCCESS) {
 		zap_ugni_log("FAIL:GNI_SubscribeErrors returned error %s\n", gni_err_str[status]);


### PR DESCRIPTION
Calling GNI_SubscribeErrors() with NULL nic_handle is restricted for
privileged users. For a non-privileged user, the function call results
in GNI_RC_INVALID_PARAM. Since GNI_SubscribeErrors() is called after
zap_ugni attached to a domain and got a `_dom.nic` handle, the handle is
is used instead of NULL so that non-privileged users can also use
zap_ugni.