### PR TITLE
Fix a share_lookup RBD reference leak in the ldms_set_delete path

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -690,12 +690,6 @@ static void __destroy_set(void *v)
 	pthread_mutex_unlock(&__del_tree_lock);
 }
 
-void __put_share_lookup_ref(ldms_set_t rbd)
-{
-	ref_put(&rbd->set->ref, "share_lookup");
-	ref_put(&rbd->ref, "share_lookup");
-}
-
 static void __set_delete_cb(ldms_t xprt, int status, ldms_set_t rbd, void *cb_arg)
 {
 	__put_share_lookup_ref(rbd);

--- a/ldms/src/core/ldms_private.h
+++ b/ldms/src/core/ldms_private.h
@@ -180,4 +180,9 @@ struct ldms_data_hdr *__ldms_set_array_get(ldms_set_t s, int idx)
 struct ldms_context *__ldms_alloc_ctxt(struct ldms_xprt *x, size_t sz, ldms_context_type_t type, ...);
 void __ldms_free_ctxt(struct ldms_xprt *x, struct ldms_context *ctxt);
 
+#define __put_share_lookup_ref(rbd) do { \
+		ref_put(&((rbd)->set->ref), "share_lookup"); \
+		ref_put(&((rbd)->ref), "share_lookup"); \
+	} while (0)
+
 #endif


### PR DESCRIPTION
The leak occurs when

* there is a race between the ldms_set_delete() path and the disconnected
path (Note that the disconnected path releases the transport lock, takes
the set lock, releases the set lock, and retakes the transport lock),
*the ldms_set_delete() path removes the leak RBD from the transport’s RBD
tree while the disconnected path handles another RBD, and
* LDMS fails to send the SET_DELETE request to the disconnected client,
i.e., zap_send() synchronously fails due to the disconnected connection.
The SET_DELETE context is freed upon the synchronous error.

LDMS releases the share_lookup RBD references either in the disconnected
path or in the SET_DELETE reply handling path. Since LDMS fails to send
the SET_DELETE request to the client, it will not receive the SET_DELETE
reply. Besides, the ldms_set_delete() path has removed all RBDs from all
associated LDMS transport’s RBD trees. Thus, the disconnected path has
no access to the RBDs. Therefore, LDMS did not release the share_lookup
RBD references in this scenario.