### PR TITLE
Add the zap_send_mapped() API to the zap library

### DIFF
--- a/lib/src/zap/fabric/zap_fabric.c
+++ b/lib/src/zap/fabric/zap_fabric.c
@@ -1,8 +1,8 @@
 /* -*- c-basic-offset: 8 -*-
- * Copyright (c) 2013-2019 National Technology & Engineering Solutions
+ * Copyright (c) 2013-2020 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
- * Copyright (c) 2013-2019 Open Grid Computing, Inc. All rights reserved.
+ * Copyright (c) 2013-2020 Open Grid Computing, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -107,7 +107,7 @@ static const char *z_fi_op_str[] = {
  *    For surfacing endpoint errors. Calls the endpoint's logging fn specified
  *    in zap_new.
  */
-#ifdef DEBUG
+#if defined(DEBUG) || defined(EP_DEBUG)
 static void dlog_(const char *func, int line, char *fmt, ...)
 {
 	va_list ap;
@@ -119,6 +119,7 @@ static void dlog_(const char *func, int line, char *fmt, ...)
 	clock_gettime(CLOCK_REALTIME, &ts);
 	va_start(ap, fmt);
 	vasprintf(&buf, fmt, ap);
+	va_end(ap);
 	g.log_fn("[%d] %d.%09d: %s:%d | %s", tid, ts.tv_sec, ts.tv_nsec, func, line, buf);
 	free(buf);
 }
@@ -128,7 +129,7 @@ static void dlog_(const char *func, int line, char *fmt, ...)
 		rep->ep.z->log_fn(fmt, ##__VA_ARGS__); \
 } while (0)
 
-#ifdef DEBUG
+#if defined(DEBUG) || defined(EP_DEBUG)
 #define DLOG(fmt, ...)	dlog_(__func__, __LINE__, fmt, ##__VA_ARGS__)
 #else
 #define DLOG(fmt, ...)
@@ -726,6 +727,10 @@ static void flush_io_q(struct z_fi_ep *rep)
 			ev.type = ZAP_EVENT_READ_COMPLETE;
 			ev.context = ctxt->usr_context;
 			break;
+		    case ZAP_WC_SEND_MAPPED:
+			ev.type = ZAP_EVENT_SEND_MAPPED_COMPLETE;
+			ev.context = ctxt->usr_context;
+			break;
 		    case ZAP_WC_RECV:
 		    default:
 			LOG_(rep, "invalid op type %d in queued i/o\n", ctxt->op);
@@ -757,6 +762,23 @@ post_wr(struct z_fi_ep *rep, struct z_fi_context *ctxt)
 
 		DLOG("ZAP_WC_SEND rep %p ctxt %p rb %p len %d with %d credits rc %d\n",
 		     rep, ctxt, rb, len, rep->lcl_rq_credits, rc);
+		break;
+	    case ZAP_WC_SEND_MAPPED:
+		rb = ctxt->u.send_mapped.rb;
+		rb->msg->credits = htons(rep->lcl_rq_credits);
+		rep->lcl_rq_credits = 0;
+		SEND_LOG(rep, ctxt);
+		/* NOTE: iov[0] contains prov_prefix and z_fi msg hdr using
+		 *              rb->buf,
+		 *       iov[1] contains application payload. */
+		rc = fi_sendv(rep->fi_ep, ctxt->u.send_mapped.iov,
+			      ctxt->u.send_mapped.mr_desc, 2, 0, ctxt);
+
+		DLOG("ZAP_WC_SEND_MAPPED rep %p ctxt %p rb %p hdr_len %d "
+				"payload_len %d with %d credits rc %d\n",
+		     rep, ctxt, rb, ctxt->u.send_mapped.iov[0].iov_len,
+		     ctxt->u.send_mapped.iov[1].iov_len, rep->lcl_rq_credits,
+		     rc);
 		break;
 	    case ZAP_WC_RDMA_WRITE:
 		rc = fi_write(rep->fi_ep, ctxt->u.rdma.src_addr, ctxt->u.rdma.len,
@@ -1042,7 +1064,8 @@ zap_err_t z_map_err(struct z_fi_ep *rep, struct fi_cq_err_entry *entry)
 	if (!entry->err)
 		return ZAP_ERR_OK;
 
-	if (0 == strcmp(rep->fi->fabric_attr->prov_name, "verbs"))
+	if (rep->fi->fabric_attr->prov_name &&
+			0 == strcmp(rep->fi->fabric_attr->prov_name, "verbs"))
 		goto verbs;
 
 	return zap_errno2zerr(entry->err);
@@ -1100,6 +1123,20 @@ static void process_send_wc(struct z_fi_ep *rep, struct fi_cq_err_entry *entry)
 	struct z_fi_context *ctxt = entry->op_context;
 	if (!entry->err && ctxt->u.send.rb)
 		__buffer_free(ctxt->u.send.rb);
+}
+
+static void process_send_mapped_wc(struct z_fi_ep *rep,
+				   struct fi_cq_err_entry *entry)
+{
+	struct z_fi_context *ctxt = entry->op_context;
+	struct zap_event zev = {
+			.type = ZAP_EVENT_SEND_MAPPED_COMPLETE,
+			.context = ctxt->usr_context,
+			.status = z_map_err(rep, entry),
+		};
+	rep->ep.cb(&rep->ep, &zev);
+	if (!entry->err && ctxt->u.send_mapped.rb)
+		__buffer_free(ctxt->u.send_mapped.rb);
 }
 
 static void process_read_wc(struct z_fi_ep *rep, struct fi_cq_err_entry *entry)
@@ -1387,6 +1424,14 @@ static void scrub_cq(struct z_fi_ep *rep)
 			DLOG("got ZAP_WC_SEND rep %p ctxt %p rb %p err %d proverr %d\n",
 			     rep, ctxt, ctxt->u.send.rb, entry.err, entry.prov_errno);
 			process_send_wc(rep, &entry);
+			put_sq(rep);
+			if (entry.err && ctxt->u.send.rb)
+				__buffer_free(ctxt->u.send.rb);
+			break;
+		    case ZAP_WC_SEND_MAPPED:
+			DLOG("got ZAP_WC_SEND rep %p ctxt %p rb %p err %d proverr %d\n",
+			     rep, ctxt, ctxt->u.send_mapped.rb, entry.err, entry.prov_errno);
+			process_send_mapped_wc(rep, &entry);
 			put_sq(rep);
 			if (entry.err && ctxt->u.send.rb)
 				__buffer_free(ctxt->u.send.rb);
@@ -1722,7 +1767,6 @@ static void handle_disconnected(struct z_fi_ep *rep, struct fi_eq_cm_entry *entr
 	pthread_mutex_unlock(&rep->credit_lock);
 
 	pthread_mutex_lock(&rep->ep.lock);
-
 	if (!LIST_EMPTY(&rep->active_ctxt_list)) {
 		rep->deferred_disconnected = 1;
 		pthread_mutex_unlock(&rep->ep.lock);
@@ -2130,6 +2174,62 @@ static zap_err_t z_fi_send(zap_ep_t ep, char *buf, size_t len)
 	return rc;
 }
 
+static zap_err_t z_fi_send_mapped(zap_ep_t ep, zap_map_t map,
+				  void *buf, size_t len, void *context)
+{
+	int rc, hdr_len;
+	struct z_fi_ep *rep = (struct z_fi_ep *)ep;
+	struct z_fi_context *ctxt;
+	struct z_fi_buffer *rbuf;
+	struct z_fi_map *rmap = (struct z_fi_map *)map;
+
+	if (map->type != ZAP_MAP_LOCAL)
+		return ZAP_ERR_INVALID_MAP_TYPE;
+	if (z_map_access_validate(map, buf, len, 0))
+		return ZAP_ERR_LOCAL_LEN;
+
+	pthread_mutex_lock(&rep->ep.lock);
+	rc = __ep_state_check(rep);
+	if (rc)
+		goto out;
+	rbuf = __buffer_alloc(rep);
+	if (!rbuf) {
+		rc = ZAP_ERR_RESOURCE;
+		goto out;
+	}
+	if (!_buffer_fits(rbuf, len+sizeof(struct z_fi_message_hdr))) {
+		rc = ZAP_ERR_LOCAL_LEN;
+		__buffer_free(rbuf);
+		goto out;
+	}
+	ctxt = __context_alloc(rep, context, ZAP_WC_SEND_MAPPED);
+	if (!ctxt) {
+		__buffer_free(rbuf);
+		rc = ZAP_ERR_RESOURCE;
+		goto out;
+	}
+	/* prefix + hdr */
+	hdr_len = rep->fi->ep_attr->msg_prefix_size + sizeof(struct z_fi_message_hdr);
+	rbuf->msg->msg_type = htons(Z_FI_MSG_SEND);
+	ctxt->u.send_mapped.rb = rbuf;
+	ctxt->u.send_mapped.iov[0].iov_base = rbuf->buf;
+	ctxt->u.send_mapped.iov[0].iov_len = hdr_len;
+	ctxt->u.send_mapped.mr_desc[0] = fi_mr_desc(rep->buf_pool_mr);
+	/* payload */
+	ctxt->u.send_mapped.iov[1].iov_base = buf;
+	ctxt->u.send_mapped.iov[1].iov_len = len;
+	ctxt->u.send_mapped.mr_desc[1] = fi_mr_desc(rmap->u.local.mr);
+
+	rc = submit_wr(rep, ctxt, 0);
+	if (rc) {
+		__context_free(ctxt);
+		__buffer_free(rbuf);
+	}
+out:
+	pthread_mutex_unlock(&rep->ep.lock);
+	return rc;
+}
+
 static zap_err_t z_fi_share(zap_ep_t ep, zap_map_t map,
 				const char *msg, size_t msg_len)
 {
@@ -2301,6 +2401,7 @@ out:
 
 static pthread_t cm_thread, cq_thread;
 
+__attribute__((unused))
 static void z_fi_cleanup(void)
 {
 	void *dontcare;
@@ -2347,7 +2448,7 @@ static int init_once()
 		z_fi_info_log_on = atoi(env);
 
 	init_complete = 1;
-	atexit(z_fi_cleanup);
+//	atexit(z_fi_cleanup);
 	return 0;
 
  err_3:
@@ -2385,6 +2486,7 @@ zap_err_t zap_transport_get(zap_t *pz, zap_log_fn_t log_fn,
 	z->listen = z_fi_listen;
 	z->close = z_fi_close;
 	z->send = z_fi_send;
+	z->send_mapped = z_fi_send_mapped;
 	z->read = z_fi_read;
 	z->write = z_fi_write;
 	z->map = z_fi_map;

--- a/lib/src/zap/fabric/zap_fabric.h
+++ b/lib/src/zap/fabric/zap_fabric.h
@@ -1,8 +1,8 @@
 /* -*- c-basic-offset: 8 -*-
- * Copyright (c) 2010-2015,2017 National Technology & Engineering Solutions
+ * Copyright (c) 2010-2015,2017,2019-2020 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
- * Copyright (c) 2010-2015,2017 Open Grid Computing, Inc. All rights reserved.
+ * Copyright (c) 2010-2015,2017,2019-2020 Open Grid Computing, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -137,6 +137,7 @@ enum z_fi_op {
 	ZAP_WC_RECV,
 	ZAP_WC_RDMA_READ,
 	ZAP_WC_RDMA_WRITE,
+	ZAP_WC_SEND_MAPPED,
 };
 
 struct z_fi_context {
@@ -158,6 +159,12 @@ struct z_fi_context {
 			void		*dst_addr;
 			size_t		len;
 		} rdma;
+		struct {
+			struct z_fi_buffer *rb; /* to hold fi_prefix + z_fi hdr */
+			struct iovec iov[2]; /* for SEND_MAPPED, iov[0]:prov_prefix+msghdr,
+					      * iov[1]:payload */
+			void *mr_desc[2];    /* MR desc corresponding to iov */
+		} send_mapped;
 	} u;
 	TAILQ_ENTRY(z_fi_context) pending_link; /* pending i/o */
 	LIST_ENTRY(z_fi_context) active_ctxt_link;

--- a/lib/src/zap/rdma/zap_rdma.c
+++ b/lib/src/zap/rdma/zap_rdma.c
@@ -1,8 +1,8 @@
 /* -*- c-basic-offset: 8 -*-
- * Copyright (c) 2013-2019 National Technology & Engineering Solutions
+ * Copyright (c) 2013-2020 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
- * Copyright (c) 2013-2019 Open Grid Computing, Inc. All rights reserved.
+ * Copyright (c) 2013-2020 Open Grid Computing, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -179,6 +179,9 @@ static void _rdma_context_free(struct z_rdma_context *ctxt);
 static void __rdma_buffer_free(struct z_rdma_buffer *rbuf);
 static int send_credit_update(struct z_rdma_ep *ep);
 static void _rdma_deliver_disconnected(struct z_rdma_ep *rep);
+static zap_err_t submit_wr(struct z_rdma_ep *rep, struct z_rdma_context *ctxt,
+			   int is_rdma);
+static int get_credits(struct z_rdma_ep *rep, int is_rdma);
 
 static struct z_rdma_context *__rdma_get_context(struct ibv_wc *wc)
 {
@@ -213,6 +216,7 @@ static int __enable_cq_events(struct z_rdma_ep *rep)
 static void __rdma_teardown_conn(struct z_rdma_ep *ep)
 {
 	struct z_rdma_ep *rep = (struct z_rdma_ep *)ep;
+	int rc;
 
 	if (rep->cm_id && rep->ep.state == ZAP_EP_CONNECTED)
 		assert(0);
@@ -272,6 +276,21 @@ static void __rdma_teardown_conn(struct z_rdma_ep *ep)
 		rep->cq_channel = NULL;
 	}
 
+	if (rep->buf_pool_mr) {
+		if ((rc = ibv_dereg_mr(rep->buf_pool_mr)))
+			LOG_(rep, "RDMA: Error rc: %d, errno: %d : "
+				  "ibv_dereg_mr() failed\n", rc, errno);
+		else
+			rep->buf_pool_mr = NULL;
+
+	}
+
+	if (rep->buf_pool)
+		free(rep->buf_pool);
+
+	if (rep->buf_objs)
+		free(rep->buf_objs);
+
 	rep->rem_rq_credits = RQ_DEPTH;
 	rep->sq_credits = SQ_DEPTH;
 	rep->lcl_rq_credits = 0;
@@ -288,6 +307,44 @@ static void z_rdma_destroy(zap_ep_t zep)
 		__zap_put_ep(&rep->parent_ep->ep);
 	DLOG_(rep, "rep: %p freed\n", rep);
 	free(rep);
+}
+
+static int __buf_pool_init(struct z_rdma_ep *rep)
+{
+	int			i;
+	char			*p;
+	struct z_rdma_buffer	*rb;
+	size_t			pool_sz;
+
+	rep->num_bufs = RQ_DEPTH + SQ_DEPTH + 4;  /* +4 for credit updates */
+	rep->buf_sz   = RQ_BUF_SZ;
+	pool_sz       = rep->num_bufs * rep->buf_sz;
+	rep->buf_pool = malloc(pool_sz);
+	rep->buf_objs = malloc(rep->num_bufs * sizeof(struct z_rdma_buffer));
+	if (!rep->buf_pool || !rep->buf_objs)
+		return ENOMEM;
+	/* need IBV_ACCESS_LOCAL_WRITE for RECV */
+	rep->buf_pool_mr = ibv_reg_mr(rep->pd, rep->buf_pool, pool_sz, IBV_ACCESS_LOCAL_WRITE);
+	if (!rep->buf_pool_mr) {
+		/* rep->buf_pool and rep->buf_objs are freed in
+		 * __rdma_teardown_conn() */
+		return ENOMEM;
+	}
+
+	LIST_INIT(&rep->buf_free_list);
+	pthread_mutex_init(&rep->buf_free_list_lock, NULL);
+	p  = rep->buf_pool;
+	rb = rep->buf_objs;
+	for (i = 0; i < rep->num_bufs; ++i) {
+		rb->rep      = rep;
+		rb->msg      = (void*)p;
+		rb->buf_len  = rep->buf_sz;  /* total size of buffer */
+		rb->data_len = 0;            /* # bytes of buffer used */
+		LIST_INSERT_HEAD(&rep->buf_free_list, rb, free_link);
+		++rb;
+		p += rep->buf_sz;
+	}
+	return 0;
 }
 
 static int __rdma_setup_conn(struct z_rdma_ep *rep)
@@ -354,6 +411,10 @@ static int __rdma_setup_conn(struct z_rdma_ep *rep)
 		goto err_0;
 	}
 
+	ret = __buf_pool_init(rep);
+	if (ret)
+		goto err_0;
+
 	ret = z_rdma_fill_rq(rep);
 	if (ret)
 		goto err_0;
@@ -365,30 +426,26 @@ err_0:
 	return ret;
 }
 
-static struct z_rdma_buffer *
-__rdma_buffer_alloc(struct z_rdma_ep *rep, size_t len,
-		  enum ibv_access_flags f)
+static struct z_rdma_buffer * __rdma_buffer_alloc(struct z_rdma_ep *rep)
 {
-	struct z_rdma_buffer *rbuf;
-
-	rbuf = calloc(1, sizeof *rbuf + len);
-	if (!rbuf)
-		return NULL;
-	rbuf->data = (char *)(rbuf+1);
-	rbuf->data_len = len;
-	rbuf->mr = ibv_reg_mr(rep->pd, rbuf->data, len, f);
-	if (!rbuf->mr) {
-		free(rbuf);
-		LOG_(rep, "RDMA: reg_mr failed: error %d\n", errno);
-		return NULL;
+	struct z_rdma_buffer *rb;
+	pthread_mutex_lock(&rep->buf_free_list_lock);
+	rb = LIST_FIRST(&rep->buf_free_list);
+	if (rb) {
+		LIST_REMOVE(rb, free_link);
+		rb->data_len = 0;
+	} else {
+		errno = ENOMEM;
 	}
-	return rbuf;
+	pthread_mutex_unlock(&rep->buf_free_list_lock);
+	return rb;
 }
 
-static void __rdma_buffer_free(struct z_rdma_buffer *rbuf)
+static inline void __rdma_buffer_free(struct z_rdma_buffer *rb)
 {
-	ibv_dereg_mr(rbuf->mr);
-	free(rbuf);
+	pthread_mutex_lock(&rb->rep->buf_free_list_lock);
+	LIST_INSERT_HEAD(&rb->rep->buf_free_list, rb, free_link);
+	pthread_mutex_unlock(&rb->rep->buf_free_list_lock);
 }
 
 static inline
@@ -513,6 +570,25 @@ post_send(struct z_rdma_ep *rep,
 	return zrc;
 }
 
+static zap_err_t submit_wr(struct z_rdma_ep *rep, struct z_rdma_context *ctxt,
+			   int is_rdma)
+{
+	struct ibv_send_wr *bad_wr;
+	int rc;
+	pthread_mutex_lock(&rep->credit_lock);
+	if (!get_credits(rep, is_rdma)) {
+		rc = post_send(rep, ctxt, &bad_wr, is_rdma);
+		if (rc)
+			LOG_(rep, "RDMA: post_send failed: code %d\n", errno);
+	} else {
+		rc = queue_io(rep, ctxt);
+	}
+	pthread_mutex_unlock(&rep->credit_lock);
+	if (rc)
+		return ZAP_ERR_RESOURCE;
+	return ZAP_ERR_OK;
+}
+
 char * op_str[] = {
 	[IBV_WC_SEND]        =  "IBV_WC_SEND",
 	[IBV_WC_RDMA_WRITE]  =  "IBV_WC_RDMA_WRITE",
@@ -608,7 +684,7 @@ static void submit_pending(struct z_rdma_ep *rep)
 static zap_err_t __rdma_post_send(struct z_rdma_ep *rep, struct z_rdma_buffer *rbuf)
 {
 	int rc;
-	struct ibv_send_wr *bad_wr;
+
 
 	pthread_mutex_lock(&rep->ep.lock);
 	struct z_rdma_context *ctxt =
@@ -620,24 +696,20 @@ static zap_err_t __rdma_post_send(struct z_rdma_ep *rep, struct z_rdma_buffer *r
 	}
 	pthread_mutex_unlock(&rep->ep.lock);
 
-	ctxt->sge.addr = (uint64_t) (unsigned long) rbuf->data;
-	ctxt->sge.length = rbuf->data_len;
-	ctxt->sge.lkey = rbuf->mr->lkey;
+	ctxt->sge[0].addr = (uint64_t)rbuf->msg->bytes;
+	ctxt->sge[0].length = rbuf->data_len;
+	assert(rep == rbuf->rep);
+	ctxt->sge[0].lkey = rep->buf_pool_mr->lkey;
 
 	ctxt->wr.opcode = IBV_WR_SEND;
 	ctxt->wr.next = NULL;
 	ctxt->wr.send_flags = IBV_SEND_SIGNALED;
-	ctxt->wr.sg_list = &ctxt->sge;
+	ctxt->wr.sg_list = ctxt->sge;
 	ctxt->wr.num_sge = 1;
 
 	RDMA_SET_CONTEXT(&ctxt->wr, ctxt);
 
-	pthread_mutex_lock(&rep->credit_lock);
-	if (!get_credits(rep, 0))
-		rc = post_send(rep, ctxt, &bad_wr, 0);
-	else
-		rc = queue_io(rep, ctxt);
-	pthread_mutex_unlock(&rep->credit_lock);
+	rc = submit_wr(rep, ctxt, 0);
 	if (rc)
 		goto err_0;
 
@@ -758,9 +830,10 @@ static int __rdma_post_recv(struct z_rdma_ep *rep, struct z_rdma_buffer *rb)
 		goto out;
 	}
 
-	sge.addr = (uint64_t) (unsigned long) rb->data;
-	sge.length = rb->data_len;
-	sge.lkey = rb->mr->lkey;
+	sge.addr = (uint64_t) rb->msg->bytes;
+	sge.length = rb->buf_len;
+	assert(rep == rb->rep);
+	sge.lkey = rep->buf_pool_mr->lkey;
 	wr.sg_list = &sge;
 	wr.next = NULL;
 	wr.num_sge = 1;
@@ -826,10 +899,21 @@ zap_err_t z_map_err(int wc_status)
 }
 
 static void process_send_wc(struct z_rdma_ep *rep, struct ibv_wc *wc,
-			    struct z_rdma_buffer *rb)
+					struct z_rdma_context *ctxt)
 {
-	if (!wc->status && rb)
-		__rdma_buffer_free(rb);
+	/* NOTE: send_mapped uses 2 SGEs, normal send uses 1 SGE */
+	if (ctxt->wr.num_sge < 2)
+		goto out;
+	struct zap_event zev = {
+			.type = ZAP_EVENT_SEND_MAPPED_COMPLETE,
+			.context = ctxt->usr_context,
+			.status = z_map_err(wc->status),
+		};
+	/* send_mapped needs an application callback */
+	rep->ep.cb(&rep->ep, &zev);
+out:
+	if (!wc->status && ctxt->rb)
+		__rdma_buffer_free(ctxt->rb);
 }
 
 static void process_read_wc(struct z_rdma_ep *rep, struct ibv_wc *wc,
@@ -902,7 +986,7 @@ static void handle_rendezvous(struct z_rdma_ep *rep,
 static void process_recv_wc(struct z_rdma_ep *rep, struct ibv_wc *wc,
 			    struct z_rdma_buffer *rb)
 {
-	struct z_rdma_message_hdr *msg = (struct z_rdma_message_hdr *)rb->data;
+	struct z_rdma_message_hdr *msg = &rb->msg->hdr;
 	uint16_t msg_type;
 	int ret;
 
@@ -976,9 +1060,7 @@ static int z_rdma_fill_rq(struct z_rdma_ep *rep)
 	int i;
 
 	for (i = 0; i < RQ_DEPTH+2; i++) {
-		struct z_rdma_buffer *rbuf =
-			__rdma_buffer_alloc(rep, RQ_BUF_SZ,
-					  IBV_ACCESS_LOCAL_WRITE);
+		struct z_rdma_buffer *rbuf = __rdma_buffer_alloc(rep);
 		if (rbuf) {
 			int rc = __rdma_post_recv(rep, rbuf);
 			if (rc) {
@@ -1136,7 +1218,7 @@ static int cq_event_handler(struct ibv_cq *cq, int count)
 		struct z_rdma_ep *rep = (struct z_rdma_ep *)ep;
 		switch (ctxt->op) {
 		case IBV_WC_SEND:
-			process_send_wc(rep, &wc, ctxt->rb);
+			process_send_wc(rep, &wc, ctxt);
 			put_sq(rep);
 			break;
 
@@ -1832,11 +1914,11 @@ static int send_credit_update(struct z_rdma_ep *rep)
 	struct ibv_send_wr *bad_wr;
 	int rc;
 
-	rbuf = __rdma_buffer_alloc(rep, RQ_BUF_SZ, IBV_ACCESS_LOCAL_WRITE);
+	rbuf = __rdma_buffer_alloc(rep);
 	if (!rbuf)
 		return ENOMEM;
 
-	req = (struct z_rdma_message_hdr *)rbuf->data;
+	req = &rbuf->msg->hdr;
 	req->credits = htons(rep->lcl_rq_credits);
 	req->msg_type = htons(Z_RDMA_MSG_CREDIT_UPDATE);
 	rep->lcl_rq_credits = 0;
@@ -1852,12 +1934,12 @@ static int send_credit_update(struct z_rdma_ep *rep)
 		goto out;
 	}
 
-	ctxt->sge.addr = (uint64_t)(unsigned long)rbuf->data;
-	ctxt->sge.length = sizeof(*req);
-	ctxt->sge.lkey = rbuf->mr->lkey;
+	ctxt->sge[0].addr = (uint64_t)rbuf->msg->bytes;
+	ctxt->sge[0].length = sizeof(*req);
+	ctxt->sge[0].lkey = rep->buf_pool_mr->lkey;
 
 	memset(&ctxt->wr, 0, sizeof(ctxt->wr));
-	ctxt->wr.sg_list = &ctxt->sge;
+	ctxt->wr.sg_list = ctxt->sge;
 	ctxt->wr.num_sge = 1;
 	ctxt->wr.opcode = IBV_WR_SEND;
 	ctxt->wr.send_flags = IBV_SEND_SIGNALED;
@@ -1911,18 +1993,18 @@ static zap_err_t z_rdma_send(zap_ep_t ep, char *buf, size_t len)
 		goto out;
 	}
 
-	rbuf = __rdma_buffer_alloc(rep, RQ_BUF_SZ, IBV_ACCESS_LOCAL_WRITE);
+	rbuf = __rdma_buffer_alloc(rep);
 	if (!rbuf) {
 		rc = ZAP_ERR_RESOURCE;
 		goto out;
 	}
 	pthread_mutex_unlock(&rep->ep.lock);
 
-	hdr = (struct z_rdma_message_hdr *)rbuf->data;
+	hdr = &rbuf->msg->hdr;
 	hdr->msg_type = htons(Z_RDMA_MSG_SEND);
 
 	/* copy the data, leaving room for the rdma header */
-	memcpy(rbuf->data+sizeof(struct z_rdma_message_hdr), buf, len);
+	memcpy(rbuf->msg->bytes+sizeof(struct z_rdma_message_hdr), buf, len);
 	rbuf->data_len = len + sizeof(struct z_rdma_message_hdr);
 
 	rc = __rdma_post_send(rep, rbuf);
@@ -1933,6 +2015,85 @@ static zap_err_t z_rdma_send(zap_ep_t ep, char *buf, size_t len)
  out:
 	pthread_mutex_unlock(&rep->ep.lock);
 	return rc;
+}
+
+static zap_err_t z_rdma_send_mapped(zap_ep_t ep, zap_map_t map, void *buf,
+				    size_t len, void *context)
+{
+	struct z_rdma_ep *rep = (struct z_rdma_ep *)ep;
+	struct z_rdma_message_hdr *hdr;
+	struct z_rdma_buffer *rbuf;
+	struct z_rdma_map *lmap = (struct z_rdma_map *)map;
+	int rc;
+	struct z_rdma_context *ctxt;
+
+
+	pthread_mutex_lock(&rep->ep.lock);
+	rc = __ep_state_check(rep);
+	if (rc)
+		goto err_0;
+
+	if (len > ep->z->max_msg) {
+		rc = ZAP_ERR_NO_SPACE;
+		goto err_0;
+	}
+
+	/* range check */
+	if (z_map_access_validate(map, buf, len, 0)) {
+		rc = ZAP_ERR_LOCAL_LEN;
+		goto err_0;
+	}
+
+	rbuf = __rdma_buffer_alloc(rep);
+	if (!rbuf) {
+		rc = ZAP_ERR_RESOURCE;
+		goto err_0;
+	}
+
+	ctxt = __rdma_context_alloc(rep, context, IBV_WC_SEND, rbuf);
+	if (!ctxt) {
+		rc = ZAP_ERR_RESOURCE;
+		goto err_1;
+	}
+	pthread_mutex_unlock(&rep->ep.lock);
+
+	/* NOTE: using 2 sge
+	 *       sge[0] for the rbuf containing rdma msg header
+	 *       sge[1] for the data payload
+	 */
+
+	hdr = &rbuf->msg->hdr;
+	hdr->msg_type = htons(Z_RDMA_MSG_SEND);
+
+	ctxt->sge[0].addr = (uint64_t)rbuf->msg->bytes;
+	ctxt->sge[0].length = sizeof(*hdr);
+	ctxt->sge[0].lkey = rep->buf_pool_mr->lkey;
+
+	ctxt->sge[1].addr = (uint64_t)buf;
+	ctxt->sge[1].length = len;
+	ctxt->sge[1].lkey = lmap->mr->lkey;
+
+	ctxt->wr.opcode = IBV_WR_SEND;
+	ctxt->wr.next = NULL;
+	ctxt->wr.send_flags = IBV_SEND_SIGNALED;
+	ctxt->wr.sg_list = ctxt->sge;
+	ctxt->wr.num_sge = 2;
+
+	RDMA_SET_CONTEXT(&ctxt->wr, ctxt);
+
+	rc = submit_wr(rep, ctxt, 0);
+	if (rc)
+		goto err_2;
+
+	return ZAP_ERR_OK;
+ err_2:
+	__rdma_context_free(ctxt);
+ err_1:
+	__rdma_buffer_free(rbuf);
+ err_0:
+	pthread_mutex_unlock(&rep->ep.lock);
+	return rc;
+
 }
 
 static zap_err_t z_rdma_share(zap_ep_t ep, zap_map_t map,
@@ -1958,14 +2119,14 @@ static zap_err_t z_rdma_share(zap_ep_t ep, zap_map_t map,
 		return ZAP_ERR_NO_SPACE;
 	}
 
-	rbuf = __rdma_buffer_alloc(rep, RQ_BUF_SZ, IBV_ACCESS_LOCAL_WRITE);
+	rbuf = __rdma_buffer_alloc(rep);
 	if (!rbuf) {
 		pthread_mutex_unlock(&rep->ep.lock);
 		return ZAP_ERR_RESOURCE;
 	}
 	pthread_mutex_unlock(&rep->ep.lock);
 
-	sm = (struct z_rdma_share_msg *)rbuf->data;
+	sm = &rbuf->msg->share;
 	sm->hdr.msg_type = htons(Z_RDMA_MSG_RENDEZVOUS);
 	sm->rkey = rmap->mr->rkey;
 	sm->va = (unsigned long)rmap->map.addr;
@@ -2027,9 +2188,13 @@ z_rdma_map(zap_ep_t ep, zap_map_t *pm,
 
 static zap_err_t z_rdma_unmap(zap_ep_t ep, zap_map_t map)
 {
+	int rc;
 	struct z_rdma_map *zm = (struct z_rdma_map *)map;
-	if (zm->mr)
-		ibv_dereg_mr(zm->mr);
+	if (zm->mr) {
+		rc = ibv_dereg_mr(zm->mr);
+		if (rc)
+			return ZAP_ERR_BUSY;
+	}
 	free(zm);
 	return ZAP_ERR_OK;
 }
@@ -2044,7 +2209,6 @@ static zap_err_t z_rdma_write(zap_ep_t ep,
 	struct z_rdma_ep *rep = (struct z_rdma_ep *)ep;
 	struct z_rdma_map *rmap = (struct z_rdma_map *)dst_map;
 	struct z_rdma_map *lmap = (struct z_rdma_map *)src_map;
-	struct ibv_send_wr *bad_wr;
 	struct z_rdma_context *ctxt;
 
 	pthread_mutex_lock(&rep->ep.lock);
@@ -2058,12 +2222,12 @@ static zap_err_t z_rdma_write(zap_ep_t ep,
 		goto out;
 	}
 
-	ctxt->sge.addr = (unsigned long)src;
-	ctxt->sge.length = sz;
-	ctxt->sge.lkey = lmap->mr->lkey;
+	ctxt->sge[0].addr = (unsigned long)src;
+	ctxt->sge[0].length = sz;
+	ctxt->sge[0].lkey = lmap->mr->lkey;
 
 	memset(&ctxt->wr, 0, sizeof(ctxt->wr));
-	ctxt->wr.sg_list = &ctxt->sge;
+	ctxt->wr.sg_list = ctxt->sge;
 	ctxt->wr.num_sge = 1;
 	ctxt->wr.opcode = IBV_WR_RDMA_WRITE;
 	ctxt->wr.send_flags = IBV_SEND_SIGNALED;
@@ -2071,17 +2235,7 @@ static zap_err_t z_rdma_write(zap_ep_t ep,
 	ctxt->wr.wr.rdma.rkey = rmap->rkey;
 
 	RDMA_SET_CONTEXT(&ctxt->wr, ctxt);
-	pthread_mutex_lock(&rep->credit_lock);
-	if (!get_credits(rep, 1)) {
-		rc = post_send(rep, ctxt, &bad_wr, 1);
-		if (rc) {
-			LOG_(rep, "RDMA: post_send failed: code %d\n", errno);
-			if (errno)
-				rc = errno;
-		}
-	} else
-		rc = queue_io(rep, ctxt);
-	pthread_mutex_unlock(&rep->credit_lock);
+	rc = submit_wr(rep, ctxt, 1);
 	if (rc)
 		__rdma_context_free(ctxt);
 	pthread_mutex_unlock(&rep->ep.lock);
@@ -2101,7 +2255,6 @@ static zap_err_t z_rdma_read(zap_ep_t ep,
 	struct z_rdma_ep *rep = (struct z_rdma_ep *)ep;
 	struct z_rdma_map *lmap = (struct z_rdma_map *)dst_map;
 	struct z_rdma_map *rmap = (struct z_rdma_map *)src_map;
-	struct ibv_send_wr *bad_wr;
 	struct z_rdma_context *ctxt;
 
 	pthread_mutex_lock(&rep->ep.lock);
@@ -2117,11 +2270,11 @@ static zap_err_t z_rdma_read(zap_ep_t ep,
 		return ZAP_ERR_RESOURCE;
 	}
 
-	ctxt->sge.addr = (unsigned long)dst;
-	ctxt->sge.length = sz;
-	ctxt->sge.lkey = lmap->mr->lkey;
+	ctxt->sge[0].addr = (unsigned long)dst;
+	ctxt->sge[0].length = sz;
+	ctxt->sge[0].lkey = lmap->mr->lkey;
 	memset(&ctxt->wr, 0, sizeof(ctxt->wr));
-	ctxt->wr.sg_list = &ctxt->sge;
+	ctxt->wr.sg_list = ctxt->sge;
 	ctxt->wr.num_sge = 1;
 	ctxt->wr.opcode = IBV_WR_RDMA_READ;
 	ctxt->wr.send_flags = IBV_SEND_SIGNALED;
@@ -2129,18 +2282,7 @@ static zap_err_t z_rdma_read(zap_ep_t ep,
 	ctxt->wr.wr.rdma.rkey = rmap->rkey;
 
 	RDMA_SET_CONTEXT(&ctxt->wr, ctxt);
-	pthread_mutex_lock(&rep->credit_lock);
-	if (!get_credits(rep, 1)) {
-		rc = post_send(rep, ctxt, &bad_wr, 1);
-		if (rc) {
-			LOG_(rep, "RDMA: post_send failed: code %d\n", errno);
-			if (errno)
-				rc = errno;
-		}
-	} else
-		rc = queue_io(rep, ctxt);
-	pthread_mutex_unlock(&rep->credit_lock);
-
+	rc = submit_wr(rep, ctxt, 1);
 	if (rc)
 		__rdma_context_free(ctxt);
 	pthread_mutex_unlock(&rep->ep.lock);
@@ -2220,6 +2362,7 @@ zap_err_t zap_transport_get(zap_t *pz, zap_log_fn_t log_fn,
 	z->listen = z_rdma_listen;
 	z->close = z_rdma_close;
 	z->send = z_rdma_send;
+	z->send_mapped = z_rdma_send_mapped;
 	z->read = z_rdma_read;
 	z->write = z_rdma_write;
 	z->map = z_rdma_map;

--- a/lib/src/zap/rdma/zap_rdma.h
+++ b/lib/src/zap/rdma/zap_rdma.h
@@ -1,8 +1,8 @@
 /* -*- c-basic-offset: 8 -*-
- * Copyright (c) 2010-2015,2017 National Technology & Engineering Solutions
+ * Copyright (c) 2010-2015,2017,2020 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
- * Copyright (c) 2010-2015,2017 Open Grid Computing, Inc. All rights reserved.
+ * Copyright (c) 2010-2015,2017,2020 Open Grid Computing, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -96,6 +96,15 @@ struct z_rdma_reject_msg {
 	char msg[OVIS_FLEX];
 };
 
+/* union of all messages */
+union z_rdma_msg {
+	struct z_rdma_message_hdr hdr;   /* header access */
+	struct z_rdma_share_msg   share;
+	struct z_rdma_accept_msg  accept;
+	struct z_rdma_reject_msg  reject;
+	char bytes[0]; /* bytes access */
+};
+
 #pragma pack()
 
 struct z_rdma_map {
@@ -105,9 +114,11 @@ struct z_rdma_map {
 };
 
 struct z_rdma_buffer {
-	char *data;
-	size_t data_len;
-	struct ibv_mr *mr;
+	union z_rdma_msg *msg; /* message buffer */
+	size_t buf_len;  /* buffer length */
+	size_t data_len; /* data written to the buffer */
+	struct z_rdma_ep *rep; /* the endpoint who owns the buffer */
+	LIST_ENTRY(z_rdma_buffer) free_link;
 };
 
 /**
@@ -119,7 +130,7 @@ struct z_rdma_context {
 
 	zap_ep_t ep;
 	struct ibv_send_wr wr;
-	struct ibv_sge sge;
+	struct ibv_sge sge[2];
 
 	enum ibv_wc_opcode op;  /* work-request op (can't be trusted
 				in wc on error */
@@ -154,7 +165,7 @@ struct z_rdma_ep {
 	struct ibv_qp *qp;
 
 	union {
-		struct z_rdma_conn_data conn_data; /* flexi */
+		struct z_rdma_conn_data conn_data;
 		char ___[RDMA_CONN_DATA_MAX];
 	};
 
@@ -194,6 +205,15 @@ struct z_rdma_ep {
 	pthread_mutex_t credit_lock;
 	TAILQ_HEAD(xprt_credit_list, z_rdma_context) io_q;
 	LIST_HEAD(active_ctxt_list, z_rdma_context) active_ctxt_list;
+
+	/* send/recv buffers */
+	int num_bufs;  /* total buffers: 4 + SQ_DEPTH + RQ_DEPTH */
+	size_t buf_sz; /* size of each buffer */
+	char *buf_pool;
+	struct z_rdma_buffer *buf_objs;
+	struct ibv_mr *buf_pool_mr;
+	LIST_HEAD(buf_free_list, z_rdma_buffer) buf_free_list;
+	pthread_mutex_t	buf_free_list_lock;
 
 #ifdef ZAP_DEBUG
 	int rejected_count;

--- a/lib/src/zap/sock/zap_sock.c
+++ b/lib/src/zap/sock/zap_sock.c
@@ -1,8 +1,8 @@
 /* -*- c-basic-offset: 8 -*-
- * Copyright (c) 2014-2019 National Technology & Engineering Solutions
+ * Copyright (c) 2014-2020 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
- * Copyright (c) 2014-2019 Open Grid Computing, Inc. All rights reserved.
+ * Copyright (c) 2014-2020 Open Grid Computing, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -113,7 +113,8 @@ static zap_err_t __sock_send_msg(struct z_sock_ep *sep, struct sock_msg_hdr *m,
 static zap_err_t __sock_send_msg_nolock(struct z_sock_ep *sep,
 					struct sock_msg_hdr *m,
 					size_t msg_size,
-					const char *data, size_t data_len);
+					const char *data, size_t data_len,
+					struct z_sock_io *io);
 
 static int z_sock_buff_init(z_sock_buff_t buff, size_t bytes);
 static void z_sock_buff_cleanup(z_sock_buff_t buff);
@@ -625,6 +626,10 @@ struct z_sock_io *__sock_io_alloc(struct z_sock_ep *sep)
 	if (!TAILQ_EMPTY(&sep->free_q)) {
 		io = TAILQ_FIRST(&sep->free_q);
 		TAILQ_REMOVE(&sep->free_q, io, q_link);
+		io->wr.flags = 0;
+		io->wr.msg_len = 0;
+		io->wr.data_len = 0;
+		io->wr.off = 0;
 	} else
 		io = calloc(1, sizeof(*io));
 	pthread_mutex_unlock(&sep->ep.lock);
@@ -654,10 +659,10 @@ static void process_sep_msg_read_resp(struct z_sock_ep *sep)
 	pthread_mutex_lock(&sep->ep.lock);
 	io = TAILQ_FIRST(&sep->io_q);
 	ZAP_ASSERT(io, (&sep->ep), "%s: The io_q is empty.\n", __func__);
-	ZAP_ASSERT(msg->hdr.xid == io->hdr.xid, (&sep->ep),
+	ZAP_ASSERT(msg->hdr.xid == io->wr.msg.hdr.xid, (&sep->ep),
 			"%s: The transaction IDs mismatched between the "
 			"IO entry %d and message %d.\n", __func__,
-			io->hdr.xid, msg->hdr.xid);
+			io->wr.msg.hdr.xid, msg->hdr.xid);
 	TAILQ_REMOVE(&sep->io_q, io, q_link);
 	pthread_mutex_unlock(&sep->ep.lock);
 
@@ -774,9 +779,10 @@ static void process_sep_msg_write_resp(struct z_sock_ep *sep)
 	io = TAILQ_FIRST(&sep->io_q);
 	ZAP_ASSERT(io, &sep->ep, "%s: The io_q is empty\n", __func__);
 	TAILQ_REMOVE(&sep->io_q, io, q_link);
-	ZAP_ASSERT(io, &sep->ep, "%s: The transaction IDs mismatched "
+	ZAP_ASSERT(io->wr.msg.hdr.xid == msg->hdr.xid, &sep->ep,
+			"%s: The transaction IDs mismatched "
 			"between the IO entry %d and message %d.\n",
-			__func__, io->hdr.xid, msg->hdr.xid);
+			__func__, io->wr.msg.hdr.xid, msg->hdr.xid);
 	/* Put it back on the free_q */
 	pthread_mutex_unlock(&sep->ep.lock);
 	__sock_io_free(sep, io);
@@ -1161,7 +1167,7 @@ static void sock_write(ovis_event_t ev)
 
 	/* msg */
 	while (wr->msg_len) {
-		wsz = write(sep->sock, wr->msg + wr->off, wr->msg_len);
+		wsz = write(sep->sock, wr->msg.bytes + wr->off, wr->msg_len);
 		if (wsz < 0) {
 			if (errno == EAGAIN || errno == EWOULDBLOCK) {
 				__enable_epoll_out(sep);
@@ -1199,7 +1205,24 @@ static void sock_write(ovis_event_t ev)
 
 	/* reaching here means wr->data_len and wr->msg_len are 0 */
 	TAILQ_REMOVE(&sep->sq, wr, link);
-	free(wr);
+	if (wr->flags & Z_SOCK_WR_COMPLETION) {
+		/* right now we have only SEND_COMPLETE delivering by WR */
+		assert(ntohs(wr->msg.hdr.msg_type) == SOCK_MSG_SENDRECV);
+		struct z_sock_io *io = container_of(wr, struct z_sock_io, wr);
+		TAILQ_REMOVE(&sep->io_q, io, q_link);
+		struct zap_event zev = {
+			.type = ZAP_EVENT_SEND_MAPPED_COMPLETE,
+			.status = ZAP_ERR_OK,
+			.context = (void *)io->wr.msg.hdr.ctxt
+		};
+		pthread_mutex_unlock(&sep->ep.lock);
+		sep->ep.cb(&sep->ep, &zev); /* this post to zap interpose queue */
+		__sock_io_free(sep, io);
+		pthread_mutex_lock(&sep->ep.lock);
+		goto next;
+	}
+	if (wr->flags & Z_SOCK_WR_ALLOCATED)
+		free(wr);
 	goto next;
 
  out:
@@ -1342,7 +1365,7 @@ static zap_err_t __sock_send(struct z_sock_ep *sep, uint16_t msg_type,
 	z_sock_hdr_init(&msg.hdr, 0, msg_type, (uint32_t)(sizeof(msg) + len), 0);
 	msg.data_len = htonl(len);
 
-	return __sock_send_msg_nolock(sep, &msg.hdr, sizeof(msg), buf, len);
+	return __sock_send_msg_nolock(sep, &msg.hdr, sizeof(msg), buf, len, NULL);
 }
 
 /* caller must have sep->ep.lock held */
@@ -1370,11 +1393,24 @@ static int __disable_epoll_out(struct z_sock_ep *sep)
 /*
  * Caller must acquire `sep->ep.lock` before calling this function.
  */
+static zap_err_t __wr_post(struct z_sock_ep *sep, z_sock_send_wr_t wr)
+{
+	struct ovis_event_s ev = { .param = { .ctxt = sep } };
+	TAILQ_INSERT_TAIL(&sep->sq, wr, link);
+	sock_write(&ev);
+	return ZAP_ERR_OK;
+}
+
+/*
+ * Caller must acquire `sep->ep.lock` before calling this function.
+ */
 static zap_err_t __sock_send_msg_nolock(struct z_sock_ep *sep,
 					struct sock_msg_hdr *m,
 					size_t msg_size,
-					const char *data, size_t data_len)
+					const char *data, size_t data_len,
+					struct z_sock_io *io)
 {
+	zap_err_t zerr;
 	z_sock_send_wr_t wr;
 	sock_msg_type_t mtype = ntohs(m->msg_type);
 	DEBUG_LOG_SEND_MSG(sep, m);
@@ -1388,7 +1424,7 @@ static zap_err_t __sock_send_msg_nolock(struct z_sock_ep *sep,
 		wr->data_len = data_len;
 		wr->data = data;
 		wr->off = 0;
-		memcpy(wr->msg, m, msg_size);
+		memcpy(wr->msg.bytes, m, msg_size);
 	} else {
 		if (data_len > sep->ep.z->max_msg) {
 			DEBUG_LOG(sep, "ep: %p, SEND invalid message length: %ld\n",
@@ -1402,13 +1438,14 @@ static zap_err_t __sock_send_msg_nolock(struct z_sock_ep *sep,
 		wr->data_len = 0;
 		wr->data = NULL;
 		wr->off = 0;
-		memcpy(wr->msg, m, msg_size);
-		memcpy(wr->msg + msg_size, data, data_len);
+		memcpy(wr->msg.bytes, m, msg_size);
+		memcpy(wr->msg.bytes + msg_size, data, data_len);
 	}
-	TAILQ_INSERT_TAIL(&sep->sq, wr, link);
-	struct ovis_event_s ev = { .param = { .ctxt = sep } };
-	sock_write(&ev);
-	return ZAP_ERR_OK;
+	wr->flags = Z_SOCK_WR_ALLOCATED;
+	zerr = __wr_post(sep, wr);
+	if (zerr)
+		free(wr);
+	return zerr;
 }
 
 static zap_err_t __sock_send_msg(struct z_sock_ep *sep, struct sock_msg_hdr *m,
@@ -1416,7 +1453,7 @@ static zap_err_t __sock_send_msg(struct z_sock_ep *sep, struct sock_msg_hdr *m,
 {
 	zap_err_t zerr;
 	pthread_mutex_lock(&sep->ep.lock);
-	zerr = __sock_send_msg_nolock(sep, m, msg_size, data, data_len);
+	zerr = __sock_send_msg_nolock(sep, m, msg_size, data, data_len, NULL);
 	pthread_mutex_unlock(&sep->ep.lock);
 	return zerr;
 }
@@ -1442,7 +1479,7 @@ static void sock_event(ovis_event_t ev)
 		struct z_sock_io *io = TAILQ_FIRST(&sep->io_q);
 		TAILQ_REMOVE(&sep->io_q, io, q_link);
 
-		msg_type = ntohs(io->hdr.msg_type);
+		msg_type = ntohs(io->wr.msg.hdr.msg_type);
 		if (msg_type >= SOCK_MSG_FIRST && msg_type < SOCK_MSG_TYPE_LAST)
 			ev_type = ev_type_cvt[msg_type];
 		else
@@ -1452,7 +1489,7 @@ static void sock_event(ovis_event_t ev)
 		struct zap_event zev = {
 			.type = ev_type,
 			.status = ZAP_ERR_FLUSH,
-			.context = (void *)io->hdr.ctxt
+			.context = (void *)io->wr.msg.hdr.ctxt
 		};
 		free(io);	/* Don't put back on free_q, we're closing */
 		pthread_mutex_unlock(&sep->ep.lock);
@@ -1648,6 +1685,55 @@ static zap_err_t z_sock_send(zap_ep_t ep, char *buf, size_t len)
 	zerr = __sock_send(sep, SOCK_MSG_SENDRECV, buf, len);
 out:
 	pthread_mutex_unlock(&sep->ep.lock);
+	return zerr;
+}
+
+zap_err_t z_sock_send_mapped(zap_ep_t ep, zap_map_t map, void *buf,
+			     size_t len, void *context)
+{
+	struct z_sock_ep *sep = (struct z_sock_ep *)ep;
+	struct z_sock_io *io = __sock_io_alloc(sep);
+	zap_err_t zerr;
+
+	if (!io)
+		return ZAP_ERR_RESOURCE;
+
+	/* validate */
+	if (z_map_access_validate(map, buf, len, ZAP_ACCESS_NONE) != 0) {
+		zerr = ZAP_ERR_LOCAL_LEN;
+		goto err0;
+	}
+
+	/* prepare wr and message */
+	zerr = ZAP_ERR_RESOURCE;
+	io->wr.flags = Z_SOCK_WR_COMPLETION;
+	io->wr.data = buf;
+	io->wr.data_len = len;
+	io->wr.msg_len = sizeof(io->wr.msg.sendrecv);
+	z_sock_hdr_init(&io->wr.msg.sendrecv.hdr, 0, SOCK_MSG_SENDRECV,
+			io->wr.msg_len + len, (uint64_t)context);
+	io->wr.msg.sendrecv.data_len = htonl((uint32_t) len);
+
+	pthread_mutex_lock(&sep->ep.lock);
+	if (sep->ep.state != ZAP_EP_CONNECTED) {
+		zerr = ZAP_ERR_NOT_CONNECTED;
+		goto err1;
+	}
+
+	TAILQ_INSERT_TAIL(&sep->io_q, io, q_link);
+	/* write message */
+	zerr = __wr_post(sep, &io->wr);
+	if (zerr)
+		goto err2;
+
+	pthread_mutex_unlock(&sep->ep.lock);
+	return ZAP_ERR_OK;
+err2:
+	TAILQ_REMOVE(&sep->io_q, io, q_link);
+err1:
+	pthread_mutex_unlock(&sep->ep.lock);
+err0:
+	__sock_io_free(sep, io);
 	return zerr;
 }
 
@@ -1864,6 +1950,7 @@ static zap_err_t z_sock_read(zap_ep_t ep, zap_map_t src_map, char *src,
 {
 	struct z_sock_ep *sep = (struct z_sock_ep *)ep;
 	struct z_sock_io *io = __sock_io_alloc(sep);
+	struct zap_sock_map *src_smap = (void*) src_map;
 	zap_err_t zerr = ZAP_ERR_OK;
 
 	if (!io)
@@ -1880,13 +1967,13 @@ static zap_err_t z_sock_read(zap_ep_t ep, zap_map_t src_map, char *src,
 		goto err;
 	}
 
-	/* prepare message */
-	z_sock_hdr_init(&io->read.hdr, 0, SOCK_MSG_READ_REQ,
-		   sizeof(io->read), (uint64_t)context);
-	struct zap_sock_map *src_smap = (void*) src_map;
-	io->read.src_map_key = src_smap->key;
-	io->read.src_ptr = htobe64((uint64_t) src);
-	io->read.data_len = htonl((uint32_t)sz);
+	/* prepare wr and message */
+	io->wr.msg_len = sizeof(io->wr.msg.read_req);
+	z_sock_hdr_init(&io->wr.msg.hdr, 0, SOCK_MSG_READ_REQ,
+		   sizeof(io->wr.msg.read_req), (uint64_t)context);
+	io->wr.msg.read_req.src_map_key = src_smap->key;
+	io->wr.msg.read_req.src_ptr = htobe64((uint64_t) src);
+	io->wr.msg.read_req.data_len = htonl((uint32_t)sz);
 	io->dst_map = dst_map;
 	io->dst_ptr = dst;
 
@@ -1899,14 +1986,12 @@ static zap_err_t z_sock_read(zap_ep_t ep, zap_map_t src_map, char *src,
 
 	TAILQ_INSERT_TAIL(&sep->io_q, io, q_link);
 	/* write message */
-	zerr = __sock_send_msg_nolock(sep, &io->read.hdr, sizeof(io->read),
-				      NULL, 0);
+	zerr = __wr_post(sep, &io->wr);
 	if (zerr)
 		goto err1;
 
 	pthread_mutex_unlock(&sep->ep.lock);
-	zerr = ZAP_ERR_OK;
-	return zerr;
+	return ZAP_ERR_OK;
 err1:
 	TAILQ_REMOVE(&sep->io_q, io, q_link);
 	pthread_mutex_unlock(&sep->ep.lock);
@@ -1921,6 +2006,7 @@ static zap_err_t z_sock_write(zap_ep_t ep, zap_map_t src_map, char *src,
 {
 	struct z_sock_ep *sep = (struct z_sock_ep *)ep;
 	struct z_sock_io *io = __sock_io_alloc(sep);
+	struct zap_sock_map *sdst_map = (void*)dst_map;
 	zap_err_t zerr;
 
 	if (!io)
@@ -1937,14 +2023,16 @@ static zap_err_t z_sock_write(zap_ep_t ep, zap_map_t src_map, char *src,
 		goto err0;
 	}
 
-	/* prepare message */
-
-	z_sock_hdr_init(&io->write.hdr, 0, SOCK_MSG_WRITE_REQ,
-		   sizeof(io->write) + sz, (uint64_t)context);
-	struct zap_sock_map *sdst_map = (void*)dst_map;
-	io->write.dst_map_key = sdst_map->key;
-	io->write.dst_ptr = htobe64((uint64_t) dst);
-	io->write.data_len = htonl((uint32_t) sz);
+	/* prepare wr and message */
+	zerr = ZAP_ERR_RESOURCE;
+	io->wr.data = src;
+	io->wr.data_len = sz;
+	io->wr.msg_len = sizeof(io->wr.msg.write_req);
+	z_sock_hdr_init(&io->wr.msg.write_req.hdr, 0, SOCK_MSG_WRITE_REQ,
+			io->wr.msg_len + sz, (uint64_t)context);
+	io->wr.msg.write_req.dst_map_key = sdst_map->key;
+	io->wr.msg.write_req.dst_ptr = htobe64((uint64_t) dst);
+	io->wr.msg.write_req.data_len = htonl((uint32_t) sz);
 
 
 	pthread_mutex_lock(&sep->ep.lock);
@@ -1955,8 +2043,7 @@ static zap_err_t z_sock_write(zap_ep_t ep, zap_map_t src_map, char *src,
 
 	TAILQ_INSERT_TAIL(&sep->io_q, io, q_link);
 	/* write message */
-	zerr = __sock_send_msg_nolock(sep, &io->write.hdr, sizeof(io->write),
-				      src, sz);
+	zerr = __wr_post(sep, &io->wr);
 	if (zerr)
 		goto err2;
 
@@ -2006,6 +2093,7 @@ zap_err_t zap_transport_get(zap_t *pz, zap_log_fn_t log_fn,
 	z->unmap = z_sock_unmap;
 	z->share = z_sock_share;
 	z->get_name = z_get_name;
+	z->send_mapped = z_sock_send_mapped;
 
 	/* is it needed? */
 	z->mem_info_fn = mem_info_fn;

--- a/lib/src/zap/ugni/zap_ugni.c
+++ b/lib/src/zap/ugni/zap_ugni.c
@@ -1,8 +1,8 @@
 /* -*- c-basic-offset: 8 -*-
- * Copyright (c) 2014-2017,2019 National Technology & Engineering Solutions
+ * Copyright (c) 2014-2017,2019-2020 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
- * Copyright (c) 2014-2017,2019 Open Grid Computing, Inc. All rights reserved.
+ * Copyright (c) 2014-2017,2019-2020 Open Grid Computing, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -199,6 +199,7 @@ static void ugni_sock_connect(ovis_event_t ev);
 
 static void stalled_timeout_cb(ovis_event_t ev);
 static zap_err_t __setup_connection(struct z_ugni_ep *uep);
+static zap_err_t z_ugni_close(zap_ep_t ep);
 
 static int __get_nodeid(struct sockaddr *sa, socklen_t sa_len);
 static int __check_node_state(int node_id);
@@ -307,6 +308,33 @@ static int __set_sockbuf_sz(int sockfd)
 	rc = setsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, &optval, sizeof(optval));
 	return rc;
 }
+
+static zap_err_t __node_state_check(struct z_ugni_ep *uep)
+{
+	/* node state validation */
+	if (!_node_state.check_state)
+		return ZAP_ERR_OK;
+	if (uep->node_id == -1) {
+		struct sockaddr lsa, sa;
+		socklen_t sa_len;
+		zap_err_t zerr;
+		zerr = zap_get_name(&uep->ep, &lsa, &sa, &sa_len);
+		if (zerr) {
+			DLOG("zap_get_name() error: %d\n", zerr);
+			return ZAP_ERR_ENDPOINT;
+		}
+		uep->node_id = __get_nodeid(&sa, sa_len);
+	}
+	if (uep->node_id != -1) {
+		if (__check_node_state(uep->node_id)) {
+			DLOG("Node %d is in a bad state\n", uep->node_id);
+			z_ugni_close(&uep->ep);
+			return ZAP_ERR_ENDPOINT;
+		}
+	}
+	return ZAP_ERR_OK;
+}
+
 static int __sock_nonblock(int fd)
 {
 	int rc;
@@ -643,22 +671,40 @@ static void ugni_sock_write(ovis_event_t ev)
 		goto out;
 	}
 
-	wsz = write(uep->sock, wr->data + wr->off, wr->alen);
-	if (wsz < 0) {
-		if (errno == EAGAIN || errno == EWOULDBLOCK)
-			goto out;
-		/* bad error */
-		goto err;
+	/* msg part */
+	while (wr->moff < wr->msz) {
+		wsz = write(uep->sock, wr->msg.bytes + wr->moff, wr->msz - wr->moff);
+		if (wsz < 0) {
+			if (errno == EAGAIN || errno == EWOULDBLOCK)
+				goto out;
+			/* bad error */
+			goto err;
+		}
+		wr->moff += wsz;
+	}
+	/* data part */
+	while (wr->doff < wr->dsz) {
+		wsz = write(uep->sock, wr->data + wr->doff, wr->dsz - wr->doff);
+		if (wsz < 0) {
+			if (errno == EAGAIN || errno == EWOULDBLOCK)
+				goto out;
+			/* bad error */
+			goto err;
+		}
+		wr->doff += wsz;
 	}
 
-	if (wsz < wr->alen) {
-		wr->alen -= wsz;
-		wr->off += wsz;
-		goto out;
-	}
-
-	/* reaching here means wr->alen == 0 */
+	/* wr completed */
 	STAILQ_REMOVE_HEAD(&uep->sq, link);
+	if (wr->cb) {
+		pthread_mutex_unlock(&uep->ep.lock);
+		struct zap_event ev = {
+				.type = ZAP_EVENT_SEND_MAPPED_COMPLETE,
+				.context = wr->ctxt
+			};
+		uep->ep.cb(&uep->ep, &ev);
+		pthread_mutex_lock(&uep->ep.lock);
+	}
 	free(wr);
 	goto next;
 
@@ -1367,35 +1413,72 @@ static void *error_thread_proc(void *args)
 	return NULL;
 }
 
-/* msg hdr fields are in network-byte-order */
-/* caller must held uep->ep.lock */
-static zap_err_t __ugni_send_msg(struct z_ugni_ep *uep,
-				 struct zap_ugni_msg_hdr *msg,
-				 size_t msg_len,
-				 const void *data,
-				 size_t data_len)
+static struct zap_ugni_send_wr *__wr_alloc(enum zap_ugni_msg_type mtype,
+					   size_t data_len,
+					   int buf_alloc)
 {
-	int rc;
+	/* buf_alloc:  0 - do not allocate data buffer,
+	 * buf_alloc: !0 - allocate data buffer */
+	size_t msz;
 	struct zap_ugni_send_wr *wr;
 
-	if (data_len > uep->ep.z->max_msg) {
-		/* message too big */
-		return ZAP_ERR_NO_SPACE;
+	switch (mtype) {
+	case ZAP_UGNI_MSG_CONNECT:
+		msz = sizeof(struct zap_ugni_msg_connect);
+		break;
+	case ZAP_UGNI_MSG_REGULAR:
+	case ZAP_UGNI_MSG_REJECTED:     /* use regular msg */
+	case ZAP_UGNI_MSG_ACK_ACCEPTED: /* use regular msg */
+		msz = sizeof(struct zap_ugni_msg_regular);
+		break;
+	case ZAP_UGNI_MSG_RENDEZVOUS:
+		msz = sizeof(struct zap_ugni_msg_rendezvous);
+		break;
+	case ZAP_UGNI_MSG_ACCEPTED:
+		msz = sizeof(struct zap_ugni_msg_accepted);
+		break;
+	default:
+		errno = EINVAL;
+		return NULL;
 	}
 
-	wr = malloc(sizeof(*wr) + msg_len + data_len);
+	wr = malloc(sizeof(*wr) + (!!buf_alloc)*data_len);
 	if (!wr)
-		return ZAP_ERR_RESOURCE;
-	wr->alen = msg_len + data_len;
-	wr->off = 0;
-	memcpy(wr->data, msg, msg_len);
-	if (data && data_len)
-		memcpy(wr->data + msg_len, data, data_len);
+		return NULL;
+
+	wr->cb = 0;
+	wr->moff = 0;
+	wr->msz = msz;
+	wr->doff = 0;
+	wr->dsz = data_len;
+	wr->data = (char*)&wr[1];
+	wr->msg.hdr.msg_type = htons(mtype);
+	wr->msg.hdr.msg_len  = htonl((uint32_t)(msz + data_len));
+	return wr;
+}
+
+/* caller must held uep->ep.lock */
+static zap_err_t __wr_post(struct z_ugni_ep *uep, struct zap_ugni_send_wr *wr)
+{
+	int rc;
+	switch (uep->ep.state) {
+	case ZAP_EP_LISTENING:
+	case ZAP_EP_ACCEPTING:
+	case ZAP_EP_CONNECTING:
+	case ZAP_EP_CONNECTED:
+		/* OK */
+		break;
+	case ZAP_EP_PEER_CLOSE:
+	case ZAP_EP_CLOSE:
+	case ZAP_EP_ERROR:
+	default:
+		return ZAP_ERR_NOT_CONNECTED;
+	}
+
 	STAILQ_INSERT_TAIL(&uep->sq, wr, link);
 	rc = __enable_epoll_out(uep);
-	if (rc) {
+	if (rc)
 		return ZAP_ERR_RESOURCE;
-	}
 	return ZAP_ERR_OK;
 }
 
@@ -1403,23 +1486,22 @@ static zap_err_t __ugni_send_msg(struct z_ugni_ep *uep,
 static zap_err_t __ugni_send_connect(struct z_ugni_ep *uep, char *buf, size_t len)
 {
 	zap_err_t zerr;
-	struct zap_ugni_msg_connect msg = {
-		.hdr = {
-			.msg_type = htons(ZAP_UGNI_MSG_CONNECT),
-			.msg_len = htonl((uint32_t)(sizeof(msg) + len)),
-		},
-		.data_len = htonl(len),
-		.inst_id = htonl(_dom.inst_id),
-		.pe_addr = htonl(_dom.pe_addr),
-	};
-
-	ZAP_VERSION_SET(msg.ver);
-	memcpy(&msg.sig, ZAP_UGNI_SIG, sizeof(msg.sig));
-
-	zerr = __ugni_send_msg(uep, &msg.hdr, sizeof(msg), buf, len);
+	struct zap_ugni_msg_connect *msg;
+	struct zap_ugni_send_wr *wr = __wr_alloc(ZAP_UGNI_MSG_CONNECT, len, 1);
+	if (!wr)
+		return ZAP_ERR_RESOURCE;
+	msg = &wr->msg.connect;
+	msg->data_len     = htonl(len);
+	msg->inst_id      = htonl(_dom.inst_id);
+	msg->pe_addr      = htonl(_dom.pe_addr);
+	ZAP_VERSION_SET(msg->ver);
+	memcpy(&msg->sig, ZAP_UGNI_SIG, sizeof(msg->sig));
+	if (buf && len)
+		memcpy(wr->data, buf, len);
+	zerr = __wr_post(uep, wr);
 	if (zerr)
-		return zerr;
-	return ZAP_ERR_OK;
+		free(wr);
+	return zerr;
 }
 
 /* caller must held uep->ep.lock */
@@ -1428,17 +1510,19 @@ __ugni_send(struct z_ugni_ep *uep, enum zap_ugni_msg_type type,
 						char *buf, size_t len)
 {
 	zap_err_t zerr;
-	struct zap_ugni_msg_regular msg = {
-		.hdr = {
-			.msg_type = htons(type),
-			.msg_len = htonl((uint32_t)(sizeof(msg) + len)),
-		},
-		.data_len = htonl(len),
-	};
-
-	zerr = __ugni_send_msg(uep, &msg.hdr, sizeof(msg), buf, len);
-	if (zerr)
+	struct zap_ugni_msg_regular *msg;
+	struct zap_ugni_send_wr *wr = __wr_alloc(type, len, 1);
+	if (!wr)
+		return ZAP_ERR_RESOURCE;
+	msg = &wr->msg.sendrecv;
+	msg->data_len     = htonl(len);
+	if (buf && len)
+		memcpy(wr->data, buf, len);
+	zerr = __wr_post(uep, wr);
+	if (zerr) {
+		free(wr);
 		return zerr;
+	}
 	return ZAP_ERR_OK;
 }
 
@@ -1578,6 +1662,7 @@ static void ugni_sock_event(ovis_event_t ev)
 	int rc;
 	struct z_ugni_ep *uep = ev->param.ctxt;
 	struct zap_event *zev = &uep->conn_ev;
+	struct zap_ugni_send_wr *wr;
 
 	/* Reaching here means bev is one of the EOF, ERROR or TIMEOUT */
 	pthread_mutex_lock(&uep->ep.lock);
@@ -1619,6 +1704,23 @@ static void ugni_sock_event(ovis_event_t ev)
 	}
 	DLOG_(uep, "%s: ep %p: state %s\n", __func__, uep,
 				__zap_ep_state_str[uep->ep.state]);
+
+	/* flush wr */
+	while ((wr = STAILQ_FIRST(&uep->sq))) {
+		STAILQ_REMOVE_HEAD(&uep->sq, link);
+		if (wr->cb) {
+			struct zap_event ev = {
+				.type    = ZAP_EVENT_SEND_MAPPED_COMPLETE,
+				.status  = ZAP_ERR_FLUSH,
+				.context = wr->ctxt,
+			};
+			pthread_mutex_unlock(&uep->ep.lock);
+			uep->ep.cb(&uep->ep, &ev);
+			pthread_mutex_lock(&uep->ep.lock);
+		}
+		free(wr);
+	}
+
 	pthread_mutex_unlock(&uep->ep.lock);
 	if (defer) {
 		/*
@@ -1820,26 +1922,9 @@ static zap_err_t z_ugni_send(zap_ep_t ep, char *buf, size_t len)
 	zap_err_t zerr;
 
 	/* node state validation */
-	if (_node_state.check_state) {
-		if (uep->node_id == -1) {
-			struct sockaddr lsa, sa;
-			socklen_t sa_len;
-			zap_err_t zerr;
-			zerr = zap_get_name(ep, &lsa, &sa, &sa_len);
-			if (zerr) {
-				DLOG("zap_get_name() error: %d\n", zerr);
-				return ZAP_ERR_ENDPOINT;
-			}
-			uep->node_id = __get_nodeid(&sa, sa_len);
-		}
-		if (uep->node_id != -1) {
-			if (__check_node_state(uep->node_id)) {
-				DLOG("Node %d is in a bad state\n", uep->node_id);
-				z_ugni_close(ep);
-				return ZAP_ERR_ENDPOINT;
-			}
-		}
-	}
+	zerr = __node_state_check(uep);
+	if (zerr)
+		return zerr;
 
 	pthread_mutex_lock(&uep->ep.lock);
 	if (!uep->gni_ep || ep->state != ZAP_EP_CONNECTED) {
@@ -1849,6 +1934,43 @@ static zap_err_t z_ugni_send(zap_ep_t ep, char *buf, size_t len)
 
 	zerr = __ugni_send(uep, ZAP_UGNI_MSG_REGULAR, buf, len);
 	pthread_mutex_unlock(&uep->ep.lock);
+	return zerr;
+}
+
+static zap_err_t
+z_ugni_send_mapped(zap_ep_t ep, zap_map_t map, void *buf, size_t len,
+		   void *context)
+{
+	struct z_ugni_ep *uep = (void*)ep;
+	zap_err_t zerr;
+	struct zap_ugni_msg_regular *msg;
+	struct zap_ugni_send_wr *wr;
+
+	/* map validation */
+	if (map->type != ZAP_MAP_LOCAL)
+		return ZAP_ERR_INVALID_MAP_TYPE;
+	if (z_map_access_validate(map, buf, len, 0))
+		return ZAP_ERR_LOCAL_LEN;
+
+	/* node state validation */
+	zerr = __node_state_check(uep);
+	if (zerr)
+		return zerr;
+
+	wr = __wr_alloc(ZAP_UGNI_MSG_REGULAR, len, 0);
+	if(!wr)
+		return ZAP_ERR_TRANSPORT;
+	wr->ctxt = context;
+	wr->cb = 1;
+	wr->data = buf;
+	msg = &wr->msg.sendrecv;
+	msg->data_len = htonl(len);
+	pthread_mutex_lock(&uep->ep.lock);
+	zerr = __wr_post(uep, wr);
+	if (zerr)
+		free(wr);
+	pthread_mutex_unlock(&uep->ep.lock);
+
 	return zerr;
 }
 
@@ -2476,21 +2598,22 @@ static void z_ugni_destroy(zap_ep_t ep)
 static zap_err_t __ugni_send_accept(struct z_ugni_ep *uep, char *buf, size_t len)
 {
 	zap_err_t zerr;
-	struct zap_ugni_msg_accepted msg = {
-		.hdr = {
-			.msg_type = htons(ZAP_UGNI_MSG_ACCEPTED),
-			.msg_len = htonl((uint32_t)(sizeof(msg) + len)),
-		},
-		.data_len = htonl(len),
-		.inst_id = htonl(_dom.inst_id),
-		.pe_addr = htonl(_dom.pe_addr),
-	};
-
+	struct zap_ugni_msg_accepted *msg;
+	struct zap_ugni_send_wr *wr = __wr_alloc(ZAP_UGNI_MSG_ACCEPTED, len, 1);
+	if (!wr)
+		return ZAP_ERR_RESOURCE;
+	msg = &wr->msg.accept;
+	msg->data_len = htonl(len);
+	msg->inst_id = htonl(_dom.inst_id);
+	msg->pe_addr = htonl(_dom.pe_addr);
+	if (buf && len)
+		memcpy(wr->data, buf, len);
 	DLOG_(uep, "Sending ZAP_UGNI_MSG_ACCEPTED\n");
-
-	zerr = __ugni_send_msg(uep, &msg.hdr, sizeof(msg), buf, len);
-	if (zerr)
+	zerr = __wr_post(uep, wr);
+	if (zerr) {
+		free(wr);
 		return zerr;
+	}
 	return ZAP_ERR_OK;
 }
 
@@ -2533,10 +2656,10 @@ static zap_err_t z_ugni_reject(zap_ep_t ep, char *data, size_t data_len)
 	zap_err_t zerr;
 
 	pthread_mutex_lock(&uep->ep.lock);
-	uep->ep.state = ZAP_EP_ERROR;
 	zerr = __ugni_send(uep, ZAP_UGNI_MSG_REJECTED, data, data_len);
 	if (zerr)
 		goto err;
+	uep->ep.state = ZAP_EP_ERROR;
 	pthread_mutex_unlock(&uep->ep.lock);
 	return ZAP_ERR_OK;
 err:
@@ -2582,6 +2705,7 @@ static zap_err_t z_ugni_share(zap_ep_t ep, zap_map_t map,
 				const char *msg, size_t msg_len)
 {
 	zap_err_t rc;
+	struct z_ugni_ep *uep = (void*) ep;
 
 	/* validate */
 	if (ep->state != ZAP_EP_CONNECTED)
@@ -2590,51 +2714,33 @@ static zap_err_t z_ugni_share(zap_ep_t ep, zap_map_t map,
 	if (map->type != ZAP_MAP_LOCAL)
 		return ZAP_ERR_INVALID_MAP_TYPE;
 
-	struct z_ugni_ep *uep = (void*) ep;
-
 	/* node state validation */
-	if (_node_state.check_state) {
-		if (uep->node_id == -1) {
-			struct sockaddr lsa, sa;
-			socklen_t sa_len;
-			zap_err_t zerr;
-			zerr = zap_get_name(ep, &lsa, &sa, &sa_len);
-			if (zerr) {
-				DLOG("zap_get_name() error: %d\n", zerr);
-				return ZAP_ERR_ENDPOINT;
-			}
-			uep->node_id = __get_nodeid(&sa, sa_len);
-		}
-		if (uep->node_id != -1) {
-			if (__check_node_state(uep->node_id)) {
-				DLOG("Node %d is in a bad state\n", uep->node_id);
-				z_ugni_close(ep);
-				return ZAP_ERR_ENDPOINT;
-			}
-		}
-	}
+	rc = __node_state_check(uep);
+	if (rc)
+		return rc;
 
 	/* prepare message */
 	struct zap_ugni_map *smap = (struct zap_ugni_map *)map;
-	struct zap_ugni_msg_rendezvous msgr = {
-		.hdr = {
-			.msg_type = htons(ZAP_UGNI_MSG_RENDEZVOUS),
-			.msg_len = htonl(sizeof(msgr) + msg_len),
-		},
-		.gni_mh = {
-			.qword1 = htobe64(smap->gni_mh.qword1),
-			.qword2 = htobe64(smap->gni_mh.qword2),
-		},
-		.addr = htobe64((uint64_t)map->addr),
-		.data_len = htonl(map->len),
-		.acc = htonl(map->acc),
-
-	};
+	struct zap_ugni_msg_rendezvous *msgr;
+	struct zap_ugni_send_wr *wr = __wr_alloc(ZAP_UGNI_MSG_RENDEZVOUS, msg_len, 1);
+	if (!wr)
+		return ZAP_ERR_RESOURCE;
+	wr->dsz = msg_len;
+	wr->msz = sizeof(*msgr);
+	msgr = &wr->msg.rendezvous;
+	msgr->gni_mh.qword1  =  htobe64(smap->gni_mh.qword1);
+	msgr->gni_mh.qword2  =  htobe64(smap->gni_mh.qword2);
+	msgr->addr           =  htobe64((uint64_t)map->addr);
+	msgr->data_len       =  htonl(map->len);
+	msgr->acc            =  htonl(map->acc);
+	if (msg && msg_len)
+		memcpy(wr->data, msg, msg_len);
 
 	pthread_mutex_lock(&uep->ep.lock);
-	rc = __ugni_send_msg(uep, &msgr.hdr, sizeof(msgr), msg, msg_len);
+	rc = __wr_post(uep, wr);
 	pthread_mutex_unlock(&uep->ep.lock);
-
+	if (rc)
+		free(wr);
 	return rc;
 }
 
@@ -2661,26 +2767,9 @@ static zap_err_t z_ugni_read(zap_ep_t ep, zap_map_t src_map, char *src,
 	struct zap_ugni_map *dmap = (struct zap_ugni_map *)dst_map;
 
 	/* node state validation */
-	if (_node_state.check_state) {
-		if (uep->node_id == -1) {
-			struct sockaddr lsa, sa;
-			socklen_t sa_len;
-			zap_err_t zerr;
-			zerr = zap_get_name(ep, &lsa, &sa, &sa_len);
-			if (zerr) {
-				DLOG("zap_get_name() error: %d\n", zerr);
-				return ZAP_ERR_ENDPOINT;
-			}
-			uep->node_id = __get_nodeid(&sa, sa_len);
-		}
-		if (uep->node_id != -1) {
-			if (__check_node_state(uep->node_id)) {
-				DLOG("Node %d is in a bad state\n", uep->node_id);
-				z_ugni_close(ep);
-				return ZAP_ERR_ENDPOINT;
-			}
-		}
-	}
+	zerr = __node_state_check(uep);
+	if (zerr)
+		return zerr;
 
 	pthread_mutex_lock(&ep->lock);
 	if (!uep->gni_ep || ep->state != ZAP_EP_CONNECTED) {
@@ -2778,26 +2867,10 @@ static zap_err_t z_ugni_write(zap_ep_t ep, zap_map_t src_map, char *src,
 	struct zap_ugni_map *dmap = (void*)dst_map;
 
 	/* node state validation */
-	if (_node_state.check_state) {
-		if (uep->node_id == -1) {
-			struct sockaddr lsa, sa;
-			socklen_t sa_len;
-			zap_err_t zerr;
-			zerr = zap_get_name(ep, &lsa, &sa, &sa_len);
-			if (zerr) {
-				DLOG("zap_get_name() error: %d\n", zerr);
-				return ZAP_ERR_ENDPOINT;
-			}
-			uep->node_id = __get_nodeid(&sa, sa_len);
-		}
-		if (uep->node_id != -1) {
-			if (__check_node_state(uep->node_id)) {
-				DLOG("Node %d is in a bad state\n", uep->node_id);
-				z_ugni_close(ep);
-				return ZAP_ERR_ENDPOINT;
-			}
-		}
-	}
+	zap_err_t zerr;
+	zerr = __node_state_check(uep);
+	if (zerr)
+		return zerr;
 
 	pthread_mutex_lock(&ep->lock);
 	if (!uep->gni_ep || ep->state != ZAP_EP_CONNECTED) {
@@ -2874,6 +2947,7 @@ zap_err_t zap_transport_get(zap_t *pz, zap_log_fn_t log_fn,
 	z->listen = z_ugni_listen;
 	z->close = z_ugni_close;
 	z->send = z_ugni_send;
+	z->send_mapped = z_ugni_send_mapped;
 	z->read = z_ugni_read;
 	z->write = z_ugni_write;
 	z->map = z_ugni_map;

--- a/lib/src/zap/ugni/zap_ugni.h
+++ b/lib/src/zap/ugni/zap_ugni.h
@@ -1,8 +1,8 @@
 /**
- * Copyright (c) 2014-2017,2019 National Technology & Engineering Solutions
+ * Copyright (c) 2014-2017,2019-2020 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
- * Copyright (c) 2014-2017,2019 Open Grid Computing, Inc. All rights reserved.
+ * Copyright (c) 2014-2017,2019-2020 Open Grid Computing, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -225,13 +225,28 @@ struct zap_ugni_msg_connect {
 	char data[OVIS_FLEX];      /**< Size of connection data */
 };
 
+/* union of all messages */
+union zap_ugni_msg {
+	char bytes[0]; /* bytes access */
+	struct zap_ugni_msg_hdr        hdr;        /* the header part */
+	struct zap_ugni_msg_regular    sendrecv;   /* send-recv */
+	struct zap_ugni_msg_rendezvous rendezvous; /* rendezvous */
+	struct zap_ugni_msg_accepted   accept;     /* rendezvous */
+	struct zap_ugni_msg_connect    connect;    /* rendezvous */
+};
+
 #pragma pack()
 
 struct zap_ugni_send_wr {
 	STAILQ_ENTRY(zap_ugni_send_wr) link;
-	off_t off; /* offset of to be written */
-	size_t alen; /* remaining length after data + off */
-	char data[OVIS_FLEX];
+	void  *ctxt; /* for send_mapped completion */
+	int    cb;   /* 1 if completion causes a callback */
+	off_t  moff; /* message offset (bytes written) */
+	size_t msz;  /* size of message in the union msg (excluding data) */
+	off_t  doff; /* data payload offset (bytes written) */
+	size_t dsz;  /* size of the data payload */
+	char  *data; /* pointer to the data payload */
+	union zap_ugni_msg msg; /* the message (excluding data) */
 };
 
 struct zap_ugni_recv_buff {

--- a/lib/src/zap/zap.c
+++ b/lib/src/zap/zap.c
@@ -1,8 +1,8 @@
 /* -*- c-basic-offset: 8 -*-
- * Copyright (c) 2013-2017,2019 National Technology & Engineering Solutions
+ * Copyright (c) 2013-2017,2019,2020 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
- * Copyright (c) 2013-2017,2019 Open Grid Computing, Inc. All rights reserved.
+ * Copyright (c) 2013-2017,2019,2020 Open Grid Computing, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -136,6 +136,7 @@ static char *__zap_event_str[] = {
 	"ZAP_EVENT_READ_COMPLETE",
 	"ZAP_EVENT_WRITE_COMPLETE",
 	"ZAP_EVENT_RENDEZVOUS",
+	"ZAP_EVENT_SEND_MAPPED_COMPLETE",
 	"ZAP_EVENT_LAST"
 };
 
@@ -356,6 +357,7 @@ void blocking_zap_cb(zap_ep_t zep, zap_event_t ev)
 		/* Just do nothing */
 		break;
 	case ZAP_EVENT_WRITE_COMPLETE:
+	case ZAP_EVENT_SEND_MAPPED_COMPLETE:
 		/* Do nothing */
 		break;
 	default:
@@ -392,6 +394,7 @@ void zap_interpose_cb(zap_ep_t ep, zap_event_t ev)
 	case ZAP_EVENT_DISCONNECTED:
 	case ZAP_EVENT_READ_COMPLETE:
 	case ZAP_EVENT_WRITE_COMPLETE:
+	case ZAP_EVENT_SEND_MAPPED_COMPLETE:
 		ev->data = NULL;
 		ev->data_len = 0;
 		/* do nothing */
@@ -526,6 +529,14 @@ zap_err_t zap_send(zap_ep_t ep, void *buf, size_t sz)
 	zerr = ep->z->send(ep, buf, sz);
 	zap_put_ep(ep);
 	return zerr;
+}
+
+zap_err_t zap_send_mapped(zap_ep_t ep, zap_map_t map, void *buf, size_t len,
+			  void *context)
+{
+	if (!ep->z->send_mapped)
+		return ZAP_ERR_NOT_SUPPORTED;
+	return ep->z->send_mapped(ep, map, buf, len, context);
 }
 
 zap_err_t zap_write(zap_ep_t ep,
@@ -669,15 +680,6 @@ zap_err_t zap_share(zap_ep_t ep, zap_map_t m, const char *msg, size_t msg_len)
 zap_err_t zap_reject(zap_ep_t ep, char *data, size_t data_len)
 {
 	return ep->z->reject(ep, data, data_len);
-}
-
-int z_map_access_validate(zap_map_t map, char *p, size_t sz, zap_access_t acc)
-{
-	if (p < map->addr || (map->addr + map->len) < (p + sz))
-		return ERANGE;
-	if ((map->acc & acc) != acc)
-		return EACCES;
-	return 0;
 }
 
 void *zap_event_thread_proc(void *arg)

--- a/lib/src/zap/zap.h
+++ b/lib/src/zap/zap.h
@@ -1,8 +1,8 @@
 /* -*- c-basic-offset: 8 -*-
- * Copyright (c) 2013-2017 National Technology & Engineering Solutions
+ * Copyright (c) 2013-2017,2020 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
- * Copyright (c) 2013-2017 Open Grid Computing, Inc. All rights reserved.
+ * Copyright (c) 2013-2017,2020 Open Grid Computing, Inc. All rights reserved.
  *
  * Under the terms of Contract DE-AC04-94AL85000, there is a non-exclusive
  * license for use of this work by or on behalf of the U.S. Government.
@@ -112,6 +112,8 @@ typedef enum zap_event_type {
 	ZAP_EVENT_WRITE_COMPLETE,
 	/*! The peer has shared a buffer with \c zap_share(). */
 	ZAP_EVENT_RENDEZVOUS,
+	/*! A \c zap_send_mapped() request has completed. */
+	ZAP_EVENT_SEND_MAPPED_COMPLETE,
 	/*! Last event (dummy) */
 	ZAP_EVENT_LAST
 } zap_event_type_t;
@@ -166,6 +168,8 @@ typedef enum zap_err_e {
 	ZAP_ERR_TIMEOUT,
 	/*! Transport flush error. */
 	ZAP_ERR_FLUSH,
+	/*! Operation not supported. */
+	ZAP_ERR_NOT_SUPPORTED,
 	/*! Last error (dummy). */
 	ZAP_ERR_LAST
 } zap_err_t;
@@ -195,6 +199,7 @@ static const char *__zap_err_str[] = {
 	"ZAP_ERR_RETRY_EXCEEDED",
 	"ZAP_ERR_TIMEOUT",
 	"ZAP_ERR_FLUSH",
+	"ZAP_ERR_NOT_SUPPORTED",
 	"ZAP_ERR_LAST"
 };
 
@@ -553,6 +558,39 @@ zap_err_t zap_close(zap_ep_t ep);
  *		reason for failure.
  */
 zap_err_t zap_send(zap_ep_t ep, void *buf, size_t sz);
+
+/**
+ * \brief Send data to peer using map.
+ *
+ * This is a more efficient send interface compared to \c zap_send(). The data
+ * to be sent is described by \c map, \c buf and \c len. The data will not be
+ * copied out to the internal zap buffer (unlike \c zap_send()) and the
+ * application should not modify the data in the specified range (buf[0..len-1])
+ * before the send operation is completed. The \c buf buffer is owned by
+ * the transport until the ZAP_EVENT_SEND_MAPPED_COMPLETE event is received.
+ * The completion of the send operation results in \c ZAP_EVENT_SEND_MAPPED_COMPLETE
+ * event with the specified \c context delivered via the callback function
+ * specified in \c zap_new() or \c zap_accept(). The completion status
+ * could be success or failed.
+ *
+ * If the function call returns \c ZAP_ERR_OK, it is guaranteed that \c
+ * ZAP_EVENT_SEND_MAPPED_COMPLETE corresponding to the call will be delivered.
+ * On the other hand, if this function returns an error (synchronously failed),
+ * it is also guaranteed that \c ZAP_EVENT_SEND_MAPPED_COMPLETE (that would
+ * associate with the call) won't be delivered.
+ *
+ * \param ep      The endpoint handle.
+ * \param map     The map handler describing the memory region used in the send
+ *                operation.
+ * \param buf     The pointer of the send buffer.
+ * \param len     The length of the data to be sent.
+ * \param context The application context.
+ *
+ * \retval ZAP_ERR_OK The send operation is posted successfully.
+ * \retval ZAP_ERR    The zap error code describing the synchronous error.
+ */
+zap_err_t zap_send_mapped(zap_ep_t ep, zap_map_t map, void *buf, size_t len,
+			  void *context);
 
 /** \brief RDMA write data to a remote buffer */
 zap_err_t zap_write(zap_ep_t t,

--- a/lib/src/zap/zap_priv.h
+++ b/lib/src/zap/zap_priv.h
@@ -53,6 +53,7 @@
 #include <semaphore.h>
 #include <sys/queue.h>
 #include <pthread.h>
+#include <errno.h>
 #include "ovis-ldms-config.h"
 #include "zap.h"
 
@@ -246,6 +247,18 @@ struct zap {
 
 	/** Pointer to the transport's private data */
 	void *private;
+
+	/**
+	 * \brief Send mapped data to peer.
+	 *
+	 * No data is copied out from the described memory region. When the
+	 * operation is completed, \c ZAP_EVENT_SEND_COMPLETE shall be
+	 * delivered. If the operation synchronously failed, \c
+	 * ZAP_EVENT_SEND_NAPPED_COMPLETE will not be delivered. The \c context is the
+	 * application context coupling with the completion event.
+	 */
+	zap_err_t (*send_mapped)(zap_ep_t ep, zap_map_t map, void *buf,
+				 size_t len, void *context);
 };
 
 static inline zap_err_t
@@ -308,7 +321,15 @@ typedef zap_err_t (*zap_get_fn_t)(zap_t *pz, zap_log_fn_t log_fn,
  * \returns ERANGE For invalid range access.
  * \returns EACCES For invalid access permission.
  */
-int z_map_access_validate(zap_map_t map, char *p, size_t sz, zap_access_t acc);
+static inline
+int z_map_access_validate(zap_map_t map, char *p, size_t sz, zap_access_t acc)
+{
+	if (p < map->addr || (map->addr + map->len) < (p + sz))
+		return ERANGE;
+	if ((map->acc & acc) != acc)
+		return EACCES;
+	return 0;
+}
 
 /* this is the default value for the number of zap_io_threads */
 #define ZAP_EVENT_WORKERS 4


### PR DESCRIPTION
Currently the zap_send() API receives application buffer and copies it
to another buffer that has been registered with the hardware using the
zap_map() interface. The zap_send() API is simple to use but is
inefficient when the same buffer is to be sent to many clients because
the same buffer is mapped and copied many times.

The zap_send_mapped() API has the following signature.

   int zap_send_mapped(zap_ep_t ep, zap_map_t map, void *buf,
                       size_t len, void *context)

The zap_send_mapped() API posts the RDMA_SEND operation directly from
the previously mapped buffer (map) without requiring registration or
copy by the transport. This significantly improves performance for
sending operation. Unlike the zap_send() API, the zap_send_mapped() API
delivers a completion event via the application callback function unless
the function return an error.