### PR TITLE
remove unsupported udata_default argument from tests

### DIFF
--- a/ldms/scripts/examples/conf_csv.2
+++ b/ldms/scripts/examples/conf_csv.2
@@ -1,12 +1,12 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} job_set=localhost${i}/job_info
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} job_set=localhost${i}/job_info
 start name=vmstat interval=1000000 offset=0
 load name=clock
-config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} job_set=localhost${i}/job_info
 start name=clock interval=1000000 offset=0
 load name=procstat
-config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} job_set=localhost${i}/job_info
 start name=procstat interval=1000000 offset=0

--- a/ldms/scripts/examples/conf_csv.3
+++ b/ldms/scripts/examples/conf_csv.3
@@ -1,12 +1,12 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} job_set=localhost${i}/job_info
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} job_set=localhost${i}/job_info
 start name=vmstat interval=1000000 offset=0
 load name=clock
-config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} job_set=localhost${i}/job_info
 start name=clock interval=1000000 offset=0
 load name=procstat
-config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} job_set=localhost${i}/job_info
 start name=procstat interval=1000000 offset=0

--- a/ldms/scripts/examples/conf_file_csv.2
+++ b/ldms/scripts/examples/conf_file_csv.2
@@ -1,12 +1,12 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} job_set=localhost${i}/job_info
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} job_set=localhost${i}/job_info
 start name=vmstat interval=1000000 offset=0
 load name=clock
-config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} job_set=localhost${i}/job_info
 start name=clock interval=1000000 offset=0
 load name=procstat
-config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} job_set=localhost${i}/job_info
 start name=procstat interval=1000000 offset=0

--- a/ldms/scripts/examples/conf_file_csv.3
+++ b/ldms/scripts/examples/conf_file_csv.3
@@ -1,12 +1,12 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} job_set=localhost${i}/job_info
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} job_set=localhost${i}/job_info
 start name=vmstat interval=1000000 offset=0
 load name=clock
-config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} job_set=localhost${i}/job_info
 start name=clock interval=1000000 offset=0
 load name=procstat
-config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} job_set=localhost${i}/job_info
 start name=procstat interval=1000000 offset=0

--- a/ldms/scripts/examples/many.2
+++ b/ldms/scripts/examples/many.2
@@ -1,12 +1,12 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} job_set=localhost${i}/job_info
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} job_set=localhost${i}/job_info
 start name=vmstat interval=1000000 offset=0
 load name=clock
-config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} job_set=localhost${i}/job_info
 start name=clock interval=1000000 offset=0
 load name=procstat
-config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} job_set=localhost${i}/job_info
 start name=procstat interval=1000000 offset=0

--- a/ldms/scripts/examples/many.3
+++ b/ldms/scripts/examples/many.3
@@ -1,12 +1,12 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} job_set=localhost${i}/job_info
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} job_set=localhost${i}/job_info
 start name=vmstat interval=1000000 offset=0
 load name=clock
-config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} job_set=localhost${i}/job_info
 start name=clock interval=1000000 offset=0
 load name=procstat
-config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} job_set=localhost${i}/job_info
 start name=procstat interval=1000000 offset=0

--- a/ldms/scripts/examples/rabbitkw.2
+++ b/ldms/scripts/examples/rabbitkw.2
@@ -1,11 +1,11 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i}
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} 
 start name=meminfo interval=1000000 offset=0
 
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i}
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} 
 start name=vmstat interval=1000000 offset=0
 
 load name=array_example
-config name=array_example producer=localhost${i} instance=localhost${i}/ax schema=vmstat component_id=${i} udata_default=${i} num_metrics=2 num_ele=3 type=F32_ARRAY
+config name=array_example producer=localhost${i} instance=localhost${i}/ax schema=vmstat component_id=${i} num_metrics=2 num_ele=3 type=F32_ARRAY
 start name=array_example interval=1000000 offset=0

--- a/ldms/scripts/examples/rabbitkw.3
+++ b/ldms/scripts/examples/rabbitkw.3
@@ -1,6 +1,6 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i}
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} 
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i}
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} 
 start name=vmstat interval=1000000 offset=0

--- a/ldms/scripts/examples/rabbitkwl2.3
+++ b/ldms/scripts/examples/rabbitkwl2.3
@@ -1,9 +1,9 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i}
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} 
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i}
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} 
 start name=vmstat interval=1000000 offset=0
 load name=procnetdev
-config name=procnetdev producer=localhost${i} instance=localhost${i}/procnetdev schema=procnetdev component_id=${i} udata_default=${i} ifaces=lo
+config name=procnetdev producer=localhost${i} instance=localhost${i}/procnetdev schema=procnetdev component_id=${i} ifaces=lo
 start name=procnetdev interval=1000000 offset=0

--- a/ldms/scripts/examples/rabbitl2remote.2
+++ b/ldms/scripts/examples/rabbitl2remote.2
@@ -1,5 +1,5 @@
 load name=dstat
-config name=dstat producer=localhost${i} instance=localhost${i}/dstat schema=dstat component_id=${i} udata_default=${i} mmalloc=1
+config name=dstat producer=localhost${i} instance=localhost${i}/dstat schema=dstat component_id=${i} mmalloc=1
 start name=dstat interval=1000000 offset=0
 
 updtr_add name=allhosts interval=1000000 offset=100000

--- a/ldms/scripts/examples/rabbitl2remote.3
+++ b/ldms/scripts/examples/rabbitl2remote.3
@@ -1,9 +1,9 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i}
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} 
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i}
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} 
 start name=vmstat interval=1000000 offset=0
 load name=procnetdev
-config name=procnetdev producer=localhost${i} instance=localhost${i}/procnetdev schema=procnetdev component_id=${i} udata_default=${i} ifaces=lo
+config name=procnetdev producer=localhost${i} instance=localhost${i}/procnetdev schema=procnetdev component_id=${i} ifaces=lo
 start name=procnetdev interval=1000000 offset=0

--- a/ldms/scripts/examples/rabbitv3.2
+++ b/ldms/scripts/examples/rabbitv3.2
@@ -1,6 +1,6 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i}
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} 
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i}
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} 
 start name=vmstat interval=1000000 offset=0

--- a/ldms/scripts/examples/rabbitv3.3
+++ b/ldms/scripts/examples/rabbitv3.3
@@ -1,6 +1,6 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i}
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} 
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i}
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} 
 start name=vmstat interval=1000000 offset=0

--- a/ldms/scripts/examples/vg_csv.1
+++ b/ldms/scripts/examples/vg_csv.1
@@ -1,5 +1,5 @@
 load name=dstat
-config name=dstat producer=localhost${i} instance=localhost${i}/dstat schema=dstat component_id=${i} udata_default=${i}
+config name=dstat producer=localhost${i} instance=localhost${i}/dstat schema=dstat component_id=${i} 
 start name=dstat interval=1000000 offset=0
 
 prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=2000000

--- a/ldms/scripts/examples/vg_csv.2
+++ b/ldms/scripts/examples/vg_csv.2
@@ -1,12 +1,12 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} job_set=localhost${i}/job_info
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} job_set=localhost${i}/job_info
 start name=vmstat interval=1000000 offset=0
 load name=clock
-config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} job_set=localhost${i}/job_info
 start name=clock interval=1000000 offset=0
 load name=procstat
-config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} job_set=localhost${i}/job_info
 start name=procstat interval=1000000 offset=0

--- a/ldms/scripts/examples/vg_csv.3
+++ b/ldms/scripts/examples/vg_csv.3
@@ -1,12 +1,12 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} job_set=localhost${i}/job_info
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} job_set=localhost${i}/job_info
 start name=vmstat interval=1000000 offset=0
 load name=clock
-config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} job_set=localhost${i}/job_info
 start name=clock interval=1000000 offset=0
 load name=procstat
-config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} job_set=localhost${i}/job_info
 start name=procstat interval=1000000 offset=0

--- a/ldms/scripts/examples/vg_sos.1
+++ b/ldms/scripts/examples/vg_sos.1
@@ -1,5 +1,5 @@
 load name=dstat
-config name=dstat producer=localhost${i} instance=localhost${i}/dstat schema=dstat component_id=${i} udata_default=${i}
+config name=dstat producer=localhost${i} instance=localhost${i}/dstat schema=dstat component_id=${i} 
 start name=dstat interval=1000000 offset=0
 
 prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=2000000

--- a/ldms/scripts/examples/vg_sos.2
+++ b/ldms/scripts/examples/vg_sos.2
@@ -1,12 +1,12 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} job_set=localhost${i}/job_info
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} job_set=localhost${i}/job_info
 start name=vmstat interval=1000000 offset=0
 load name=clock
-config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} job_set=localhost${i}/job_info
 start name=clock interval=1000000 offset=0
 load name=procstat
-config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} job_set=localhost${i}/job_info
 start name=procstat interval=1000000 offset=0

--- a/ldms/scripts/examples/vg_sos.3
+++ b/ldms/scripts/examples/vg_sos.3
@@ -1,12 +1,12 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} job_set=localhost${i}/job_info
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} job_set=localhost${i}/job_info
 start name=vmstat interval=1000000 offset=0
 load name=clock
-config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} job_set=localhost${i}/job_info
 start name=clock interval=1000000 offset=0
 load name=procstat
-config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} udata_default=${i} job_set=localhost${i}/job_info
+config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} job_set=localhost${i}/job_info
 start name=procstat interval=1000000 offset=0

--- a/ldms/scripts/ldms-meminfo.sh.in
+++ b/ldms/scripts/ldms-meminfo.sh.in
@@ -133,7 +133,7 @@ config name=jobid producer=localhost1 instance=localhost1/jobid component_id=3 f
 start name=jobid interval=1000000 offset=0
 
 load name=meminfo
-config name=meminfo producer=localhost1 instance=localhost1/meminfo schema=meminfo component_id=1 udata_default=10 job_set=localhost1/jobid
+config name=meminfo producer=localhost1 instance=localhost1/meminfo schema=meminfo component_id=1 job_set=localhost1/jobid
 start name=meminfo interval=1000000
 EOF
 

--- a/ldms/scripts/ldms-py-rename.sh.in
+++ b/ldms/scripts/ldms-py-rename.sh.in
@@ -121,13 +121,13 @@ mysleep 1
 echo Starting plugins on daemon1
 echo load name=meminfo | $LC --port $port1
 die $?
-echo config name=meminfo producer=localhost1 instance=localhost1/meminfo schema=meminfo component_id=1 udata_default=10 | $LC --port $port1
+echo config name=meminfo producer=localhost1 instance=localhost1/meminfo schema=meminfo component_id=1 | $LC --port $port1
 die $?
 echo start name=meminfo interval=1000000 | $LC --port $port1
 die $?
 echo load name=sysclassib | $LC --port $port1
 die $?
-echo config name=sysclassib producer=localhost1 instance=localhost1/sysclassib schema=sysclassib ports=mlx4_0.1,qib_0.1 component_id=1 udata_default=10 | $LC --port $port1
+echo config name=sysclassib producer=localhost1 instance=localhost1/sysclassib schema=sysclassib ports=mlx4_0.1,qib_0.1 component_id=1 | $LC --port $port1
 die $?
 echo start name=sysclassib interval=1000000 | $LC --port $port1
 die $?

--- a/ldms/scripts/ldms-py-subset_test.sh.in
+++ b/ldms/scripts/ldms-py-subset_test.sh.in
@@ -123,7 +123,7 @@ mysleep 1
 echo Starting plugins on daemon1
 cat << EOF | $LC --port $port1
 load name=meminfo
-config name=meminfo producer=localhost1 instance=localhost1/meminfo schema=meminfo component_id=1 udata_default=10 max_mc=2 max_csrow=4
+config name=meminfo producer=localhost1 instance=localhost1/meminfo schema=meminfo component_id=1 max_mc=2 max_csrow=4
 start name=meminfo interval=1000000
 EOF
 die $?

--- a/ldms/scripts/ldms-py-syslog.sh.in
+++ b/ldms/scripts/ldms-py-syslog.sh.in
@@ -122,7 +122,7 @@ mysleep 1
 echo Starting plugins on daemon1
 cat << EOF | $LC --port $port1
 load name=meminfo
-config name=meminfo producer=localhost1 instance=localhost1/meminfo schema=meminfo component_id=1 udata_default=10
+config name=meminfo producer=localhost1 instance=localhost1/meminfo schema=meminfo component_id=1 
 start name=meminfo interval=1000000
 EOF
 die $?

--- a/ldms/scripts/ldms-py-varset.sh.in
+++ b/ldms/scripts/ldms-py-varset.sh.in
@@ -119,7 +119,7 @@ mysleep 1
 echo Starting plugins on daemon1
 cat << EOF | $LC --port $port1
 load name=variable
-config name=variable producer=localhost1 instance=localhost1/variable schema=variable component_id=1 udata_default=10 max_mc=2 max_csrow=4
+config name=variable producer=localhost1 instance=localhost1/variable schema=variable component_id=1 max_mc=2 max_csrow=4
 start name=variable interval=1000000
 EOF
 die $?

--- a/ldms/scripts/ldms_local_opa2test.sh.in
+++ b/ldms/scripts/ldms_local_opa2test.sh.in
@@ -96,8 +96,8 @@ config name=jobid producer=localhost1 instance=localhost1/jobid component_id=3 f
 start name=jobid interval=1000000 offset=0
 
 load name=opa2
-#config name=opa2 producer=localhost1 instance=localhost1/opa2 schema=opa2 component_id=1 udata_default=10 job_set=localhost1/jobid ports=hfi1_0.1
-config name=opa2 producer=localhost1 instance=localhost1/opa2 schema=opa2 component_id=1 udata_default=10 job_set=localhost1/jobid
+#config name=opa2 producer=localhost1 instance=localhost1/opa2 schema=opa2 component_id=1 job_set=localhost1/jobid ports=hfi1_0.1
+config name=opa2 producer=localhost1 instance=localhost1/opa2 schema=opa2 component_id=1 job_set=localhost1/jobid
 start name=opa2 interval=1000000
 EOF
 

--- a/ldms/scripts/slurm-examples/cluster.2
+++ b/ldms/scripts/slurm-examples/cluster.2
@@ -1,7 +1,7 @@
 # this is the L1 aggregator
 # collect resource stats about the L1
 load name=dstat
-config name=dstat producer=L1 instance=localhost${i}/dstat component_id=${i} udata_default=${i} mmalloc=1 statm=1 stat=1 io=1 fdtypes=1 auto-schema=1
+config name=dstat producer=L1 instance=localhost${i}/dstat component_id=${i} mmalloc=1 statm=1 stat=1 io=1 fdtypes=1 auto-schema=1
 start name=dstat interval=1000000 offset=0
 
 updtr_add name=allhosts interval=1000000 offset=300000

--- a/ldms/scripts/slurm-examples/cluster.3
+++ b/ldms/scripts/slurm-examples/cluster.3
@@ -1,12 +1,12 @@
 load name=meminfo
-config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} udata_default=${i}
+config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} 
 start name=meminfo interval=1000000 offset=0
 load name=vmstat
-config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} udata_default=${i}
+config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} 
 start name=vmstat interval=1000000 offset=0
 load name=procnetdev
-config name=procnetdev producer=localhost${i} instance=localhost${i}/procnetdev schema=procnetdev component_id=${i} udata_default=${i} ifaces=lo
+config name=procnetdev producer=localhost${i} instance=localhost${i}/procnetdev schema=procnetdev component_id=${i} ifaces=lo
 start name=procnetdev interval=1000000 offset=0
 load name=dstat
-config name=dstat producer=localhost${i} instance=localhost${i}/dstat component_id=${i} udata_default=${i} mmalloc=1 statm=1 stat=1 io=1 fdtypes=1 auto-schema=1
+config name=dstat producer=localhost${i} instance=localhost${i}/dstat component_id=${i} mmalloc=1 statm=1 stat=1 io=1 fdtypes=1 auto-schema=1
 start name=dstat interval=1000000 offset=100000


### PR DESCRIPTION
the udata_default attribute no longer exists in v4,
This patch removes it from all test scripts that tried to apply it.