### PR TITLE
fix uninit var messages so Wall/Werror works for ldms_jobid.c

### DIFF
--- a/ldms/src/sampler/ldms_jobid.c
+++ b/ldms/src/sampler/ldms_jobid.c
@@ -542,9 +542,9 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 
 
 
-	uid_t uid;
-	gid_t gid;
-	int perm;
+	uid_t uid = 0;
+	gid_t gid = 0;
+	int perm = 0777;
 	bool uid_is_set = false;
 	bool gid_is_set = false;
 	bool perm_is_set = false;


### PR DESCRIPTION
The variables being additionally initialized are actually guarded by corresponding
*_is_set bools, but it would take IPA for gcc to notice and prevent the extraneous warning.