### PR TITLE
zap_rdma omnipath workaround

### DIFF
--- a/lib/src/zap/rdma/zap_rdma.c
+++ b/lib/src/zap/rdma/zap_rdma.c
@@ -1414,6 +1414,9 @@ handle_addr_resolved(struct z_rdma_ep *rep, struct rdma_cm_id *cma_id)
 	assert(rep->ep.state == ZAP_EP_CONNECTING);
 	DLOG("addr_resolved cm_id %p (rep %p), device %s\n",
 			rep->cm_id, rep, rep->cm_id->verbs->device->name);
+	if (0 == strncasecmp("hfi1", rep->cm_id->verbs->device->name, 4)) {
+		rep->dev_type = Z_RDMA_DEV_HFI1;
+	}
 	ret = rdma_resolve_route(cma_id, 2000);
 	if (ret) {
 		DLOG("removing cm_channel %p fd %d (rep %p)\n", rep->cm_channel, rep->cm_channel->fd, rep);
@@ -1897,6 +1900,9 @@ z_rdma_listen(zap_ep_t ep, struct sockaddr *sin, socklen_t sa_len)
 	}
 	DLOG("listening cm_id %p created (rep %p), device %s\n",
 			rep->cm_id, rep, rep->cm_id->verbs->device->name);
+	if (0 == strncasecmp("hfi1", rep->cm_id->verbs->device->name, 4)) {
+		rep->dev_type = Z_RDMA_DEV_HFI1;
+	}
 
 	cm_event.events = EPOLLIN | EPOLLOUT;
 	cm_event.data.ptr = rep;

--- a/lib/src/zap/rdma/zap_rdma.h
+++ b/lib/src/zap/rdma/zap_rdma.h
@@ -205,6 +205,8 @@ struct z_rdma_ep {
 		Z_RDMA_DEV_OTHER,
 		Z_RDMA_DEV_HFI1,  /* omnipath */
 	} dev_type;
+	int cm_channel_enabled;
+	int cq_channel_enabled;
 };
 
 #endif

--- a/lib/src/zap/rdma/zap_rdma.h
+++ b/lib/src/zap/rdma/zap_rdma.h
@@ -201,6 +201,10 @@ struct z_rdma_ep {
 #endif /* ZAP_DEBUG */
 
 	LIST_ENTRY(z_rdma_ep) ep_link;
+	enum {
+		Z_RDMA_DEV_OTHER,
+		Z_RDMA_DEV_HFI1,  /* omnipath */
+	} dev_type;
 };
 
 #endif

--- a/lib/src/zap/rdma/zap_rdma.h
+++ b/lib/src/zap/rdma/zap_rdma.h
@@ -127,6 +127,8 @@ struct z_rdma_context {
 
 	TAILQ_ENTRY(z_rdma_context) pending_link; /* pending i/o */
 	LIST_ENTRY(z_rdma_context) active_ctxt_link;
+
+	int is_pending; /* for debugging */
 };
 
 #pragma pack(push, 1)
@@ -200,7 +202,8 @@ struct z_rdma_ep {
 	int rejected_conn_error_count;
 #endif /* ZAP_DEBUG */
 
-	LIST_ENTRY(z_rdma_ep) ep_link;
+	TAILQ_ENTRY(z_rdma_ep) ep_link;
+
 	enum {
 		Z_RDMA_DEV_OTHER,
 		Z_RDMA_DEV_HFI1,  /* omnipath */


### PR DESCRIPTION
omnipath evidently does not deliver all completions. This series of commits contain zap_rdma workaround for omnipath and zap_rdma debug log improvements introduced when debugging zap_rdma over omnipath.