### PR TITLE
remove buggy ldmsd_msg_logger function

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -277,15 +277,6 @@ LDMSD_LOG_AT(LDMSD_LERROR,error);
 LDMSD_LOG_AT(LDMSD_LCRITICAL,critical);
 LDMSD_LOG_AT(LDMSD_LALL,all);
 
-static char msg_buf[4096];
-void ldmsd_msg_logger(enum ldmsd_loglevel level, const char *fmt, ...)
-{
-	va_list ap;
-	va_start(ap, fmt);
-	vsnprintf(msg_buf, sizeof(msg_buf), fmt, ap);
-	ldmsd_log(level, "%s", msg_buf);
-}
-
 enum ldmsd_loglevel ldmsd_str_to_loglevel(const char *level_s)
 {
 	int i;

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -811,7 +811,7 @@ extern ldmsctl_cmd_fn_t cmd_table[LDMSCTL_LAST_COMMAND + 1];
 #define LEN_ERRSTR 256
 #define LDMSD_ENOMEM_MSG "Memory allocation failure\n"
 
-void ldmsd_msg_logger(enum ldmsd_loglevel level, const char *fmt, ...);
+#define ldmsd_msg_logger ldmsd_log /* ldmsd_msg_logger is deprecated */
 int ldmsd_logrotate();
 int ldmsd_plugins_usage(const char *plugin_name);
 void ldmsd_mm_status(enum ldmsd_loglevel level, const char *prefix);

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -172,7 +172,7 @@ struct ldmsd_plugin_cfg *new_plugin(char *plugin_name,
 			 "function.", plugin_name);
 		goto err;
 	}
-	lpi = pget(ldmsd_msg_logger);
+	lpi = pget(ldmsd_log);
 	if (!lpi) {
 		snprintf(errstr, errlen, "The plugin '%s' could not be loaded.",
 								plugin_name);


### PR DESCRIPTION
the ldmsd_msg_logger function:
is not thread safe
is passed to all the plugins that take a log pointer
contains an easily exploitable buffer overrun
is redundant with ldmsd_log.

This patch removes the function and redirects the only caller to ldmsd_log.
It leaves a #define for any client code that might have used it.