### PR TITLE
fix information leak in sock plugin

### DIFF
--- a/lib/src/zap/sock/zap_sock.c
+++ b/lib/src/zap/sock/zap_sock.c
@@ -575,6 +575,8 @@ static void process_sep_msg_read_req(struct z_sock_ep *sep)
 	uint32_t data_len;
 	char *src;
 	struct sock_msg_read_resp rmsg;
+	memset(&(rmsg.status), 0, sizeof(int32_t));
+	rmsg.dst_ptr = 0;
 
 	msg = sep->buff.data;
 


### PR DESCRIPTION
struct sock_msg_read_resp has an alignment hole after 'status'.
This change fixes the information leak to network of that hole (memset)
and the uninitialized dst_ptr space.