### PR TITLE
fix redundant connection err and duplicate set messages.

### DIFF
--- a/ldms/scripts/examples/.canned
+++ b/ldms/scripts/examples/.canned
@@ -1,6 +1,7 @@
 # working
 aggl2 # ldms_ls inconsistent, set duplicates at L2
 aggl2simple
+aggdup
 all_example
 all_example.sos
 array_example

--- a/ldms/scripts/examples/aggdup
+++ b/ldms/scripts/examples/aggdup
@@ -1,0 +1,27 @@
+# This tests what happens when redundant paths from source to L2 agg occur
+portbase=61300
+export plugname=meminfo
+export storename=store_csv
+DAEMONS `seq 4`
+LDMSD 1 
+LDMSD 4
+vgon
+LDMSD 3
+vgoff
+LDMSD 2
+SLEEP 5
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2
+MESSAGE ldms_ls on host 3:
+LDMS_LS 3
+MESSAGE ldms_ls on host 4:
+LDMS_LS 4 -l -v
+SLEEP 2
+KILL_LDMSD 1
+SLEEP 2
+LDMSD 1
+SLEEP 2
+KILL_LDMSD `seq 4`
+file_created $STOREDIR/store_csv/meminfo

--- a/ldms/scripts/examples/aggdup.1
+++ b/ldms/scripts/examples/aggdup.1
@@ -1,0 +1,8 @@
+# L0 meminfo
+load name=${plugname}
+config name=${plugname} producer=localhost${i} schema=${plugname} instance=localhost${i}/${plugname} component_id=${i}
+start name=${plugname} interval=1000000 offset=0
+
+load name=vmstat
+config name=vmstat producer=localhost${i} schema=vmstat instance=localhost${i}/vmstat component_id=${i}
+start name=vmstat interval=1000000 offset=0

--- a/ldms/scripts/examples/aggdup.2
+++ b/ldms/scripts/examples/aggdup.2
@@ -1,0 +1,8 @@
+# L0 redundantly named different instance
+load name=${plugname}
+config name=${plugname} producer=localhost${i} schema=${plugname} instance=localhost1/${plugname} component_id=${i}
+start name=${plugname} interval=1000000 offset=0
+
+load name=vmstat
+config name=vmstat producer=localhost${i} schema=vmstat instance=localhost${i}/vmstat component_id=${i}
+start name=vmstat interval=1000000 offset=0

--- a/ldms/scripts/examples/aggdup.3
+++ b/ldms/scripts/examples/aggdup.3
@@ -1,0 +1,10 @@
+# L1 agg 
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=1000000
+prdcr_start name=localhost1
+
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=1000000
+prdcr_start name=localhost2
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts

--- a/ldms/scripts/examples/aggdup.4
+++ b/ldms/scripts/examples/aggdup.4
@@ -1,0 +1,18 @@
+# L2 agg
+load name=${storename}
+config name=${storename} path=${STOREDIR} altheader=0
+
+prdcr_add name=localhost3 host=${HOST} type=active xprt=${XPRT} port=${port3} interval=1000000
+prdcr_start name=localhost3
+
+updtr_add name=allhosts interval=1000000 offset=200000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+strgp_add name=${testname} plugin=${storename} schema=${plugname} container=${storename}
+strgp_prdcr_add name=${testname} regex=.*
+strgp_start name=${testname}
+
+strgp_add name=${testname}2 plugin=${storename} schema=vmstat container=${storename}
+strgp_prdcr_add name=${testname}2 regex=.*
+strgp_start name=${testname}2

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -205,6 +205,7 @@ typedef struct ldmsd_prdcr {
 	socklen_t ss_len;
 	char *host_name;	/* Host name */
 	unsigned short port_no;		/* Port number */
+	uint8_t warned; 
 	char *xprt_name;	/* Transport name */
 	ldms_t xprt;
 	long conn_intrvl_us;	/* connect interval */
@@ -257,6 +258,7 @@ typedef struct ldmsd_prdcr {
 	double sched_update_time;
 #endif /* LDMSD_UPDATE_TIME */
 } *ldmsd_prdcr_t;
+#define LDMSD_PRDCR_WARNED_CONNERR 0x1
 
 struct ldmsd_strgp;
 typedef struct ldmsd_strgp *ldmsd_strgp_t;
@@ -306,6 +308,7 @@ typedef struct ldmsd_prdcr_set {
 	int updt_interval;
 	int updt_offset;
 	uint8_t updt_sync;
+	uint8_t warned; 
 
 #ifdef LDMSD_UPDATE_TIME
 	struct ldmsd_updt_time *updt_time;
@@ -314,6 +317,9 @@ typedef struct ldmsd_prdcr_set {
 
 	int ref_count;
 } *ldmsd_prdcr_set_t;
+#define LDMSD_PRDCR_SET_WARNED_NOMEM 0x1
+#define LDMSD_PRDCR_SET_WARNED_EXIST 0x2
+#define LDMSD_PRDCR_SET_WARNED_LOOKUP 0x4
 
 #ifdef LDMSD_UPDATE_TIME
 double ldmsd_timeval_diff(struct timeval *start, struct timeval *end);


### PR DESCRIPTION
This adds (at no additional memory cost due to word alignment) the warned flag(s) to producer and producer-set objects so that warnings about 'failed connections that will be retried' and about 'duplicate set instance names' are issued once per event.

In addition:
- related messages that are informational instead of unexpected errors have been demoted to INFO.
- prdcr names have been added to debug messages about set update and update scheduling.
- the aggdup test demonstrates correct handling when 2 samplers produce the same set instance, then one sampler disappears and reappears.