### PR TITLE
Fix zap endpoint leak

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -571,6 +571,7 @@ void __ldms_xprt_resource_free(struct ldms_xprt *x)
 	}
 	if (x->zap_ep) {
 		zap_set_ucontext(x->zap_ep, NULL);
+		zap_free(x->zap_ep);
 		x->zap_ep = NULL;
 		drop_ep_ref = 1;
 	}
@@ -604,8 +605,6 @@ void ldms_xprt_put(ldms_t x)
 		return;
 
 	__ldms_xprt_resource_free(x);
-	if (x->zap_ep)
-		zap_free(x->zap_ep);
 	sem_destroy(&x->sem);
 	free(x);
 }


### PR DESCRIPTION
Zap endpoint `x->zap_ep` in the LDMS transport were set to `NULL` in
`__ldsm_xprt_resource_free()` without calling `zap_free()`. As a
result, the zap endpoint is leaked. The bug is verified in sock, rdma
and fabric-over-verbs transports by running a sampler ldmsd and check
the number of file descriptors before and after `ldms_ls` to the
daemon.

This patch freed the zap endpoint before setting it to `NULL`. The fix
is verified with the file descriptors check described above on sock,
rdma and fabric-over-verbs transports.