### PR TITLE
fix V4 auth plugin location issue and log library access problem

### DIFF
--- a/ldms/src/auth/Makefile.am
+++ b/ldms/src/auth/Makefile.am
@@ -1,4 +1,4 @@
-lib_LTLIBRARIES =
+pkglib_LTLIBRARIES =
 
 AM_LDFLAGS = @OVIS_LIB_ABS@
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
@@ -12,19 +12,19 @@ AM_CFLAGS += \
 
 libldms_auth_none_la_SOURCES = ldms_auth_none.c
 libldms_auth_none_la_LIBADD = ../core/libldms.la
-lib_LTLIBRARIES += libldms_auth_none.la
+pkglib_LTLIBRARIES += libldms_auth_none.la
 
 libldms_auth_naive_la_SOURCES = ldms_auth_naive.c
 libldms_auth_naive_la_LIBADD = ../core/libldms.la \
 			       $(top_builddir)/lib/src/ovis_util/libovis_util.la
 
-lib_LTLIBRARIES += libldms_auth_naive.la
+pkglib_LTLIBRARIES += libldms_auth_naive.la
 
 libldms_auth_ovis_la_SOURCES = ldms_auth_ovis.c
 libldms_auth_ovis_la_LIBADD = ../core/libldms.la \
 			      $(top_builddir)/lib/src/ovis_util/libovis_util.la \
 			      $(top_builddir)/lib/src/ovis_auth/libovis_auth.la
-lib_LTLIBRARIES += libldms_auth_ovis.la
+pkglib_LTLIBRARIES += libldms_auth_ovis.la
 
 if ENABLE_MUNGE
 libldms_auth_munge_la_SOURCES = ldms_auth_munge.c
@@ -34,5 +34,5 @@ libldms_auth_munge_la_LIBADD = ../core/libldms.la \
 			       -lmunge \
 			       @MUNGE_LIB64DIR_FLAG@ \
 			       @MUNGE_LIBDIR_FLAG@
-lib_LTLIBRARIES += libldms_auth_munge.la
+pkglib_LTLIBRARIES += libldms_auth_munge.la
 endif

--- a/ldms/src/core/Makefile.am
+++ b/ldms/src/core/Makefile.am
@@ -10,10 +10,10 @@ AM_CFLAGS += \
 "-DLDMS_BUILDDIR=\"$(abs_top_builddir)\""
 
 ldmscoreincludedir = $(includedir)/ldms
-ldmscoreinclude_HEADERS = ldms.h ldms_core.h ldms_xprt.h ldms_auth.h kldms_req.h ref.h
+ldmscoreinclude_HEADERS = ldms.h ldms_core.h ldms_xprt.h ldms_auth.h kldms_req.h ref.h ldms_log.h
 
 libldms_la_SOURCES = ldms.c ldms_xprt.c ldms_private.h ref.h \
-		     ldms_auth.c ldms_xprt_auth.c
+		     ldms_auth.c ldms_xprt_auth.c ldms_log.c
 libldms_la_LIBADD = -ldl -lpthread $(top_builddir)/lib/src/coll/libcoll.la \
 		    $(top_builddir)/lib/src/ovis_json/libovis_json.la \
 		    $(top_builddir)/lib/src/mmalloc/libmmalloc.la \

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -61,6 +61,7 @@
 #include "coll/rbt.h"
 #include "ovis_util/os_util.h"
 #include "ovis_util/util.h"
+#include "ldms_log.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/ldms/src/core/ldms_core.h
+++ b/ldms/src/core/ldms_core.h
@@ -84,6 +84,7 @@
 
 #define LDMS_SET_NAME_MAX 256
 #define LDMS_PRODUCER_NAME_MAX 64 /* including the terminating null byte */
+#define LDMS_PLUGIN_LIBPATH_MAX	1024
 
 #pragma pack(4)
 #define LDMS_MDESC_F_DATA	1

--- a/ldms/src/core/ldms_log.c
+++ b/ldms/src/core/ldms_log.c
@@ -1,0 +1,339 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2010-2019 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ * Copyright (c) 2010-2019 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ldms_log.h"
+#include "ovis_util/util.h"
+#include <sys/time.h>
+
+#include <unistd.h>
+#include <inttypes.h>
+#include <stdarg.h>
+#include <getopt.h>
+#include <stdlib.h>
+#include <sys/errno.h>
+#include <stdio.h>
+#include <syslog.h>
+#include <string.h>
+#include <sys/queue.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/fcntl.h>
+#include <sys/mman.h>
+#include <pthread.h>
+#include <netinet/in.h>
+#include <signal.h>
+
+#ifdef DEBUG
+#include <mcheck.h>
+#endif /* DEBUG */
+
+static char *logfile = NULL;
+static pthread_mutex_t log_lock = PTHREAD_MUTEX_INITIALIZER;
+static FILE *log_fp;
+static int log_level_thr = LDMSD_LERROR;  /* log level threshold */
+static int quiet = 0; /* Is verbosity quiet? 0 for no and 1 for yes */
+
+const char* ldms_loglevel_names[] = {
+	LOGLEVELS(LDMSD_STR_WRAP)
+	NULL
+};
+
+int ldms_loglevel_set(char *verbose_level)
+{
+	int level = -1;
+	if (0 == strcmp(verbose_level, "QUIET")) {
+		quiet = 1;
+		level = LDMSD_LLASTLEVEL;
+	} else {
+		level = ldms_str_to_loglevel(verbose_level);
+		quiet = 0;
+	}
+	if (level < 0)
+		return level;
+	log_level_thr = level;
+	return 0;
+}
+
+enum ldms_loglevel ldms_loglevel_get()
+{
+	return log_level_thr;
+}
+
+int ldms_loglevel_to_syslog(enum ldms_loglevel level)
+{
+	switch (level) {
+#define MAPLOG(X,Y) case LDMSD_L##X: return LOG_##Y
+	MAPLOG(DEBUG,DEBUG);
+	MAPLOG(INFO,INFO);
+	MAPLOG(WARNING,WARNING);
+	MAPLOG(ERROR,ERR);
+	MAPLOG(CRITICAL,CRIT);
+	MAPLOG(ALL,ALERT);
+	default:
+		return LOG_ERR;
+	}
+#undef MAPLOG
+}
+
+/* Impossible file pointer as syslog-use sentinel */
+#define LDMSD_LOG_SYSLOG ((FILE*)0x7)
+
+void __ldms_log(enum ldms_loglevel level, const char *fmt, va_list ap)
+{
+	if ((level != LDMSD_LALL) &&
+			(quiet || ((0 <= level) && (level < log_level_thr))))
+		return;
+	if (log_fp == LDMSD_LOG_SYSLOG) {
+		vsyslog(ldms_loglevel_to_syslog(level),fmt,ap);
+		return;
+	}
+	time_t t;
+	struct tm tm;
+	char dtsz[200];
+
+	pthread_mutex_lock(&log_lock);
+	if (!log_fp) {
+		pthread_mutex_unlock(&log_lock);
+		return;
+	}
+	t = time(NULL);
+	localtime_r(&t, &tm);
+	if (strftime(dtsz, sizeof(dtsz), "%a %b %d %H:%M:%S %Y", &tm))
+		fprintf(log_fp, "%s: ", dtsz);
+
+	if (level < LDMSD_LALL) {
+		fprintf(log_fp, "%-10s: ", ldms_loglevel_names[level]);
+	}
+
+	vfprintf(log_fp, fmt, ap);
+	fflush(log_fp);
+	pthread_mutex_unlock(&log_lock);
+}
+
+void ldms_log(enum ldms_loglevel level, const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	__ldms_log(level, fmt, ap);
+	va_end(ap);
+}
+
+/* All messages from the ldms library are of e level.*/
+#define LDMSD_LOG_AT(e,fsuf) \
+void ldms_l##fsuf(const char *fmt, ...) \
+{ \
+	va_list ap; \
+	va_start(ap, fmt); \
+	__ldms_log(e, fmt, ap); \
+	va_end(ap); \
+}
+
+LDMSD_LOG_AT(LDMSD_LDEBUG,debug);
+LDMSD_LOG_AT(LDMSD_LINFO,info);
+LDMSD_LOG_AT(LDMSD_LWARNING,warning);
+LDMSD_LOG_AT(LDMSD_LERROR,error);
+LDMSD_LOG_AT(LDMSD_LCRITICAL,critical);
+LDMSD_LOG_AT(LDMSD_LALL,all);
+
+static char msg_buf[4096];
+void ldms_msg_logger(enum ldms_loglevel level, const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	vsnprintf(msg_buf, sizeof(msg_buf), fmt, ap);
+	ldms_log(level, "%s", msg_buf);
+}
+
+enum ldms_loglevel ldms_str_to_loglevel(const char *level_s)
+{
+	int i;
+	for (i = 0; i < LDMSD_LLASTLEVEL; i++)
+		if (0 == strcasecmp(level_s, ldms_loglevel_names[i]))
+			return i;
+	if (strcasecmp(level_s,"QUIET") == 0) {
+		return LDMSD_LALL;
+				}
+	if (strcasecmp(level_s,"ALWAYS") == 0) {
+		return LDMSD_LALL;
+	}
+	if (strcasecmp(level_s,"CRIT") == 0) {
+		return LDMSD_LCRITICAL;
+	}
+	return LDMSD_LNONE;
+}
+
+const char *ldms_loglevel_to_str(enum ldms_loglevel level)
+{
+	if ((level >= LDMSD_LDEBUG) && (level < LDMSD_LLASTLEVEL))
+		return ldms_loglevel_names[level];
+	return "LDMSD_LNONE";
+}
+
+/** return a file pointer or a special syslog pointer */
+int ldms_log_open(const char *progname, const char* xlogfile, const char **errstr)
+{
+	if (!progname || ! xlogfile || !errstr) {
+		ldms_log(LDMSD_LERROR, "invalid arguments to ldms_open_log: %p %p %p\n",
+			progname, xlogfile, errstr);
+		return EINVAL;
+	}
+	FILE *f;
+	if (strcasecmp(xlogfile,"syslog")==0) {
+		ldms_log(LDMSD_LDEBUG, "Switching to syslog.\n");
+		f = LDMSD_LOG_SYSLOG;
+		openlog(progname, LOG_NDELAY|LOG_PID, LOG_DAEMON);
+		log_fp = f;
+		return 0;
+	}
+
+	logfile = strdup(xlogfile);
+	if (!logfile) {
+		return ENOMEM;
+	}
+	f = fopen_perm(logfile, "a", LDMS_DEFAULT_FILE_PERM);
+	if (!f) {
+		ldms_log(LDMSD_LERROR, "Could not open the log file named '%s'\n",
+							logfile);
+		*errstr = "log open failed";
+		return 9;
+	} else {
+		int fd = fileno(f);
+		if (dup2(fd, 1) < 0) {
+			ldms_log(LDMSD_LERROR, "Cannot redirect log to %s\n",
+							logfile);
+			*errstr =  "error redirecting stdout";
+			return 10;
+		}
+		if (dup2(fd, 2) < 0) {
+			ldms_log(LDMSD_LERROR, "Cannot redirect log to %s\n",
+							logfile);
+			*errstr =  "error redirecting stderr";
+			return 11;
+		}
+		stdout = f;
+		stderr = f;
+	}
+	log_fp = f;
+	return 0;
+}
+
+int ldms_logrotate() {
+	int rc;
+	if (!logfile) {
+		ldms_log(LDMSD_LERROR, "Received a logrotate command but "
+			"the log messages are printed to the standard out.\n");
+		return EINVAL;
+	}
+	if (log_fp == LDMSD_LOG_SYSLOG) {
+		/* nothing to do */
+		return 0;
+	}
+	struct timeval tv;
+	char ofile_name[PATH_MAX];
+	gettimeofday(&tv, NULL);
+	sprintf(ofile_name, "%s-%ld", logfile, tv.tv_sec);
+
+	pthread_mutex_lock(&log_lock);
+	if (!log_fp) {
+		pthread_mutex_unlock(&log_lock);
+		return EINVAL;
+	}
+	fflush(log_fp);
+	fclose(log_fp);
+	rename(logfile, ofile_name);
+	log_fp = fopen_perm(logfile, "a", LDMS_DEFAULT_FILE_PERM);
+	if (!log_fp) {
+		printf("%-10s: Failed to rotate the log file. Cannot open a new "
+			"log file\n", "ERROR");
+		fflush(stdout);
+		rc = errno;
+		goto err;
+	}
+	int fd = fileno(log_fp);
+	if (dup2(fd, 1) < 0) {
+		rc = errno;
+		goto err;
+	}
+	if (dup2(fd, 2) < 0) {
+		rc = errno;
+		goto err;
+	}
+	stdout = stderr = log_fp;
+	pthread_mutex_unlock(&log_lock);
+	return 0;
+err:
+	pthread_mutex_unlock(&log_lock);
+	return rc;
+}
+
+int ldms_log_parse_verbosity(const char *optarg) {
+	if (0 == strcmp(optarg, "QUIET")) {
+		quiet = 1;
+		log_level_thr = LDMSD_LLASTLEVEL;
+	} else {
+		log_level_thr = ldms_str_to_loglevel(optarg);
+	}
+	if (log_level_thr < 0) {
+		return -1;
+	}
+	return 0;
+}
+
+void ldms_log_close() {
+	if (logfile) {
+		free(logfile);
+		logfile = NULL;
+	}
+}
+
+static __attribute__((constructor))
+void __init()
+{
+	log_fp = stdout;
+}

--- a/ldms/src/core/ldms_log.h
+++ b/ldms/src/core/ldms_log.h
@@ -1,0 +1,216 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2020 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ * Copyright (c) 2020 Open Grid Computing, Inc. All rights reserved.
+ *
+ * Under the terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+ * license for use of this work by or on behalf of the U.S. Government.
+ * Export of this program may require a license from the United States
+ * Government.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __LDMS_LOG_H__
+#define __LDMS_LOG_H__
+#include <limits.h>
+#include <pthread.h>
+#include <stdarg.h>
+
+/* LDMS_LOG present if ldmsd_log is being retired. */
+#define LDMS_LOG
+#define LDMS_LOGFILE_DEFAULT "/var/log/ldmsd.log"
+
+#ifndef LDMS_LOG_ONLY
+/* compile which CFLAGS += "-DLDMS_LOG_ONLY" to trap all old ldmsd/LDMSD usages.
+ * Otherwise, the following back-compatible macros will keep old code working
+ * until it is cleaned up.
+ * Functions all redefined to their ldms_ equivalent.
+ * nm will show no ldmsd_log related functions when this header is in use.
+ */
+#define LDMSD_STR_WRAP(NAME) #NAME
+#define LDMSD_LWRAP(NAME) LDMSD_L ## NAME = LDMS_L ## NAME
+#define ldmsd_loglevel ldms_loglevel
+#define ldmsd_loglevel_names _Pragma ("GCC warning \"'ldmsd_loglevel_names' is deprecated. use ldms_loglevel_names.\"") ldms_loglevel_names
+#define ldmsd_log ldms_log
+#define ldmsd_loglevel_set ldms_loglevel_set
+#define ldmsd_loglevel_get ldms_loglevel_get
+#define ldmsd_str_to_loglevel ldms_str_to_loglevel
+#define ldmsd_loglevel_to_str ldms_loglevel_to_str
+#define ldmsd_ldebug ldms_ldebug
+#define ldmsd_linfo ldms_linfo
+#define ldmsd_lwarning ldms_lwarning
+#define ldmsd_lerror ldms_lerror
+#define ldmsd_lcritical ldms_lcritical
+#define ldmsd_lall ldms_lall
+#define __ldmsd_log __ldms_log
+#define ldmsd_loglevel_to_syslog ldms_loglevel_to_syslog
+#define ldmsd_msg_log_f ldms_msg_log_f
+#define ldmsd_msg_logger ldms_msg_logger
+#define ldmsd_logrotate ldms_logrotate
+#define LDMSD_LOGFILE LDMS_LOGFILE_DEFAULT
+#endif
+
+/** This section is everything plugin and library clients might need.
+ * The assumption for this section is that main() takes care of logging init.
+ */
+#define LDMS_DEFAULT_FILE_PERM 0600
+
+/* The ldmsd_log facility has been converted to an ldms core library.
+ * Aliases in old ldmsd style are provided for everything until the
+ * transition is complete.
+ */
+
+#define LDMS_STR_WRAP(NAME) #NAME
+#define LDMS_LWRAP(NAME) LDMS_L ## NAME
+/**
+ * \brief ldms log levels
+ *
+ * The ldms log levels, in order of increasing importance, are
+ *  - DEBUG
+ *  - INFO
+ *  - WARNING
+ *  - ERROR
+ *  - CRITICAL
+ *  - ALL
+ *
+ * ALL is for messages printed to the log file per users requests,
+ * e.g, messages printed from the 'info' command.
+ */
+#define LOGLEVELS(WRAP) \
+	WRAP (DEBUG), \
+	WRAP (INFO), \
+	WRAP (WARNING), \
+	WRAP (ERROR), \
+	WRAP (CRITICAL), \
+	WRAP (ALL), \
+	WRAP (LASTLEVEL),
+
+/* LDMSD_ and LDMS_ loglevels are identical for transition to LDMS logging API */
+enum ldms_loglevel {
+	LDMS_LNONE = -1,
+#ifndef LDMS_LOG_ONLY
+	LDMSD_LNONE = -1,
+#endif
+	LOGLEVELS(LDMS_LWRAP)
+#ifndef LDMS_LOG_ONLY
+	LOGLEVELS(LDMSD_LWRAP)
+#endif
+};
+#define ldmsd_loglevel ldms_loglevel
+
+extern const char *ldms_loglevel_names[];
+#define ldmsd_loglevel_names _Pragma ("GCC warning \"'ldmsd_loglevel_names' is deprecated. use ldms_loglevel_names.\"") ldms_loglevel_names
+
+__attribute__((format(printf, 2, 3)))
+void ldms_log(enum ldms_loglevel level, const char *fmt, ...);
+
+int ldms_loglevel_set(char *verbose_level);
+
+enum ldms_loglevel ldms_loglevel_get();
+
+enum ldms_loglevel ldms_str_to_loglevel(const char *level_s);
+
+const char *ldms_loglevel_to_str(enum ldms_loglevel level);
+
+__attribute__((format(printf, 1, 2)))
+void ldms_ldebug(const char *fmt, ...);
+
+__attribute__((format(printf, 1, 2)))
+void ldms_linfo(const char *fmt, ...);
+
+__attribute__((format(printf, 1, 2)))
+void ldms_lwarning(const char *fmt, ...);
+
+__attribute__((format(printf, 1, 2)))
+void ldms_lerror(const char *fmt, ...);
+
+__attribute__((format(printf, 1, 2)))
+void ldms_lcritical(const char *fmt, ...);
+
+__attribute__((format(printf, 1, 2)))
+void ldms_lall(const char *fmt, ...);
+
+void __ldms_log(enum ldms_loglevel level, const char *fmt, va_list ap);
+
+/** Get syslog int value for a level.
+ *  \return LOG_CRIT for invalid inputs, NONE, & ENDLEVEL.
+ */
+int ldms_loglevel_to_syslog(enum ldms_loglevel level);
+
+/** syslog compatible log function pointer. */
+typedef void (*ldms_msg_log_f)(enum ldms_loglevel level, const char *fmt, ...);
+
+/** thread unsafe wrapper of ldms_log */
+void ldms_msg_logger(enum ldms_loglevel level, const char *fmt, ...);
+
+int ldms_logrotate();
+
+/** END of plugin client section. */
+
+/** This section is for main() usage (init and cleanup) only. 
+ * All LDMS plugins and libraries can be written assuming that
+ * ldms_log_open has been completed by libldms or ldmsd main. Passing around pointers to
+ * ldms_log or lower level log functions is no longer needed.
+ */
+
+/** parse verbosity level.
+ * \param optarg one of QUIET, ALL,
+ *    DEBUG, INFO, WARNING, ERROR, CRITICAL.
+ */
+int ldms_log_parse_verbosity(const char *optarg);
+
+/** nerr = ldmsd_open_log(pname, lname, &errstr);
+ * If not called, the log defaults to stdout.
+ * \param pname name of the driver.
+ * \param logfile is path of log file or 'syslog' to use vsyslog.
+ * \param errstr output string pointer space.
+ * \return einval, enomem, or a value 9-11 for cleanup.
+ */
+int ldms_log_open(const char *progname, const char* logfile, const char **errstr);
+
+/** cleanup internal log data structures.
+ */
+void ldms_log_close();
+
+#endif

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -81,7 +81,7 @@
 #define LDMSD_VERSION_PATCH	0x02
 #define LDMSD_VERSION_FLAGS	0x00
 
-#define LDMSD_DEFAULT_FILE_PERM 0600
+#define LDMSD_DEFAULT_FILE_PERM LDMS_DEFAULT_FILE_PERM
 
 #define LDMSD_FAILOVER_NAME_PREFIX "#"
 
@@ -645,6 +645,8 @@ struct ldmsd_store_policy {
 	LIST_ENTRY(ldmsd_store_policy) link;
 };
 
+#ifndef LDMS_LOG
+
 #define LDMSD_STR_WRAP(NAME) #NAME
 #define LDMSD_LWRAP(NAME) LDMSD_L ## NAME
 /**
@@ -704,6 +706,7 @@ void ldmsd_lall(const char *fmt, ...);
  */
 int ldmsd_loglevel_to_syslog(enum ldmsd_loglevel level);
 
+#endif // log
 
 /**
  * \brief Get the security context (uid, gid) of the daemon.
@@ -746,7 +749,10 @@ ldmsd_store_close(struct ldmsd_store *store, ldmsd_store_handle_t sh)
 	store->close(sh);
 }
 
+#ifndef LDMS_LOG
 typedef void (*ldmsd_msg_log_f)(enum ldmsd_loglevel level, const char *fmt, ...);
+#endif
+
 typedef struct ldmsd_plugin *(*ldmsd_plugin_get_f)(ldmsd_msg_log_f pf);
 
 /* ldmsctl command callback function definition */
@@ -810,8 +816,10 @@ extern ldmsctl_cmd_fn_t cmd_table[LDMSCTL_LAST_COMMAND + 1];
 #define LEN_ERRSTR 256
 #define LDMSD_ENOMEM_MSG "Memory allocation failure\n"
 
+#ifndef LDMS_LOG
 void ldmsd_msg_logger(enum ldmsd_loglevel level, const char *fmt, ...);
 int ldmsd_logrotate();
+#endif
 int ldmsd_plugins_usage(const char *plugin_name);
 void ldmsd_mm_status(enum ldmsd_loglevel level, const char *prefix);
 

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -172,7 +172,8 @@ struct ldmsd_plugin_cfg *new_plugin(char *plugin_name,
 			 "function.", plugin_name);
 		goto err;
 	}
-	lpi = pget(ldmsd_msg_logger);
+	// lpi = pget(ldmsd_msg_logger);
+	lpi = pget(ldmsd_log);
 	if (!lpi) {
 		snprintf(errstr, errlen, "The plugin '%s' could not be loaded.",
 								plugin_name);

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -89,7 +89,7 @@ LIST_HEAD(host_list_s, hostspec) host_list;
 LIST_HEAD(ldmsd_store_policy_list, ldmsd_store_policy) sp_list;
 pthread_mutex_t sp_list_lock = PTHREAD_MUTEX_INITIALIZER;
 
-#define LDMSD_PLUGIN_LIBPATH_MAX	1024
+#define LDMSD_PLUGIN_LIBPATH_MAX	LDMS_PLUGIN_LIBPATH_MAX
 struct plugin_list plugin_list;
 
 void ldmsd_cfg_unix_cleanup(ldmsd_cfg_xprt_t xprt)

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -97,8 +97,6 @@ int ldmsd_req_debug = 0; /* turn on / off using gdb or edit src to
 
 static int cleanup_requested = 0;
 
-void __ldmsd_log(enum ldmsd_loglevel level, const char *fmt, va_list ap);
-
 __attribute__((format(printf, 1, 2)))
 static inline
 void __dlog(const char *fmt, ...)

--- a/packaging/make-all-top.sh
+++ b/packaging/make-all-top.sh
@@ -43,7 +43,7 @@ if test -f ldms/src/sampler/meminfo/meminfo.c; then
 	cd $build_subdir
 	expected_ovislib_prefix=$prefix
 	expected_sos_prefix=/badsos
-	allconfig="--prefix=$prefix --disable-rdma --enable-ssl --with-libevent=$expected_event2_prefix --disable-sos --disable-perfevent --disable-rpath --enable-zap --disable-zaptest --enable-authentication --disable-sysclassib --disable-ibnet"
+	allconfig="--prefix=$prefix --disable-rdma --enable-ssl --with-libevent=$expected_event2_prefix --disable-sos --disable-perfevent --disable-rpath --enable-zap --disable-zaptest --enable-authentication --disable-sysclassib --disable-ibnet --disable-python"
 	../configure $allconfig && \
 	make && \
 	make install && \


### PR DESCRIPTION
This request creates an ldms (rather than ldmsd) logging library from the logging API defined in ldmsd and then uses it in the auth plugins loader. Because ldms_xprt and ldms_auth are part of core/ and both need to log errors appropriately, logging  belongs in core and not in ldmsd/. The changes to the auth plugin loader are in a separate patch for easier review of the auth logic adjustment.

The refactored 'ldms_log.h" api provides back compatiblity with the former ldmsd declarations. This can be easily removed with sed over the entire code base, but to avoid conflicts we should do that sed at a point where everyone is pretty much checked in. 

This change allows all plugin and core library writers to assume that ldms_log() just exists instead of passing around logging pointers.
Refactoring plugin apis to stop passing log pointers is a little more complicated than sed and should also be done at a community negotiated point.