### PR TITLE
Fix zap.c so that LDMS processes can run as daemons on Ubuntu20.04

### DIFF
--- a/lib/src/zap/zap.c
+++ b/lib/src/zap/zap.c
@@ -994,18 +994,14 @@ void zap_thrstat_free_result(struct zap_thrstat_result *res)
 	free(res);
 }
 
-#ifdef NDEBUG
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#endif
-static void __attribute__ ((constructor)) cs_init(void)
+static void init_atfork(void)
 {
 	int i;
 	int rc;
 	int stats_w;
 
-	pthread_atfork(NULL, NULL, cs_init);
 	pthread_mutex_init(&zap_list_lock, 0);
-	
+
 	stats_w = ZAP_ENV_INT(ZAP_THRSTAT_WINDOW);
 	zap_event_workers = ZAP_ENV_INT(ZAP_EVENT_WORKERS);
 	zap_event_qdepth = ZAP_ENV_INT(ZAP_EVENT_QDEPTH);
@@ -1024,6 +1020,15 @@ static void __attribute__ ((constructor)) cs_init(void)
 		pthread_setname_np(zev_queue[i].thread, thread_name);
 
 	}
+}
+
+#ifdef NDEBUG
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
+static void __attribute__ ((constructor)) cs_init(void)
+{
+	pthread_atfork(NULL, NULL, init_atfork);
+	init_atfork();
 }
 
 static void __attribute__ ((destructor)) cs_term(void)


### PR DESCRIPTION
When an LDMSD starts on Ubuntu20.04 as a daemon, the process stuck after
the demonization process starts. It turns out that it is a deadlock when
glibc is handling the child hook registered in zap.c by calling
pthead_atfork(). In zap.c, cs_init() calls pthread_atfork() and
registers cs_init() itself as the child hook handler.