### PR TITLE
Fix zap_fabric flush_io_q

### DIFF
--- a/lib/src/zap/fabric/zap_fabric.c
+++ b/lib/src/zap/fabric/zap_fabric.c
@@ -706,7 +706,7 @@ static void flush_io_q(struct z_fi_ep *rep)
 			if (ctxt->u.send.rb)
 				__buffer_free(ctxt->u.send.rb);
 			__context_free(ctxt);
-			return;
+			continue;
 		    case ZAP_WC_RDMA_WRITE:
 			ev.type = ZAP_EVENT_WRITE_COMPLETE;
 			ev.context = ctxt->usr_context;


### PR DESCRIPTION
Since zap does not (yet) have send completion, the operation is
flushed without calling application callback. However, the flush
handling of the `send` request returned from the flush_io_q() function
right away instead of continuing to flush the next work request.
This patch the flush_io_q() to continue flushing the entire io_q.