### PR TITLE
Fix ldms_xprt_sockaddr()

### DIFF
--- a/ldms/src/core/ldms_xprt.h
+++ b/ldms/src/core/ldms_xprt.h
@@ -429,8 +429,8 @@ struct ldms_xprt {
 
 	/* for addr caching */
 	socklen_t sa_len;
-	struct sockaddr local_sa;
-	struct sockaddr remote_sa;
+	struct sockaddr_storage local_sa;
+	struct sockaddr_storage remote_sa;
 };
 
 void __ldms_xprt_term(struct ldms_xprt *x);


### PR DESCRIPTION
This change fixes 2 issues in ldms_xprt_sockaddr().
* ldms_xprt_sockaddr() always passes 0 as sa_len to zap_get_name()
  instead of the given value by the caller
* ldms_xprt_sockaddr() may cause memory overflow if the given buffers
  are smaller than the actual addresses.