### PR TITLE
Fix `zap_accumulate()` sample_no overflow

### DIFF
--- a/lib/src/zap/zap.c
+++ b/lib/src/zap/zap.c
@@ -893,7 +893,7 @@ zap_utilization(zap_thrstat_t in, struct timespec *now)
    	return (double)proc_us / (double)(proc_us + wait_us);
 }
 
-static uint64_t zap_accumulate(int sample_no,
+static uint64_t zap_accumulate(uint64_t sample_no,
 							uint64_t sample,
 							int window_size,
 							uint64_t current_sum,


### PR DESCRIPTION
`zap_accumulate()` uses `int` to receive `sample_no`. The caller however
supplied `uint64_t` (`proc_count` and `wait_count`), causing the overflow. This
patch change the type of the `sample_no` parameter to the matching `uint64_t`.