### PR TITLE
V4 transport bugs

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -340,7 +340,7 @@ static void send_dir_update(struct ldms_xprt *x,
 	hdr_len = sizeof(struct ldms_reply_hdr)
 		+ sizeof(struct ldms_dir_reply);
 	buf_len = ldms_xprt_msg_max(x);
-	reply = malloc(buf_len);
+	reply = calloc(1, buf_len);
 
 	cnt = snprintf(reply->dir.json_data, buf_len - hdr_len,
 		       "{ \"directory\" : [ %s ]}", json);

--- a/lib/src/zap/rdma/zap_rdma.c
+++ b/lib/src/zap/rdma/zap_rdma.c
@@ -198,6 +198,7 @@ static int __enable_cq_events(struct z_rdma_ep *rep)
 	struct epoll_event cq_event;
 	cq_event.data.ptr = rep;
 	cq_event.events = EPOLLIN | EPOLLOUT;
+	/* safe to suppress "Syscall param epoll_ctl(event)" valgrind msg here. */
 
 	/* Release when deleting the cq_channel fd from the epoll */
 	__zap_get_ep(&rep->ep);
@@ -714,6 +715,7 @@ static zap_err_t z_rdma_connect(zap_ep_t ep,
 
 	cm_event.events = EPOLLIN | EPOLLOUT;
 	cm_event.data.ptr = rep;
+	/* safe to suppress "Syscall param epoll_ctl(event)" valgrind msg here. */
 	__zap_get_ep(&rep->ep); /* Release when disconnected */
 	rc = epoll_ctl(cm_fd, EPOLL_CTL_ADD, rep->cm_channel->fd, &cm_event);
 	if (rc)
@@ -1786,6 +1788,7 @@ z_rdma_listen(zap_ep_t ep, struct sockaddr *sin, socklen_t sa_len)
 
 	cm_event.events = EPOLLIN | EPOLLOUT;
 	cm_event.data.ptr = rep;
+	/* safe to suppress "Syscall param epoll_ctl(event)" valgrind msg here. */
 	zerr = ZAP_ERR_RESOURCE;
 	rc = epoll_ctl(cm_fd, EPOLL_CTL_ADD, rep->cm_channel->fd, &cm_event);
 	if (rc) {

--- a/lib/src/zap/rdma/zap_rdma.c
+++ b/lib/src/zap/rdma/zap_rdma.c
@@ -198,7 +198,6 @@ static int __enable_cq_events(struct z_rdma_ep *rep)
 	struct epoll_event cq_event;
 	cq_event.data.ptr = rep;
 	cq_event.events = EPOLLIN | EPOLLOUT;
-	/* safe to suppress "Syscall param epoll_ctl(event)" valgrind msg here. */
 
 	/* Release when deleting the cq_channel fd from the epoll */
 	__zap_get_ep(&rep->ep);
@@ -715,7 +714,6 @@ static zap_err_t z_rdma_connect(zap_ep_t ep,
 
 	cm_event.events = EPOLLIN | EPOLLOUT;
 	cm_event.data.ptr = rep;
-	/* safe to suppress "Syscall param epoll_ctl(event)" valgrind msg here. */
 	__zap_get_ep(&rep->ep); /* Release when disconnected */
 	rc = epoll_ctl(cm_fd, EPOLL_CTL_ADD, rep->cm_channel->fd, &cm_event);
 	if (rc)
@@ -1788,7 +1786,6 @@ z_rdma_listen(zap_ep_t ep, struct sockaddr *sin, socklen_t sa_len)
 
 	cm_event.events = EPOLLIN | EPOLLOUT;
 	cm_event.data.ptr = rep;
-	/* safe to suppress "Syscall param epoll_ctl(event)" valgrind msg here. */
 	zerr = ZAP_ERR_RESOURCE;
 	rc = epoll_ctl(cm_fd, EPOLL_CTL_ADD, rep->cm_channel->fd, &cm_event);
 	if (rc) {

--- a/lib/src/zap/sock/zap_sock.c
+++ b/lib/src/zap/sock/zap_sock.c
@@ -575,6 +575,7 @@ static void process_sep_msg_read_req(struct z_sock_ep *sep)
 	uint32_t data_len;
 	char *src;
 	struct sock_msg_read_resp rmsg;
+	memset(&rmsg, 0, sizeof(rmsg));
 
 	msg = sep->buff.data;
 


### PR DESCRIPTION
This fixes two information remote disclosure nits and documents (instead of excessively initializing) valid suppression of epoll_ctl event argument initialization warnings. 