### PR TITLE
Fix zap_fabric build error (w/o DEBUG)

### DIFF
--- a/lib/src/zap/fabric/zap_fabric.c
+++ b/lib/src/zap/fabric/zap_fabric.c
@@ -90,6 +90,7 @@ static struct {
 	pthread_mutex_t		lock;
 } g;
 
+__attribute__((unused))
 static const char *z_fi_op_str[] = {
 	[ZAP_WC_SEND]        =  "ZAP_WC_SEND",
 	[ZAP_WC_RECV]        =  "ZAP_WC_RECV",


### PR DESCRIPTION
When building zap_fabric without `-DDEBUG`, the static global variable
`z_fi_op_str` is not used. With `-Wall -Werror`, this resulted in
build error. This patch marks the variable unused with
`__attribute__((unused))`.