### PR TITLE
fix buffer overrun in zap event queue definition.

### DIFF
--- a/lib/src/zap/zap.c
+++ b/lib/src/zap/zap.c
@@ -1010,8 +1010,8 @@ static void init_atfork(void)
 	assert(zev_queue);
 
 	for (i = 0; i < zap_event_workers; i++) {
-		char thread_name[16];
-		(void)snprintf(thread_name, 16, "zap:worker:%d", i);
+		char thread_name[24];
+		(void)snprintf(thread_name, 24, "zap:worker:%d", i);
 		zap_event_queue_init(&zev_queue[i], zap_event_qdepth,
 					thread_name, stats_w);
 		rc = pthread_create(&zev_queue[i].thread, NULL,


### PR DESCRIPTION
The thread name buffer is too small for the potential names, if thread limit
from user is high. This could potentially corrupt event queue setup in init_atfork, depending on stack layout determined by compiler.