### PR TITLE
Fix endpoint leak when zap_connect failed synchronously

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -3529,8 +3529,10 @@ int ldms_xprt_connect(ldms_t x, struct sockaddr *sa, socklen_t sa_len,
 	ldms_xprt_get(x);
 	rc = zap_connect(_x->zap_ep, sa, sa_len,
 			 (void*)&msg, sizeof(msg.ver) + strlen(msg.auth_name) + 1);
-	if (rc)
+	if (rc) {
+		__ldms_xprt_resource_free(x);
 		ldms_xprt_put(x);
+	}
 	return rc;
 }
 


### PR DESCRIPTION
When `zap_connect()` failed synchronously, zap endpoint were left alone
and the ldms xprt reference that was taken when setting zap ucontext was
not put back. Hence, the LDMS xprt reference would never reached 0 and
the associated resources would not be freed. This patch releases the
zap endpoint and put down the associated LDMS xprt reference.