### PR TITLE
Fix zap_fabric busy wait in listening endpoint

### DIFF
--- a/lib/src/zap/fabric/zap_fabric.c
+++ b/lib/src/zap/fabric/zap_fabric.c
@@ -1978,7 +1978,7 @@ static zap_err_t z_fi_listen(zap_ep_t ep, struct sockaddr *saddr, socklen_t sa_l
 			   rep->fi->fabric_attr->prov_name,
 			   rep->fi->domain_attr->name);
 
-	cm_event.events = EPOLLIN | EPOLLOUT;
+	cm_event.events = EPOLLIN;
 	cm_event.data.ptr = rep;
 	rc = epoll_ctl(g.cm_fd, EPOLL_CTL_ADD, rep->cm_fd, &cm_event);
 	if (rc)


### PR DESCRIPTION
The epoll event parameter for the zap_fabric listening endpoint event
queue was set to `EPOLLIN|EPOLLOUT`. This made `epoll_wait()` returned
right away since the file descriptor was (somehow) ready for "write",
and when we process the event queue (`scrub_cq()`), we got -FI_EAGAIN
since there was nothing yet to read. The CM thread in zap_fabric that
processes the event queus will appear busy. Setting the epoll event
parameter to `EPOLLIN` solved the issue.