### PR TITLE
Overhaul the libpapi/libpfm configuration handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -254,14 +254,11 @@ OPTION_DEFAULT_DISABLE([msr_interlagos], [ENABLE_MSR_INTERLAGOS])
 OPTION_DEFAULT_ENABLE([array_example], [ENABLE_ARRAY_EXAMPLE])
 OPTION_DEFAULT_ENABLE([hello_stream], [ENABLE_HELLO_STREAM])
 OPTION_DEFAULT_DISABLE([perfevent], [ENABLE_PERFEVENT])
-OPTION_DEFAULT_DISABLE([rapl], [ENABLE_RAPL])
-OPTION_DEFAULT_DISABLE([hweventpapi], [ENABLE_HWEVENTPAPI])
 OPTION_DEFAULT_DISABLE([mpi_sampler], [ENABLE_MPI_SAMPLER])
 OPTION_DEFAULT_DISABLE([mpi_noprofile], [ENABLE_MPI_NOPROFILE])
 if test -z "$ENABLE_MPI_SAMPLER_TRUE" ; then
 	AX_MPI([:],[ AC_MSG_ERROR([MPICC required by mpi_sampler ])])
 fi
-OPTION_WITH([libpapi], [LIBPAPI])
 OPTION_DEFAULT_ENABLE([procinterrupts], [ENABLE_PROCINTERRUPTS])
 OPTION_DEFAULT_ENABLE([procnetdev], [ENABLE_PROCNETDEV])
 OPTION_DEFAULT_ENABLE([procnfs], [ENABLE_PROCNFS])
@@ -294,7 +291,6 @@ OPTION_DEFAULT_DISABLE([switchx], [ENABLE_SWITCHX])
 OPTION_WITH([switchx], [SWITCHX],[/usr/local])
 OPTION_DEFAULT_DISABLE([kokkos], [ENABLE_KOKKOS])
 OPTION_DEFAULT_ENABLE([jobinfo-sampler], [ENABLE_JOBINFO])
-OPTION_DEFAULT_DISABLE([papi-sampler], [ENABLE_PAPI_SAMPLER])
 OPTION_DEFAULT_DISABLE([ibm_occ], [ENABLE_IBM_OCC_SAMPLER])
 OPTION_DEFAULT_DISABLE([appinfo], [ENABLE_APPINFO])
 OPTION_DEFAULT_DISABLE([app-sampler], [ENABLE_APP_SAMPLER])
@@ -322,40 +318,24 @@ if test -z "$ENABLE_INFLUX_TRUE"; then
 	LIBS="$TMPLIBS"
 fi
 
-OPTION_WITH([libpfm], [LIBPFM])
-OPTION_DEFAULT_DISABLE([syspapi-sampler], [ENABLE_SYSPAPI_SAMPLER])
-if test -z "$ENABLE_SYSPAPI_SAMPLER_TRUE" -o -z "$ENABLE_PAPI_SAMPLER_TRUE"; then
-	TMPLIBS="$LIBS"
-	TMPCFLAGS="$CFLAGS"
-	LIBS=""
-	AC_CHECK_LIB(papi, PAPI_library_init, [],
-		AC_MSG_ERROR([libpapi not found (required by papi-sampler/syspapi-sampler).]),
-		$LIBPAPI_LIBDIR_FLAG $LIBPAPI_LIB64DIR_FLAG)
-	LIBS=""
-	dnl Check headers
-	CFLAGS=$LIBPAPI_INCDIR_FLAG
-	AC_CHECK_HEADER(papi.h, [],
-		AC_MSG_ERROR([`papi.h` not found (required by papi-sampler/syspapi-sampler).]))
-	LIBS="$TMPLIBS"
-	CFLAGS="$TMPCFLAGS"
-fi
-
-if test -z "$ENABLE_SYSPAPI_SAMPLER_TRUE"; then
-	TMPLIBS="$LIBS"
-	TMPCFLAGS="$CFLAGS"
-	LIBS=""
-	AC_CHECK_LIB(pfm, pfm_initialize, [],
-		AC_MSG_ERROR([libpfm not found (required by syspapi-sampler).]),
-		$LIBPFM_LIBDIR_FLAG $LIBPFM_LIB64DIR_FLAG)
-	LIBS=""
-	dnl Check headers
-	CFLAGS=$LIBPFM_INCDIR_FLAG
-	AC_CHECK_HEADER(perfmon/pfmlib_perf_event.h, [],
-		AC_MSG_ERROR([`perfmon/pfmlib_perf_event.h` not found (required by syspapi-sampler).]))
-	LIBS="$TMPLIBS"
-	CFLAGS="$TMPCFLAGS"
-fi
-
+AC_ARG_ENABLE([papi],
+	[AS_HELP_STRING([--enable-papi], [require components that depend upon libpapi (and libpfm) @<:@default=check@:>@])],
+	[],
+	[enable_papi="check"])
+AS_IF([test "x$enable_papi" != xno],[
+	AC_LIB_HAVE_LINKFLAGS([papi], [], [#include <papi.h>])
+	AS_IF([test "x$enable_papi" != xcheck],[
+		AS_IF([test "x$HAVE_LIBPAPI" = xno],
+			[AC_MSG_ERROR([libpapi or headers not found])])
+	])
+	AC_LIB_HAVE_LINKFLAGS([pfm], [], [#include <perfmon/pfmlib_perf_event.h>])
+	AS_IF([test "x$enable_papi" != xcheck],[
+		AS_IF([test "x$HAVE_LIBPFM" = xno],
+			[AC_MSG_ERROR([libpfm or headers not found])])
+	])
+])
+AM_CONDITIONAL([HAVE_LIBPAPI], [test "x$HAVE_LIBPAPI" = xyes])
+AM_CONDITIONAL([HAVE_LIBPFM], [test "x$HAVE_LIBPFM" = xyes])
 
 if test -z "$ENABLE_KOKKOS_TRUE"; then
 	dnl kokkos needs sos (not the storesos).
@@ -447,7 +427,7 @@ fi
 
 AC_ARG_WITH([slurm],
 	[AS_HELP_STRING([--with-slurm],
-			[support SLURM jobid information and more $<:$default=check@:>@])],
+			[support SLURM jobid information and more @<:@default=check@:>@])],
 			[AS_IF([test "x$withval" != xyes -a "x$withval" != xno],
 				[SLURM_CFLAGS="-I $withval"])],
 	[with_slurm=check])

--- a/ldms/src/sampler/Makefile.am
+++ b/ldms/src/sampler/Makefile.am
@@ -17,9 +17,6 @@ libsampler_base_la_SOURCES = sampler_base.c sampler_base.h
 libsampler_base_la_LIBADD = $(CORE_LIBADD)
 lib_LTLIBRARIES += libsampler_base.la
 
-PAPI_LDFLAGS = @LIBPAPI_LIB64DIR_FLAG@ @LIBPAPI_LIBDIR_FLAG@ \
-             @LIBPFM_LIB64DIR_FLAG@ @LIBPFM_LIBDIR_FLAG@
-
 ldmssamplerincludedir = $(includedir)/ldms/sampler
 ldmssamplerinclude_HEADERS = sampler_base.h
 
@@ -111,10 +108,6 @@ if ENABLE_LUSTRE
 SUBDIRS += lustre
 endif
 
-if ENABLE_PAPI_SAMPLER
-SUBDIRS += papi
-endif
-
 if ENABLE_IBM_OCC_SAMPLER
 SUBDIRS += ibm_occ
 endif
@@ -167,14 +160,6 @@ libperfevent_la_LIBADD = $(COMMON_LIBADD) -lm
 pkglib_LTLIBRARIES += libperfevent.la
 endif
 
-if ENABLE_HWEVENTPAPI
-libhweventpapi_la_SOURCES = hweventpapi.c
-libhweventpapi_la_CFLAGS = $(AM_CFLAGS) $(LIBPAPI_INCDIR_FLAG)
-libhweventpapi_la_LDFLAGS = $(AM_LDFLAGS) $(PAPI_LDFLAGS)
-libhweventpapi_la_LIBADD = $(COMMON_LIBADD) $(JOBID_LIBFLAGS) -lpapi -lpfm -lm
-pkglib_LTLIBRARIES += libhweventpapi.la
-endif
-
 if ENABLE_APPINFO
 libappinfo_la_SOURCES = appinfo.c
 libappinfo_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/appinfo_lib
@@ -187,12 +172,23 @@ if ENABLE_MPI_SAMPLER
 SUBDIRS += shm
 endif
 
-if ENABLE_RAPL
+if HAVE_LIBPAPI
+SUBDIRS += papi
+if HAVE_LIBPFM
+SUBDIRS += syspapi
+
+libhweventpapi_la_SOURCES = hweventpapi.c
+libhweventpapi_la_CFLAGS = $(AM_CFLAGS)
+libhweventpapi_la_LDFLAGS = $(AM_LDFLAGS)
+libhweventpapi_la_LIBADD = $(COMMON_LIBADD) $(JOBID_LIBFLAGS) $(LTLIBPAPI) $(LTLIBPFM) -lm
+pkglib_LTLIBRARIES += libhweventpapi.la
+
 librapl_la_SOURCES = rapl.c
-librapl_la_CFLAGS = $(AM_CFLAGS) $(LIBPAPI_INCDIR_FLAG)
+librapl_la_CFLAGS = $(AM_CFLAGS)
 librapl_la_LDFLAGS = $(AM_LDFLAGS) $(PAPI_LDFLAGS)
-librapl_la_LIBADD = $(COMMON_LIBADD) -lpapi -lpfm -lm
+librapl_la_LIBADD = $(COMMON_LIBADD) $(LTLIBPAPI) $(LTLIBPFM) -lm
 pkglib_LTLIBRARIES += librapl.la
+endif
 endif
 
 if ENABLE_PROCDISKSTATS
@@ -261,10 +257,6 @@ if ENABLE_GRPTEST_LDMS_TEST
 libgrptest_la_SOURCES = grptest.c
 libgrptest_la_LIBADD = $(COMMON_LIBADD)
 pkglib_LTLIBRARIES += libgrptest.la
-endif
-
-if ENABLE_SYSPAPI_SAMPLER
-SUBDIRS += syspapi
 endif
 
 if ENABLE_APP_SAMPLER

--- a/ldms/src/sampler/papi/Makefile.am
+++ b/ldms/src/sampler/papi/Makefile.am
@@ -1,8 +1,8 @@
 pkglib_LTLIBRARIES =
 dist_man7_MANS=
 
-AM_CPPFLAGS = @OVIS_INCLUDE_ABS@ @LIBPAPI_INCDIR_FLAG@
-AM_LDFLAGS = @OVIS_LIB_ABS@ @LIBPAPI_LIB64DIR_FLAG@ @LIBPAPI_LIBDIR_FLAG@
+AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
+AM_LDFLAGS = @OVIS_LIB_ABS@
 COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
 		$(top_builddir)/ldms/src/core/libldms.la \
 		$(top_builddir)/ldms/src/ldmsd/libldmsd_stream.la \
@@ -10,10 +10,9 @@ COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
 		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
 		$(top_builddir)/lib/src/coll/libcoll.la \
 		$(top_builddir)/lib/src/ovis_json/libovis_json.la \
-		-lpapi -lm -lpthread
+		-lm -lpthread
 
 libpapi_sampler_la_SOURCES = papi_sampler.h papi_sampler.c papi_config.c
-libpapi_sampler_la_LIBADD = $(COMMON_LIBADD)
+libpapi_sampler_la_LIBADD = $(COMMON_LIBADD) $(LTLIBPAPI)
 libpapi_sampler_la_CFLAGS = -DSYSCONFDIR='"$(sysconfdir)"'
 pkglib_LTLIBRARIES += libpapi_sampler.la
-

--- a/ldms/src/sampler/syspapi/Makefile.am
+++ b/ldms/src/sampler/syspapi/Makefile.am
@@ -3,7 +3,7 @@ dist_man7_MANS=
 
 EXTRA_DIST = test/ldmsd.sh
 
-AM_CPPFLAGS = @OVIS_INCLUDE_ABS@ @LIBPAPI_INCDIR_FLAG@ @LIBPFM_INCDIR_FLAG@ 
+AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
 COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
 		$(top_builddir)/ldms/src/core/libldms.la \
@@ -11,10 +11,7 @@ COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
 		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
 		$(top_builddir)/lib/src/coll/libcoll.la
 
-AM_LDFLAGS += @LIBPAPI_LIB64DIR_FLAG@ @LIBPAPI_LIBDIR_FLAG@ \
-	     @LIBPFM_LIB64DIR_FLAG@ @LIBPFM_LIBDIR_FLAG@
-
 libsyspapi_sampler_la_SOURCES = syspapi_sampler.c
-libsyspapi_sampler_la_LIBADD = $(COMMON_LIBADD) -lpapi -lpfm -lpthread
+libsyspapi_sampler_la_LIBADD = $(COMMON_LIBADD) $(LTLIBPAPI) $(LTLIBPFM) -lpthread
 libsyspapi_sampler_la_CFLAGS = $(AM_CFLAGS) -DSYSCONFDIR='"$(sysconfdir)"'
 pkglib_LTLIBRARIES += libsyspapi_sampler.la


### PR DESCRIPTION
Convert the libpapi/libpfm configuration to the use of more
standard AC_LIB_HAVE_LINKFLAGS() configuration mechanisms. Also
update all modules that are dependant on libpapi/libpfm to
use the LTLIBPAPI and LTLIBPFM variables that are created by
AC_LIB_HAVE_LINKFLAGS. This fixes the broken linkage and rpath
dependencies that currently existed when using custome papi/pfm
install paths.

We also eliminate the unessary extra configure options for each
component that depends on papi, and instead just have one option
for all components that require papi. The new configure option
is --enable-papi/--disable-papi. The three options are:

--enable-papi specified: papi must be found, or configure returns
   an error
--disable-papi specified: do not build components that depend on papi
No papi option specified: test for papi and pfm, and activate build
   of dependant components if found

The options to specify customs library install locations are:

--with-libpapi-prefix=PATH
--with-libpfm-prefix=PATH

Both of these options are introduced by AC_LIB_HAVE_LINKFLAGS().