### PR TITLE
Put back the RBD share_lookup reference when disconnected

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -690,11 +690,15 @@ static void __destroy_set(void *v)
 	pthread_mutex_unlock(&__del_tree_lock);
 }
 
+void __put_share_lookup_ref(ldms_set_t rbd)
+{
+	ref_put(&rbd->set->ref, "share_lookup");
+	ref_put(&rbd->ref, "share_lookup");
+}
+
 static void __set_delete_cb(ldms_t xprt, int status, ldms_set_t rbd, void *cb_arg)
 {
-	struct ldms_set *set = cb_arg;
-	ref_put(&set->ref, "share_lookup");
-	ref_put(&rbd->ref, "share_lookup");
+	__put_share_lookup_ref(rbd);
 }
 
 void ldms_set_delete(ldms_set_t s)


### PR DESCRIPTION
LDMS takes the share_lookup references on RBDs and sets when it responds to a
lookup request. Without this patch, LDMS puts the references back only when
applications call ldms_set_delete(). Thus, LDMS leaks the RBDs and sets that
have been looked-up. The leak also affects LDMSDs when it respond to an ldms_ls
-l request.