### PR TITLE
Add missing CLEANFILES

### DIFF
--- a/.github/workflows/build-test-centos7.yaml
+++ b/.github/workflows/build-test-centos7.yaml
@@ -17,3 +17,12 @@ jobs:
     - run: ./configure
     - run: make
 
+  distcheck:
+    runs-on: ubuntu-20.04
+    container:
+        image: morrone/centos7-ldms-build:latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: sh autogen.sh
+    - run: ./configure
+    - run: make distcheck

--- a/ldms/src/Makefile.am
+++ b/ldms/src/Makefile.am
@@ -51,3 +51,5 @@ EXTRA_DIST = ovis-ldms-configvars.sh.in
 # override pkglibdir sanity checks
 mypkglibdir = $(pkglibdir)
 mypkglib_DATA = ovis-ldms-configure-args ovis-ldms-configure-env
+
+CLEANFILES =  ovis-ldms-configvars.sh ovis-ldms-configure-args ovis-ldms-configure-env


### PR DESCRIPTION
Add the missing CLEANFILES to ldms/src/Makefile.am to repair
"make distcheck".

The commit:

* 713db19 2020-09-30 General build system cleanup

neglected to add the appropriate CLEANFILES in ldms/src/Makefile.am
when it removed the custom distclean-local.

Also add a "make distcheck" job to the centos7 workflow.