### PR TITLE
github action build test update

### DIFF
--- a/.github/workflows/build-test-centos7.yaml
+++ b/.github/workflows/build-test-centos7.yaml
@@ -10,17 +10,17 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     container:
-        image: morrone/centos7-ldms-build:latest
+        image: ovishpc/ovis-centos-build
     steps:
     - uses: actions/checkout@v2
     - run: sh autogen.sh
-    - run: ./configure
+    - run: ./configure CFLAGS="-Wall -Werror"
     - run: make
 
   distcheck:
     runs-on: ubuntu-20.04
     container:
-        image: morrone/centos7-ldms-build:latest
+        image: ovishpc/ovis-centos-build
     steps:
     - uses: actions/checkout@v2
     - run: sh autogen.sh


### PR DESCRIPTION
- add "-Wall -Werror" to the build test.
- use ovishpc container image for the build. This is the same one used
  in ldms-test repository.