### PR TITLE
add define for sampler base attributes.

### DIFF
--- a/ldms/src/sampler/dstat/dstat.c
+++ b/ldms/src/sampler/dstat/dstat.c
@@ -418,16 +418,8 @@ static const char *usage(struct ldmsd_plugin *self)
 }
 
 static const char *dstat_opts[] = {
+	BASE_ATTRIBUTES,
 	"debug",
-	"schema",
-	"instance",
-	"producer",
-	"component_id",
-	"uid",
-	"gid",
-	"perm",
-	"job_set",
-	"set_array_card",
 	"io",
 	"stat",
 	"statm",

--- a/ldms/src/sampler/sampler_base.h
+++ b/ldms/src/sampler/sampler_base.h
@@ -119,6 +119,25 @@ typedef struct base_data_s {
 
 #define BASE_CONFIG_USAGE BASE_CONFIG_SYNOPSIS BASE_CONFIG_DESC
 
+/** Define the list of reserved attributes plugins derived from 
+ * base should not use for other than the standard purposes.
+ * Format is suitable for inclusion in an array of strings initializer.
+ */
+#define BASE_ATTRIBUTES \
+	"producer", \
+	"instance", \
+	"component_id", \
+	"schema", \
+	"job_set", \
+	"job_id", \
+	"app_id", \
+	"job_start", \
+	"job_end", \
+	"uid", \
+	"gid", \
+	"perm", \
+	"set_array_card"
+
 /**
  * \brief Create a sample schema with the standard metrics
  *


### PR DESCRIPTION
This lets plugins apply attribute config filters without duplicating
a string list that can get out of date as the base evolves.
It also documents the list in code form instead of comments.
The list is the union of the attributes actually processed
in sampler_base.c and the ones reserved in the documentation
of sampler_base.h.