### PR TITLE
add file descriptor count option to dstat

### DIFF
--- a/ldms/scripts/examples/dstat.job
+++ b/ldms/scripts/examples/dstat.job
@@ -2,19 +2,23 @@
 export plugname=dstat
 portbase=62086
 JOBDATA $TESTDIR/job.data 1 2 3
+export dsname=$(ldms_dstat_schema_name mmalloc=1 io=1 fd=1 auto-schema=1)
+echo DSNAME=$dsname
 LDMSD -p prolog.jobid  1 2
 LDMSD -p prolog.jobid -p prolog.jobid.store3 3
 MESSAGE ldms_ls on host 1:
 JOBDATA $TESTDIR/job.data 1 2 3
-LDMS_LS 1 -l
+SLEEP 2
+LDMS_LS 1 -lv
 MESSAGE ldms_ls on host 2:
-LDMS_LS 2 -l
+LDMS_LS 2 -lv
 MESSAGE ldms_ls on host 3:
-LDMS_LS 3
+LDMS_LS 3 -lv
 JOBDATA $TESTDIR/job.data 1 2
 SLEEP 3
 JOBDATA $TESTDIR/job.data 1 3
 SLEEP 2
 KILL_LDMSD `seq 3`
-file_created $STOREDIR/node/$testname
+file_created $STOREDIR/node/dstat_19
+file_created $STOREDIR/node/dstat_39
 file_created $STOREDIR/node/jobid

--- a/ldms/scripts/examples/dstat.job.1
+++ b/ldms/scripts/examples/dstat.job.1
@@ -1,3 +1,3 @@
 load name=${plugname}
-config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} mmalloc=1 io=1
+config name=${plugname} producer=localhost${i} instance=localhost${i}/${testname} component_id=${i} mmalloc=1 io=1 auto-schema=1 fd=1
 start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/dstat.job.2
+++ b/ldms/scripts/examples/dstat.job.2
@@ -1,3 +1,3 @@
 load name=${plugname}
-config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} mmalloc=1 io=1
+config name=${plugname} producer=localhost${i} instance=localhost${i}/${testname} component_id=${i} mmalloc=1 io=1 auto-schema=1 fdtypes=1
 start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/dstat.job.3
+++ b/ldms/scripts/examples/dstat.job.3
@@ -1,3 +1,11 @@
 load name=${plugname}
-config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} mmalloc=1 io=1
+config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} mmalloc=1 io=1 auto-schema=1
 start name=${plugname} interval=1000000 offset=0
+
+strgp_add name=store_${testname}.auto plugin=store_csv schema=${dsname} container=node
+strgp_prdcr_add name=store_${testname}.auto regex=.*
+strgp_start name=store_${testname}.auto
+
+strgp_add name=store_${testname}.auto2 plugin=store_csv schema=dstat_39 container=node
+strgp_prdcr_add name=store_${testname}.auto2 regex=.*
+strgp_start name=store_${testname}.auto2

--- a/ldms/src/sampler/dstat/Makefile.am
+++ b/ldms/src/sampler/dstat/Makefile.am
@@ -1,11 +1,14 @@
 pkglib_LTLIBRARIES =
 lib_LTLIBRARIES =
 check_PROGRAMS =
+bin_PROGRAMS =
 dist_man7_MANS =
+dist_man1_MANS =
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
 COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+		$(top_builddir)/ldms/src/ldmsd/libldmsd_plugattr.la \
 		libparse_stat.la \
 		$(top_builddir)/ldms/src/core/libldms.la \
 		@LDFLAGS_GETTIME@ \
@@ -20,6 +23,13 @@ libdstat_la_SOURCES = dstat.c
 libdstat_la_LIBADD = $(COMMON_LIBADD)
 pkglib_LTLIBRARIES += libdstat.la
 dist_man7_MANS += Plugin_dstat.man
+
+bin_PROGRAMS += ldms_dstat_schema_name
+dist_man1_MANS += ldms_dstat_schema_name.man
+ldms_dstat_schema_name_SOURCES = dstat.c
+ldms_dstat_schema_name_CFLAGS = -DMAIN
+ldms_dstat_schema_name_LDADD = \
+	$(top_builddir)/lib/src/ovis_util/libovis_util.la
 
 check_PROGRAMS += parse_stat_test
 parse_stat_test_SOURCES = parse_stat.c parse_stat.h

--- a/ldms/src/sampler/dstat/Plugin_dstat.man
+++ b/ldms/src/sampler/dstat/Plugin_dstat.man
@@ -1,6 +1,6 @@
 .\" Manpage for Plugin_dstat
 .\" Contact ovis-help@sandia.gov to correct errors or typos.
-.TH man 7 "6 Jul 2018" "v4.1" "LDMS Plugin dstat man page"
+.TH man 7 "4 Nov 2020" "v4.3" "LDMS Plugin dstat man page"
 
 .SH NAME
 Plugin_dstat - man page for the LDMS dstat plugin
@@ -11,13 +11,13 @@ Within ldmsd_controller
 config name=dstat [ <attr> = <value> ]
 
 .SH DESCRIPTION
-The dstat plugin provides ldmsd process information from /proc/self/[io,stat,statm].
+The dstat plugin provides ldmsd process information from /proc/self/[io,stat,statm,fd].
 
 .SH CONFIGURATION ATTRIBUTE SYNTAX
 
 .TP
 .BR config
-name=<plugin_name> component_id=<comp_id> [io=<bool>] [stat=<bool>] [statm=<bool>] [mmalloc=<bool>] set=<set_name> 
+name=<plugin_name> component_id=<comp_id> [io=<bool>] [stat=<bool>] [statm=<bool>] [mmalloc=<bool>] [fd=<bool>] [fdtypes=<bool>] set=<set_name> 
 .br
  configuration line
 .RS
@@ -36,14 +36,18 @@ The name of the metric set.
 .TP
 schema=<schema>
 .br
-Optional schema name. It is intended that the same sampler on different nodes with different metrics have a
-different schema. If not specified, will default to dstat.
+Optional schema name. It is required by most storage backends that the same sampler on different nodes with different metric subsets needs to have a unique schema name. Use auto-schema=1 instead of schema to automatically meet the backend requirement.
+.TP
+auto-schema=<bool>
+.br
+If true, change the schema name to dstat_$X, where $X will be
+a unique hex value derived from the data selection options. If both schema and auto-schema are given, for backward-compatibility auto-schema is ignored for the dstat plugin.
 .TP
 component_id=<comp_id>
 .br
 The component id numerical value.
 with_jobid=<bool>
-.br
+.r
 Option to collect job id with set or 0 if not.
 .TP
 io=<bool>
@@ -61,6 +65,15 @@ Include the metrics from /proc/self/statm.
 mmalloc=<bool>
 .br
 Include the mmap memory usage metric from LDMS mmalloc.
+.TP
+fd=<bool>
+.br
+Include the number of open file descriptors found in /proc/self/fd.
+.TP
+fdtypes=<bool>
+.br
+Include the number and types of open file descriptors found in /proc/self/fd.
+This option may have high overhead on aggregators with many open connections.
 .RE
 
 .SH DATA
@@ -78,9 +91,22 @@ start name=dstat interval=1000000
 
 .SH NOTES
 .PP
-See proc(5) for the definitions of the metrics. Metrics which are invariant (other than pids) are not included. Where naming is potentially ambiguous and a more specific name is used in /proc/self/status for the same metrics, the name from /proc/self/status is used.
+See proc(5) for the definitions of all the metrics except fd data. Metrics which are invariant (other than pids) are not included. Where naming is potentially ambiguous and a more specific name is used in /proc/self/status for the same metrics, the name from /proc/self/status is used.
 .PP
-Requesting mmalloc (which may be high overhead) requires explicitly requesting it and all others which are wanted. 
+Requesting mmalloc or fd or fdtypes (any of which may be high overhead) requires explicitly requesting it and all others which are wanted. 
+.PP
+The numbers listed in /proc/self/fd/ are symbolic links.
+The "types" of reported are based on the names pointed to by the links as follows:
+.nf
+fd_count        total number of open file descriptors.
+fd_max          highest file number.
+fd_socket       count of link targets starting with "socket:"
+fd_dev          count of link targets starting with "/dev:"
+fd_anon_inode   count of link targets starting with "anon_inode:"
+fd_pipe         count of link targets starting with "pipe:"
+fd_path         count of link targets starting with . or / but not /dev.
+.fi
+
 .PP
 This is the LDMSD answer to the ancient question "Quis custodiet ipsos custodes?"
 

--- a/ldms/src/sampler/dstat/Plugin_dstat.man
+++ b/ldms/src/sampler/dstat/Plugin_dstat.man
@@ -46,9 +46,6 @@ a unique hex value derived from the data selection options. If both schema and a
 component_id=<comp_id>
 .br
 The component id numerical value.
-with_jobid=<bool>
-.r
-Option to collect job id with set or 0 if not.
 .TP
 io=<bool>
 .br

--- a/ldms/src/sampler/dstat/ldms_dstat_schema_name.man
+++ b/ldms/src/sampler/dstat/ldms_dstat_schema_name.man
@@ -1,0 +1,31 @@
+.\" Manpage for ldms_dstat_schema_name
+.\" Contact ovis-help@ca.sandia.gov to correct errors or typos.
+.TH man 1 "17 Nov 2020" "v4.3" "LDMS utility ldms_dstat_schema_name man page"
+
+.SH NAME
+ldms_dstat_schema_name - man page for the LDMS dstat plugin support utility
+
+.SH SYNOPSIS
+ldms_dstat_schema_name <plugin config options>
+
+.SH DESCRIPTION
+The dstat plugin optionally generates a schema name including a short hash of certain
+configuration data. ldms_dstat_schema_name provides the user with the
+schema name the dstat plugin will generate for the given options.
+
+.SH CONFIGURATION ATTRIBUTE SYNTAX
+
+See Plugin_dstat(7).
+
+.SH EXAMPLES
+.PP
+.nf
+ldms_dstat_schema_name auto-schema=1 fd=1
+
+yields
+
+dstat_10
+.fi
+
+.SH SEE ALSO
+Plugin_dstat(7)

--- a/ldms/src/sampler/dstat/parse_stat.h
+++ b/ldms/src/sampler/dstat/parse_stat.h
@@ -2,6 +2,8 @@
 #define parse_stat_h_seen
 
 #include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 
 struct proc_pid_io {
@@ -70,23 +72,40 @@ struct proc_pid_stat {
 	unsigned long long delayacct_blkio_ticks;
 };
 
+struct proc_pid_fd {
+	uint32_t fd_count; /*< number of open file descriptors */
+	uint32_t fd_max; /*< highest file number */
+	uint32_t fd_socket; /* targets starting with socket: */
+	uint32_t fd_dev; /* targets starting with /dev: */
+	uint32_t fd_anon_inode; /* targets starting with anon_inode: */
+	uint32_t fd_pipe; /* targets starting with pipe: */
+	uint32_t fd_path; /* targets starting with . or / but not /dev. */
+};
 
-/* \brief parse /proc/$pid/io and fill provides struct.
+/* \brief parse /proc/$pid/io and fill provided struct.
  * \return 0 on success, errno from fopen, ENODATA from
  * failed fgets, ENOKEY or ENAMETOOLONG from failed parse.
  */
 int parse_proc_pid_io(struct proc_pid_io *s, const char *pid);
 
-/* \brief parse /proc/$pid/stat and fill provides struct.
+/* \brief parse /proc/$pid/stat and fill provided struct.
  * \return 0 on success, errno from fopen, ENODATA from
  * failed fgets, ENOKEY or ENAMETOOLONG from failed parse.
  */
 int parse_proc_pid_stat(struct proc_pid_stat *s, const char *pid);
 
-/* \brief parse /proc/$pid/stat and fill provides struct.
+/* \brief parse /proc/$pid/stat and fill provided struct.
  * \return 0 on success, errno from fopen, ENODATA from
  * failed fgets, ENOKEY or ENAMETOOLONG from failed parse.
  */
 int parse_proc_pid_statm(struct proc_pid_statm *s, const char *pid);
+
+/* \brief parse /proc/$pid/fd and fill provided struct.
+ * \param details: if false, update only fd_count, otherwise classify the 
+ * file descriptors by link target name heuristics.
+ * \return 0 on success, errno from readdir/opendir.
+ * On a nonzero return, the content of s is undefined.
+ */
+int parse_proc_pid_fd(struct proc_pid_fd *s, const char *pid, bool details);
 
 #endif /* parse_stat_h_seen */


### PR DESCRIPTION
The dstat sampler can now collect a simple or detailed summary
of /proc/self/fd open file descriptors. option fd=1 collects
just the count and fdtypes=1 also collects file descriptor counts
by type (anon, pipe, dev, /path, socket). fd info collection is
off by default.

this also adds the option auto-schema=1 (off by default)
which changes the default schema name from dstat to dstat_$hash
where hash is 1 or 2 hex digits derived from the option flags
which control the content of the schema. A utility ldms_dstat_schema_name
provides the schema name for storage policy setup.

When running an aggregator, using dstat with fdtypes=1 enabled will help identify leaks of file descriptors.