### PR TITLE
Add a build test on Ubuntu-20.04

### DIFF
--- a/.github/workflows/build-test-ubuntu.yaml
+++ b/.github/workflows/build-test-ubuntu.yaml
@@ -1,0 +1,28 @@
+name: Build Test - Ubuntu-20.04
+
+on:
+  push:
+    branches: [ OVIS-4 ]
+  pull_request:
+    branches: [ OVIS-4 ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    container:
+        image: ovishpc/ovis-ubuntu-build
+    steps:
+    - uses: actions/checkout@v2
+    - run: sh autogen.sh
+    - run: ./configure CFLAGS="-Wall -Werror"
+    - run: make
+
+  distcheck:
+    runs-on: ubuntu-20.04
+    container:
+        image: ovishpc/ovis-ubuntu-build
+    steps:
+    - uses: actions/checkout@v2
+    - run: sh autogen.sh
+    - run: ./configure
+    - run: make distcheck


### PR DESCRIPTION
The test includes build job and distcheck job. The build uses the
default enable/disable configure options.