### PR TITLE
Fix slurm configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -430,7 +430,7 @@ AC_ARG_WITH([slurm],
 	[AS_HELP_STRING([--with-slurm],
 			[support SLURM jobid information and more @<:@default=check@:>@])],
 			[AS_IF([test "x$withval" != xyes -a "x$withval" != xno],
-				[SLURM_CFLAGS="-I $withval"])],
+				[SLURM_CFLAGS="-I $withval/include"])],
 	[with_slurm=check])
 have_slurm=no
 AS_IF([test "x$with_slurm" != no],[
@@ -443,6 +443,7 @@ AS_IF([test "x$with_slurm" != no],[
 		AS_IF([test "x$with_slurm" != xcheck],
 			[AC_MSG_ERROR([<slurm/spank.h> not found. slurm installed?])],
 			[AC_MSG_WARN([Disabling SLURM support.])])])
+	AC_SUBST([SLURM_CFLAGS],[$SLURM_CFLAGS])
 ])
 AM_CONDITIONAL([HAVE_SLURM], [test "x$have_slurm" = xyes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -439,7 +439,7 @@ AS_IF([test "x$with_slurm" != no],[
 	AC_CHECK_HEADER([slurm/spank.h], [have_slurm=yes], [have_slurm=no])
 	CFLAGS=$save_CFLAGS
 
-	AS_IF([test "x$have_slurm=" = xno],[
+	AS_IF([test "x$have_slurm" = xno],[
 		AS_IF([test "x$with_slurm" != xcheck],
 			[AC_MSG_ERROR([<slurm/spank.h> not found. slurm installed?])],
 			[AC_MSG_WARN([Disabling SLURM support.])])])


### PR DESCRIPTION
This pull request addresses the following issues.

When Slurm is not installed in a system default directory (`/usr`), and `--with-slurm=<SLURM_PREFIX>` is given to the configure script, the build system will silently ***not*** build plugins that depend on slurm because:

1. `SLURM_CFLAGS` includes the installation prefix (`withval`) instead of prefix/include (`withval/include`). `have_slurm` will end up being `no`.
2. There is a typo in the condition checking before printing an error that makes it not printing the error.

In addition, SLURM_CFLAGS is not exported to automake -- making the build failed later even though 1 and 2 is fixed.

So far, I have not experienced this because `ovishpc/ovis-centos-build` dockerhub image has slurm installed in the default system directories. Building on a system that has slurm installed in /opt/slurm exposes the issues.