### PR TITLE
Xprt.connect() python style error handling

### DIFF
--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -1746,17 +1746,13 @@ cdef class Xprt(object):
             raise ConnectionError(rc, "ldms_xprt_connect_by_name() error: {}" \
                                       .format(ERRNO_SYM(rc)))
         if cb:
-            print("Returning None")
             return
         # Else, release the GIL and wait
-        print(f"Before wait _conn_rc = {self._conn_rc}")
         with nogil:
             sem_wait(&self._conn_sem)
-        print(f"After wait _conn_rc = {self._conn_rc}")
         if self._conn_rc:
             rc = self._conn_rc
             raise ConnectionError(rc, "Connect error: {}".format(ERRNO_SYM(rc)))
-        return 0
 
     def listen(self, host="*", port=411, cb=None, cb_arg=None):
         """X.listen(host="*", port=411, cb=None, cb_arg=None)

--- a/ldms/python/ldmsd/ldmsd_config.py
+++ b/ldms/python/ldmsd/ldmsd_config.py
@@ -264,9 +264,7 @@ class ldmsdInbandConfig(ldmsdConfig):
 
         self.state = "NEW"
         self.max_recv_len = self.ldms.msg_max
-        self.rc = self.ldms.connect(self.host, self.port)
-        if self.rc != 0:
-            raise RuntimeError("Error {0} connecting to {1}:{2}".format(self.rc, self.host, self.port))
+        self.ldms.connect(self.host, self.port)
         self.type = "inband"
         self.state = "CONNECTED"
 


### PR DESCRIPTION
Opt for python style error report and handling for Xprt.connect(), i.e.
the error would be raised, not returned. This patch also modify the
application that uses the interface (currently just `ldmsd_config`
module whic is a supporting module for ldmsd_controller).