### PR TITLE
Fix zap_sock close() not shutdown

### DIFF
--- a/lib/src/zap/sock/zap_sock.c
+++ b/lib/src/zap/sock/zap_sock.c
@@ -256,12 +256,12 @@ static zap_err_t z_sock_close(zap_ep_t ep)
 	case ZAP_EP_CONNECTED:
 	case ZAP_EP_LISTENING:
 		sep->ep.state = ZAP_EP_CLOSE;
-		// shutdown(sep->sock, SHUT_RDWR);
+		shutdown(sep->sock, SHUT_RDWR);
 		break;
 	case ZAP_EP_ERROR:
 	case ZAP_EP_ACCEPTING:
 	case ZAP_EP_CONNECTING:
-		// shutdown(sep->sock, SHUT_RDWR);
+		shutdown(sep->sock, SHUT_RDWR);
 		break;
 	case ZAP_EP_CLOSE:
 		break;
@@ -857,8 +857,6 @@ static int __recv_msg(struct z_sock_ep *sep)
 		rqsz = sizeof(struct sock_msg_hdr) - buff->len;
 		rsz = read(sep->sock, buff->data + buff->len, rqsz);
 		if (rsz == 0) {
-			if (errno == EAGAIN)
-				return errno;
 			/* peer close */
 			rc = ENOTCONN;
 			from_line = __LINE__;
@@ -911,8 +909,6 @@ static int __recv_msg(struct z_sock_ep *sep)
 		rqsz = mlen - buff->len;
 		rsz = read(sep->sock, buff->data + buff->len, rqsz);
 		if (rsz == 0) {
-			if (errno == EAGAIN)
-				return errno;
 			/* peer close */
 			rc = ENOTCONN;
 			from_line = __LINE__;


### PR DESCRIPTION
The `shutdown()` calls in zap_sock close implementation were
accidentally checked in, making socket connection stayed connected in
the case of bad authentication test (e.g. mismatched keyes or wrong
munge domain) in `ldmsd_auth_ovis_test` and `ldmsd_auth_test` tests in
`ldms-test` repository. Re-introducing the `shutdown()` calls solved the
issue.