### PR TITLE
Fix zap endpoint leak in connect error event

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2598,6 +2598,7 @@ static void ldms_zap_cb(zap_ep_t zep, zap_event_t ev)
 		ldms_xprt_put(x);
 		/* Put the reference taken in ldms_xprt_connect() */
 		ldms_xprt_put(x);
+		zap_free(zep);
 		break;
 	case ZAP_EVENT_DISCONNECTED:
 		__sync_fetch_and_add(&xprt_disconnect_count, 1);


### PR DESCRIPTION
When ldms xprt received zap connect error event, it set `xprt->zap_ep`
to `NULL` without releasing the zap endoint. This leads to zap endpoint
leak (and file descriptor leak). The bug can be verified by running an
aggregator with a prdcr that tries to connect to a sampler that is not
running. The prdcr will keep reconnecting, and hence growing
/proc/PID/fd. This patch simply put in the forgotten `zap_free()` to
release the zap endpoint.