### PR TITLE
In hello_sampler, use libsampler_base rather than sampler_base.c

### DIFF
--- a/ldms/src/sampler/hello_stream/Makefile.am
+++ b/ldms/src/sampler/hello_stream/Makefile.am
@@ -5,16 +5,15 @@ AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
 COMMON_LIBADD = $(top_builddir)/lib/src/ovis_util/libovis_util.la \
 		$(top_builddir)/lib/src/coll/libcoll.la \
-		../../core/libldms.la \
+		$(top_builddir)/ldms/src/core/libldms.la \
 		@LDFLAGS_GETTIME@
-
-
 
 if ENABLE_HELLO_STREAM
 
-libhello_sampler_la_SOURCES = hello_sampler.c ../sampler_base.c
+libhello_sampler_la_SOURCES = hello_sampler.c
 libhello_sampler_la_LIBADD = $(COMMON_LIBADD) \
-			     $(top_builddir)/lib/src/ovis_json/libovis_json.la
+			     $(top_builddir)/lib/src/ovis_json/libovis_json.la \
+			     $(top_builddir)/ldms/src/sampler/libsampler_base.la
 pkglib_LTLIBRARIES += libhello_sampler.la
 dist_man7_MANS += Plugin_hello_sampler.man
 
@@ -22,14 +21,14 @@ sbin_PROGRAMS = hello_publisher hello_cat_publisher
 hello_publisher_SOURCES = hello_publisher.c
 hello_publisher_LDADD = $(COMMON_LIBADD) \
 			$(top_builddir)/lib/src/ovis_json/libovis_json.la \
-			../../ldmsd/libldmsd_stream.la
+			$(top_builddir)/ldms/src/ldmsd/libldmsd_stream.la
 hello_publisher_LDFLAGS = $(AM_LDFLAGS) -pthread
 dist_man7_MANS += hello_publisher.man
 
 hello_cat_publisher_SOURCES = hello_cat_publisher.c
 hello_cat_publisher_LDADD = $(COMMON_LIBADD) \
 			    $(top_builddir)/lib/src/ovis_json/libovis_json.la \
-			    ../../ldmsd/libldmsd_stream.la
+			    $(top_builddir)/ldms/src/ldmsd/libldmsd_stream.la
 hello_cat_publisher_LDFLAGS = $(AM_LDFLAGS) -pthread
 dist_man7_MANS += hello_cat_publisher.man
 


### PR DESCRIPTION
Instead of using sampler_base.c in the sources of libhello_stream,
LIBADD libsampler_base.la. This should eliminate the automake warning
about subdir-objects.

Also update the library paths to consistently reference from
$(top_builddir).

Fix #457