### PR TITLE
Add build-with-rdma github action step

### DIFF
--- a/.github/workflows/build-test-centos7.yaml
+++ b/.github/workflows/build-test-centos7.yaml
@@ -26,3 +26,13 @@ jobs:
     - run: sh autogen.sh
     - run: ./configure
     - run: make distcheck
+
+  build-with-rdma:
+    runs-on: ubuntu-20.04
+    container:
+        image: ovishpc/ovis-centos-build
+    steps:
+    - uses: actions/checkout@v2
+    - run: sh autogen.sh
+    - run: ./configure --enable-rdma CFLAGS="-Wall -Werror"
+    - run: make

--- a/.github/workflows/build-test-ubuntu.yaml
+++ b/.github/workflows/build-test-ubuntu.yaml
@@ -26,3 +26,13 @@ jobs:
     - run: sh autogen.sh
     - run: ./configure
     - run: make distcheck
+
+  build:
+    runs-on: ubuntu-20.04
+    container:
+        image: ovishpc/ovis-ubuntu-build
+    steps:
+    - uses: actions/checkout@v2
+    - run: sh autogen.sh
+    - run: ./configure --enable-rdma CFLAGS="-Wall -Werror"
+    - run: make


### PR DESCRIPTION
Add another github action step to test build with rdma but without DEBUG
in both CentOS and Ubuntu build test actions.