### PR TITLE
Fix extra args appearing in ldmsd command when munge used.

### DIFF
--- a/util/sample_init_scripts/genders/man/ldmsd-genders.man
+++ b/util/sample_init_scripts/genders/man/ldmsd-genders.man
@@ -79,9 +79,15 @@ Valid level names are as given in ldmsd(8).
 
 If VERBOSE is defined as "-v", additional messages will be logged from the init scripts.
 
+.B LDMS_AUTH_TYPE=type
+
+This variable defines the type of authentication to use. The supported types are 'ovis' (the v3 secretword file) and 'munge'. See ldms_authentication(7) for details.
+
 .B LDMS_AUTH_FILE=filename
 
-This variable defines the file of the secret network key needed if any aggregation is to take place, assuming authentication is compiled in the ldmsd installation. For production use, authentication should always be used. see ldms_authentication(7). Alternatively, a correct LDMS_SECRETS_DIR defined (as below), will be used to construct the file name automatically.
+If using authentication type 'munge', this variable defines the path passed to munge with the -S argument. It must be a socket name.
+
+If using authentication type 'ovis', this variable defines the file of the secret network key needed if any aggregation is to take place, assuming authentication is compiled in the ldmsd installation. For production use, authentication should always be used. see ldms_authentication(7). Alternatively, a correct LDMS_SECRETS_DIR defined (as below), will be used to construct the file name automatically.
 
 .B LDMS_SECRETS_DIR=dirname
 

--- a/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ldmsd.in
+++ b/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ldmsd.in
@@ -92,7 +92,7 @@ fi
 if test -z "$LDMS_SECRETS_DIR"; then
 	LDMS_SECRETS_DIR=$sysconfdir/sysconfig/ldms.d/ClusterSecrets
 fi
-if test -z "$LDMS_AUTH_FILE"; then
+if test -z "$LDMS_AUTH_FILE" -a "x$LDMS_AUTH_TYPE" = "xovis" ; then; then
 	LDMS_AUTH_FILE=$LDMS_SECRETS_DIR/$LDMSCLUSTER.ldmsauth.conf
 fi
 

--- a/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ldmsd.local.conf
+++ b/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ldmsd.local.conf
@@ -1,6 +1,7 @@
-# auth file must be set to a full path name of a secretword file.
-LDMS_AUTH_FILE=
+# auth type must be ovis or munge
 LDMS_AUTH_TYPE=ovis
+# auth file must be set to a full path name of a secretword file if using type 'ovis'.
+LDMS_AUTH_FILE=
 
 # Variables overriding defaults
 # See man ldmsd-genders(8) for details.

--- a/util/sample_init_scripts/genders/systemd/services/ldmsd.service.in
+++ b/util/sample_init_scripts/genders/systemd/services/ldmsd.service.in
@@ -56,7 +56,7 @@ EnvironmentFile = -@localstatedir@/run/ldmsd/ldmsd.env.local
 # Start main service
 # This is all one line so it is easily converted to sysvinit, not so
 # it is easy to read.
-ExecStart= /bin/bash -c '/bin/rm -f $LDMSD_SOCKPATH ; @bindir@/ldmsd-wrapper.sh local $LDMSD_GLOBAL_OPTS $MEM_OPT $LDMSAGGD_MEM_RES -c $LDMSD_PLUGIN_CONFIG_FILE -a $LDMS_AUTH_TYPE -A conf=$LDMS_AUTH_FILE -r @localstatedir@/run/ldmsd/ldmsd-local.pid -x $LDMSD_XPRT:$LDMSD_PORT -P $LDMSD_EVENT_THDS $LDMSD_INET_OPT $LDMSD_CONFIG_PORT $LDMSD_SOCK_OPT $LDMSD_SOCKPATH -v $LDMSD_DBG $LDMS_LOG_OPT $LDMS_LOG_FILE 2>&1'
+ExecStart= /bin/bash -c '/bin/rm -f $LDMSD_SOCKPATH ; @bindir@/ldmsd-wrapper.sh local $LDMSD_GLOBAL_OPTS $MEM_OPT $LDMSAGGD_MEM_RES -c $LDMSD_PLUGIN_CONFIG_FILE -a $LDMS_AUTH_TYPE $LDMS_AUTH_ARGS -r @localstatedir@/run/ldmsd/ldmsd-local.pid -x $LDMSD_XPRT:$LDMSD_PORT -P $LDMSD_EVENT_THDS $LDMSD_INET_OPT $LDMSD_CONFIG_PORT $LDMSD_SOCK_OPT $LDMSD_SOCKPATH -v $LDMSD_DBG $LDMS_LOG_OPT $LDMS_LOG_FILE 2>&1'
 
 # Sets open_files_limit
 LimitNOFILE = 65536

--- a/util/sample_init_scripts/genders/systemd/services/ldmsd@.service.in
+++ b/util/sample_init_scripts/genders/systemd/services/ldmsd@.service.in
@@ -56,7 +56,7 @@ EnvironmentFile = -@localstatedir@/run/ldmsd/ldmsd.env.%I
 # Start main service
 # This is all one line so it is easily converted to sysvinit, not so
 # it is easy to read.
-ExecStart= /bin/bash -c '/bin/rm -f $LDMSD_SOCKPATH ; @bindir@/ldmsd-wrapper.sh %I $LDMSD_GLOBAL_OPTS $MEM_OPT $LDMSAGGD_MEM_RES -c $LDMSD_PLUGIN_CONFIG_FILE -a $LDMS_AUTH_TYPE -A conf=$LDMS_AUTH_FILE -r @localstatedir@/run/ldmsd/ldmsd-%I.pid -x $LDMSD_XPRT:$LDMSD_PORT -P $LDMSD_EVENT_THDS $LDMSD_INET_OPT $LDMSD_CONFIG_PORT $LDMSD_SOCK_OPT $LDMSD_SOCKPATH -v $LDMSD_DBG $LDMS_LOG_OPT $LDMS_LOG_FILE 2>&1'
+ExecStart= /bin/bash -c '/bin/rm -f $LDMSD_SOCKPATH ; @bindir@/ldmsd-wrapper.sh %I $LDMSD_GLOBAL_OPTS $MEM_OPT $LDMSAGGD_MEM_RES -c $LDMSD_PLUGIN_CONFIG_FILE -a $LDMS_AUTH_TYPE $LDMS_AUTH_ARGS -r @localstatedir@/run/ldmsd/ldmsd-%I.pid -x $LDMSD_XPRT:$LDMSD_PORT -P $LDMSD_EVENT_THDS $LDMSD_INET_OPT $LDMSD_CONFIG_PORT $LDMSD_SOCK_OPT $LDMSD_SOCKPATH -v $LDMSD_DBG $LDMS_LOG_OPT $LDMS_LOG_FILE 2>&1'
 
 # Sets open_files_limit
 LimitNOFILE = 65536


### PR DESCRIPTION
also set default key file name for ovis auth only if ovis type is specified.