### PR TITLE
Remove SLURM-related configure options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -294,9 +294,6 @@ OPTION_DEFAULT_DISABLE([switchx], [ENABLE_SWITCHX])
 OPTION_WITH([switchx], [SWITCHX],[/usr/local])
 OPTION_DEFAULT_DISABLE([kokkos], [ENABLE_KOKKOS])
 OPTION_DEFAULT_ENABLE([jobinfo-sampler], [ENABLE_JOBINFO])
-OPTION_DEFAULT_DISABLE([jobinfo-slurm], [ENABLE_SLURM_JOBINFO])
-OPTION_DEFAULT_DISABLE([spank-plugin], [ENABLE_SPANK_PLUGIN])
-OPTION_DEFAULT_ENABLE([slurm-sampler], [ENABLE_SLURM_SAMPLER])
 OPTION_DEFAULT_DISABLE([papi-sampler], [ENABLE_PAPI_SAMPLER])
 OPTION_DEFAULT_DISABLE([ibm_occ], [ENABLE_IBM_OCC_SAMPLER])
 OPTION_DEFAULT_DISABLE([appinfo], [ENABLE_APPINFO])
@@ -448,16 +445,25 @@ if test -z "$ENABLE_SYSCLASSIB_TRUE"; then
 			libibumad-devel installed?]))
 fi
 
-dnl Checks for slurm includes
-OPTION_WITH([slurm], [SLURM], [/usr])
-if test -z "$ENABLE_SLURM_JOBINFO_TRUE"; then
-	OCFLAGS=$CFLAGS
-	CFLAGS=$SLURM_INCDIR_FLAG
-	AC_CHECK_HEADER(slurm/spank.h, [],
-		AC_MSG_ERROR([<slurm/spank.h> not found.
-			slurm installed?]))
-	CFLAGS=$OCFLAGS
-fi
+AC_ARG_WITH([slurm],
+	[AS_HELP_STRING([--with-slurm],
+			[support SLURM jobid information and more $<:$default=check@:>@])],
+			[AS_IF([test "x$withval" != xyes -a "x$withval" != xno],
+				[SLURM_CFLAGS="-I $withval"])],
+	[with_slurm=check])
+have_slurm=no
+AS_IF([test "x$with_slurm" != no],[
+	save_CFLAGS=$CFLAGS
+	CFLAGS="$CFLAGS $SLURM_CFLAGS"
+	AC_CHECK_HEADER([slurm/spank.h], [have_slurm=yes], [have_slurm=no])
+	CFLAGS=$save_CFLAGS
+
+	AS_IF([test "x$have_slurm=" = xno],[
+		AS_IF([test "x$with_slurm" != xcheck],
+			[AC_MSG_ERROR([<slurm/spank.h> not found. slurm installed?])],
+			[AC_MSG_WARN([Disabling SLURM support.])])])
+])
+AM_CONDITIONAL([HAVE_SLURM], [test "x$have_slurm" = xyes])
 
 if test -z "$ENABLE_SOS_TRUE"; then
 	CHECK_SOS=1

--- a/ldms/src/sampler/Makefile.am
+++ b/ldms/src/sampler/Makefile.am
@@ -99,9 +99,13 @@ if ENABLE_JOBINFO
 SUBDIRS += job_info
 endif
 
-if ENABLE_SLURM_JOBINFO
+if HAVE_SLURM
 SUBDIRS += job_info_slurm
+SUBDIRS += spank
 endif
+
+# This slurm sampler does not have a slurm build dependency
+SUBDIRS += slurm
 
 if ENABLE_LUSTRE
 SUBDIRS += lustre
@@ -109,14 +113,6 @@ endif
 
 if ENABLE_PAPI_SAMPLER
 SUBDIRS += papi
-endif
-
-if ENABLE_SLURM_SAMPLER
-SUBDIRS += slurm
-endif
-
-if ENABLE_SPANK_PLUGIN
-SUBDIRS += spank
 endif
 
 if ENABLE_IBM_OCC_SAMPLER

--- a/ldms/src/sampler/job_info_slurm/Makefile.am
+++ b/ldms/src/sampler/job_info_slurm/Makefile.am
@@ -10,7 +10,7 @@ COMMON_LIBADD = $(top_builddir)/ldms/src/core/libldms.la \
 
 libjobinfo_slurm_la_SOURCES = jobinfo_slurm.c
 libjobinfo_slurm_la_LIBADD = $(COMMON_LIBADD)
-libjobinfo_slurm_la_CFLAGS = $(SLURM_INCDIR_FLAG) \
+libjobinfo_slurm_la_CFLAGS = $(SLURM_CFLAGS) \
 	-I$(top_srcdir)/ldms/src/sampler/job_info -DSYSCONFDIR='"$(sysconfdir)"'
 libjobinfo_slurm_la_LDFLAGS = $(AM_LDFLAGS) -module
 pkglib_LTLIBRARIES += libjobinfo_slurm.la

--- a/ldms/src/sampler/spank/Makefile.am
+++ b/ldms/src/sampler/spank/Makefile.am
@@ -13,7 +13,6 @@ COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
 
 libslurm_notifier_la_SOURCES = slurm_notifier.c
 libslurm_notifier_la_LIBADD = $(COMMON_LIBADD)
-libslurm_notifier_la_CFLAGS = $(SLURM_INCDIR_FLAG) -DSYSCONFDIR='"$(sysconfdir)"'
-# libslurm_notifier_la_LDFLAGS = -module
+libslurm_notifier_la_CFLAGS = $(SLURM_CFLAGS) -DSYSCONFDIR='"$(sysconfdir)"'
 pkglib_LTLIBRARIES += libslurm_notifier.la
 


### PR DESCRIPTION
Instead of having individual module build options, just build
slurm plugins if their dependecies are met.

The slurm_sampler plugin appears to have no external dependencies,
so it is build unconditionally.

The jobinfo_slurm and slurm_notifier slurm spank plugins are built
it slurm is detected.  They can be required by using "--with-slurm"
and turned off by using "--without-slurm".