### PR TITLE
fix ovis_join_buf to match ovis_join behavior

### DIFF
--- a/lib/src/ovis_util/test_util.c
+++ b/lib/src/ovis_util/test_util.c
@@ -49,6 +49,7 @@ void test_av()
 	} else {
 		printf("copy succeeded\n");
 	}
+	free(s);
 	free(p1);
 	free(p2);
 	av_free(cp);
@@ -115,6 +116,13 @@ int main(int argc, char **argv)
 	rc = ovis_join_buf(shortbuf, sizeof(shortbuf), NULL,s1,s2,s3,NULL);
 	if (rc == 0 || strcmp(t,shortbuf) == 0) {
 		printf("error 6: ovis_join_buf(sb,ss,NULL,s1,s2,s3,NULL) %d %s\n",
+			rc, strerror(rc));
+		errcnt++;
+	}
+	snprintf(shortbuf,12,"0123456789"); // insufficient buf
+	rc = ovis_join_buf(shortbuf, sizeof(shortbuf), NULL,s1,s2,s3,NULL);
+	if (rc == 0 || strcmp(t,shortbuf) == 0) {
+		printf("error 7: ovis_join_buf(sb,ss,NULL,s1,s2,s3,NULL) %d %s\n",
 			rc, strerror(rc));
 		errcnt++;
 	}

--- a/lib/src/ovis_util/util.c
+++ b/lib/src/ovis_util/util.c
@@ -658,6 +658,8 @@ __attribute__ ((sentinel)) int ovis_join_buf(char *buf, size_t buflen, char *pat
 
 	if (!buf)
 		return EINVAL;
+	buf[0] = '\0';
+	
 
 	va_start(ap, pathsep);
 	n = va_arg(ap, const char *);
@@ -668,7 +670,6 @@ __attribute__ ((sentinel)) int ovis_join_buf(char *buf, size_t buflen, char *pat
 
 	chunk = strlen(n);
 	if ( (len + chunk) < buflen) {
-		printf("chunk %zu %s\n", chunk, n);
 		strncat(buf + len, n, chunk);
 		len += chunk;
 	} else {

--- a/lib/src/ovis_util/util.h
+++ b/lib/src/ovis_util/util.h
@@ -226,6 +226,7 @@ __attribute__ ((sentinel)) char *ovis_join(char *joiner, ...);
  * \param ... A null terminated list of const char *.
  * Example: ovis_join_buf(buf, 256, "\\","c:\\root", "file.txt", NULL);
  * \return 0 if successful, or errno if input problem detected.
+ * Any preexisting buf content is overwritten.
  */
 __attribute__ ((sentinel)) int ovis_join_buf(char *buf, size_t buflen, char *joiner, ...);
 


### PR DESCRIPTION
also fix leak in test_util.c.
Fixes the lack of proper buf initialization in ovis_join_buf which could also lead to buffer overflow as well as the behavior mismatch.