### PR TITLE
zap_fabric: fix spinning cq/eq thread

### DIFF
--- a/lib/src/zap/fabric/zap_fabric.c
+++ b/lib/src/zap/fabric/zap_fabric.c
@@ -1338,13 +1338,19 @@ static void scrub_cq(struct z_fi_ep *rep)
 	int			ret;
 	struct z_fi_context	*ctxt;
 	struct fi_cq_err_entry	entry;
+	struct fid		*fid[1];
 
 	DLOG("rep %p\n", rep);
 	while (1) {
 		memset(&entry, 0, sizeof(entry));
 		ret = fi_cq_read(rep->cq, &entry, 1);
-		if ((ret == 0) || (ret == -FI_EAGAIN))
+		if ((ret == 0) || (ret == -FI_EAGAIN)) {
+			fid[0] = &rep->cq->fid;
+			ret = fi_trywait(rep->fabric, fid, 1);
+			if (ret == -FI_EAGAIN)
+				continue;
 			break;
+		}
 		if (ret == -FI_EAVAIL) {
 			fi_cq_readerr(rep->cq, &entry, 0);
 			if (entry.err != FI_ECANCELED) {
@@ -1753,14 +1759,20 @@ static void scrub_eq(struct z_fi_ep *rep)
 	ssize_t			ret;
 	uint32_t		event;
 	struct fi_eq_err_entry	entry;
+	struct fid		*fid[1];
 
 	DLOG("rep %p\n", rep);
 	__zap_get_ep(&rep->ep, "EQE");
 	while (1) {
 		memset(&entry, 0, sizeof(entry));
 		ret = fi_eq_read(rep->eq, &event, &entry, sizeof(entry), 0);
-		if ((ret == 0) || (ret == -FI_EAGAIN))
+		if ((ret == 0) || (ret == -FI_EAGAIN)) {
+			fid[0] = &rep->eq->fid;
+			ret = fi_trywait(rep->fabric, fid, 1);
+			if (ret == -FI_EAGAIN)
+				continue;
 			break;
+		}
 		if (ret == -FI_EAVAIL) {
 			fi_eq_readerr(rep->eq, &entry, 0);
 			event = -FI_EAVAIL;


### PR DESCRIPTION
zap_fabric cq thread uses epoll with fabric WAIT_FD to tell when a
completion is ready to be processed by `fi_cq_read()`. However,
`fi_cq_read()` only reads the completion entry from the cq. It does not
read the notification from the WAIT_FD. As a result, WAIT_FD is always
available for EPOLLIN, and `epoll_wait()` instantly returned, making the
cq thread spin with false notification.

According to `fi_poll(3)` man page, `fi_trywait()` should be called and
get `FI_SUCCESS` before we natively wait the WAIT_FD (e.g.
epoll_wait()) on both cq and eq. And, if `fi_trywait()` returns
`-FI_EAGAIN`, the queue is not empty and shall be processed before
natively wait for new entries.

This patch add the logic in zap_fabric `scrub_cq()` and `scrub_eq()` to
call `fi_trywait()` on the cq and eq, then reprocess the cq and eq if
necessary.

This has been tested with `CLAGS='-DDEBUG -DEP_DEBUG '` on fabric-TCP,
fabric-sockets, and fabric-verbs-iWarp.

NOTE: By the code inspection of
`libfabric/prov/verbs/src/verbs_cq.c`, the cq notification is read from
`channel->fd` by `ibv_get_cq_event()` from `fi_trywait()`. `-FI_EAGAIN`
only returns if `cq` has an entry in it. The fi verbs eq works a little
differently (libfabric/prov/verbs/src/verbs_eq.c). `verbs` provider uses
libfabric socket pairs and list to manage eq notification and delivery.