### PR TITLE
Address `-Wall -Werror` error (format-truncation)

### DIFF
--- a/ldms/src/ldmsd/ldmsctl.c
+++ b/ldms/src/ldmsd/ldmsctl.c
@@ -182,7 +182,7 @@ static void usage(char *argv[])
 char *ldmsctl_ts_str(uint32_t sec, uint32_t usec)
 {
 	struct tm tm;
-	char dtsz[200];
+	char dtsz[100];
 	char *str = malloc(200);
 	if (!str)
 		return NULL;

--- a/ldms/src/sampler/procinterrupts/procinterrupts.c
+++ b/ldms/src/sampler/procinterrupts/procinterrupts.c
@@ -106,7 +106,7 @@ static int create_metric_set(base_data_t base)
 	int rc, i;
 	char *s;
 	char metric_name[128];
-	char beg_name[128];
+	char beg_name[64];
 
 	mf = fopen(procfile, "r");
 	if (!mf) {


### PR DESCRIPTION
`-Wall` in GCC 9.3.0 enables `-Wformat` which also enables
`-Wformat-truncation`. The `-Wformat-truncation` warns about possible
formatted output truncationl. For example,
    char buff[64];
    char s[64];
    fgets(s, 63, stdin);
    snprintf(buff, sizeof(buff), "s is %s", s);
the length of `s` could be 63, the format "s is %s" could be
larger than 64 which results in a warning that turns in to an error by
`-Werror`.

The two places in the code tree that have format-truncation warnings
have the same kind of usage above, i.e. string printing into another
string with the same size. The printing strings (equivalent to `s` in
example above) were too big for the content they hold. Downsizing
them appropriately cleared the format-truncation warnings.