### PR TITLE
Split apart libpapi and libfm configuration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -319,7 +319,7 @@ if test -z "$ENABLE_INFLUX_TRUE"; then
 fi
 
 AC_ARG_ENABLE([papi],
-	[AS_HELP_STRING([--enable-papi], [require components that depend upon libpapi (and libpfm) @<:@default=check@:>@])],
+	[AS_HELP_STRING([--enable-papi], [require components that depend upon libpapi @<:@default=check@:>@])],
 	[],
 	[enable_papi="check"])
 AS_IF([test "x$enable_papi" != xno],[
@@ -328,14 +328,22 @@ AS_IF([test "x$enable_papi" != xno],[
 		AS_IF([test "x$HAVE_LIBPAPI" = xno],
 			[AC_MSG_ERROR([libpapi or headers not found])])
 	])
+])
+AM_CONDITIONAL([HAVE_LIBPAPI], [test "x$HAVE_LIBPAPI" = xyes])
+
+AC_ARG_ENABLE([pfm],
+	[AS_HELP_STRING([--enable-pfm], [require components that depend upon libpfm @<:@default=check@:>@])],
+	[],
+	[enable_pfm="check"])
+AS_IF([test "x$enable_pfm" != xno],[
 	AC_LIB_HAVE_LINKFLAGS([pfm], [], [#include <perfmon/pfmlib_perf_event.h>])
-	AS_IF([test "x$enable_papi" != xcheck],[
+	AS_IF([test "x$enable_pfm" != xcheck],[
 		AS_IF([test "x$HAVE_LIBPFM" = xno],
 			[AC_MSG_ERROR([libpfm or headers not found])])
 	])
 ])
-AM_CONDITIONAL([HAVE_LIBPAPI], [test "x$HAVE_LIBPAPI" = xyes])
 AM_CONDITIONAL([HAVE_LIBPFM], [test "x$HAVE_LIBPFM" = xyes])
+
 
 if test -z "$ENABLE_KOKKOS_TRUE"; then
 	dnl kokkos needs sos (not the storesos).

--- a/ldms/src/sampler/Makefile.am
+++ b/ldms/src/sampler/Makefile.am
@@ -174,20 +174,21 @@ endif
 
 if HAVE_LIBPAPI
 SUBDIRS += papi
-if HAVE_LIBPFM
-SUBDIRS += syspapi
 
 libhweventpapi_la_SOURCES = hweventpapi.c
 libhweventpapi_la_CFLAGS = $(AM_CFLAGS)
 libhweventpapi_la_LDFLAGS = $(AM_LDFLAGS)
-libhweventpapi_la_LIBADD = $(COMMON_LIBADD) $(JOBID_LIBFLAGS) $(LTLIBPAPI) $(LTLIBPFM) -lm
+libhweventpapi_la_LIBADD = $(COMMON_LIBADD) $(JOBID_LIBFLAGS) $(LTLIBPAPI) -lm
 pkglib_LTLIBRARIES += libhweventpapi.la
 
 librapl_la_SOURCES = rapl.c
 librapl_la_CFLAGS = $(AM_CFLAGS)
 librapl_la_LDFLAGS = $(AM_LDFLAGS) $(PAPI_LDFLAGS)
-librapl_la_LIBADD = $(COMMON_LIBADD) $(LTLIBPAPI) $(LTLIBPFM) -lm
+librapl_la_LIBADD = $(COMMON_LIBADD) $(LTLIBPAPI) -lm
 pkglib_LTLIBRARIES += librapl.la
+
+if HAVE_LIBPFM
+SUBDIRS += syspapi
 endif
 endif
 


### PR DESCRIPTION
We remove the libpfm linkage from the libhwevent and rapl samplers.
It appears that neither of those had a direct dependency upon libpfm.

With that change made, it is clear that our --enable-papi option should
not also depend upon pfm. We therefore remove that and instead introduce
an --enable-pfm option to require or disable libpfm inclusion. The
--with-libpfm-prefix option remains to specify a path to check for
libpfm.

For instance, the following should now work:

  --enable-papi --with-libpapi-prefix=/usr/papi600 --disable-pfm

This would result in only the samplers that depend on papi being built.
Those samplers (only one at time of writing) that also require libpfm
would not be build.