### PR TITLE
add config check for new ibv_wc_t* enums

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -137,8 +137,13 @@ if test "$disable_zap" != "yes"; then
 dnl we need libibverbs-devel and librdmacm-devel to support rdma
   if test "$enable_rdma" = "yes"; then
     AC_CHECK_HEADER([infiniband/verbs.h],
-    [AC_DEFINE([HAVE_VERBS_H], [1],
-      [Define to 1 if you have infiniband/verbs.h.])],
+    [ AC_DEFINE([HAVE_VERBS_H] , [1], [Define to 1 if you have infiniband/verbs.h.])
+	IBVERBS_ENUM_CHECK([ibvwct_enums])
+        if test "$ibvwct_enums" = "1"; then
+		AC_DEFINE([HAVE_VERBS_IBVWCT_ENUMS], [1],
+		[Defined to 1 if you have IBV_WC_T* enum values in verbs.h.])
+	fi
+	],
     [AC_MSG_ERROR([Missing header. libibverbs-devel not installed?])])
 
     AC_CHECK_HEADER([rdma/rdma_cma.h],

--- a/lib/src/zap/rdma/zap_rdma.c
+++ b/lib/src/zap/rdma/zap_rdma.c
@@ -168,14 +168,16 @@ static const char *ibv_op_str(int op)
 	case IBV_WC_FETCH_ADD: return "IBV_WC_FETCH_ADD";
 	case IBV_WC_BIND_MW: return "IBV_WC_BIND_MW";
 	case IBV_WC_LOCAL_INV: return "IBV_WC_LOCAL_INV";
-	case IBV_WC_TSO: return "IBV_WC_TSO";
 	case IBV_WC_RECV: return "IBV_WC_RECV";
 	case IBV_WC_RECV_RDMA_WITH_IMM: return "IBV_WC_RECV_RDMA_WITH_IMM";
+#ifdef HAVE_VERBS_IBVWCT_ENUMS
+	case IBV_WC_TSO: return "IBV_WC_TSO";
 	case IBV_WC_TM_ADD: return "IBV_WC_TM_ADD";
 	case IBV_WC_TM_DEL: return "IBV_WC_TM_DEL";
 	case IBV_WC_TM_SYNC: return "IBV_WC_TM_SYNC";
 	case IBV_WC_TM_RECV: return "IBV_WC_TM_RECV";
 	case IBV_WC_TM_NO_TAG: return "IBV_WC_TM_NO_TAG";
+#endif
 	}
 	return "UNKNOWN_OP";
 }

--- a/m4/verbs_enum_check.m4
+++ b/m4/verbs_enum_check.m4
@@ -1,0 +1,23 @@
+AC_DEFUN([IBVERBS_ENUM_CHECK],
+[# Check for enum elements IBV_WC_T*
+AC_LANG_PUSH([C])dnl
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include "stdlib.h"
+#include "infiniband/verbs.h"
+int check_enum(int i) {
+	switch(i) {
+	case IBV_WC_TSO:
+	case IBV_WC_TM_ADD:
+ 	case IBV_WC_TM_DEL:
+ 	case IBV_WC_TM_SYNC:
+ 	case IBV_WC_TM_RECV:
+ 	case IBV_WC_TM_NO_TAG:
+		break;
+	default:
+		break;
+	}
+	return 0;
+}
+]])], [$1=1], [$1=0])
+AC_LANG_POP([C])dnl
+])


### PR DESCRIPTION
This patch checks at configure for enums that exist on TOSS3 infiniband/verbs.h but not some mellanox ib library versions and ifdefs them out if they are not all defined. Affects at least ARM platforms.