### PR TITLE
Add `-DDEBUG` build test github job

### DIFF
--- a/.github/workflows/build-ddebug-centos7.yaml
+++ b/.github/workflows/build-ddebug-centos7.yaml
@@ -1,0 +1,18 @@
+name: Build Test with `-DDEBUG` - CentOS7
+
+on:
+  push:
+    branches: [ OVIS-4 ]
+  pull_request:
+    branches: [ OVIS-4 ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+        image: ovishpc/ovis-centos-build:latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: sh autogen.sh
+    - run: ./configure CFLAGS='-DDEBUG'
+    - run: make


### PR DESCRIPTION
This patch adds a github job for a build test with `CFLAGS='-DDEBUG'`
targeting `OVIS-4` branch. This is an effort to keep the DEBUG portion
of the code maintained (at the lesat built).