### PR TITLE
Fix a possible use-after-freed in the cleanup path

### DIFF
--- a/ldms/src/ldmsd/ldmsd_strgp.c
+++ b/ldms/src/ldmsd/ldmsd_strgp.c
@@ -633,11 +633,6 @@ void ldmsd_strgp_close()
 		strgp_close(strgp);
 		strgp->state = LDMSD_STRGP_STATE_STOPPED;
 		ldmsd_strgp_unlock(strgp);
-		/*
-		 * ref_count shouldn't reach zero
-		 * because the strgp isn't deleted yet.
-		 */
-		ldmsd_strgp_put(strgp);
 next:
 		strgp = ldmsd_strgp_next(strgp);
 	}


### PR DESCRIPTION
The cleanup logic iterates through the storage policy tree to close all
stores. It also puts back a storage policy reference, which is
erroneous. It is unnecessary to put the reference back as we only want
to close the stores and not free the storage policies. Moreover, this
could cause a use-after-free if all producer sets associated with a
storage policy have been deleted. The storage policy will be freed when
the cleanup logic puts back the reference, and then the cleanup logic
reaccesses the storage policy to get the next storage policy.