### PR TITLE
reset rc if mkdir failed because already exists

### DIFF
--- a/ldms/src/store/hello_stream/hello_stream_store.c
+++ b/ldms/src/store/hello_stream/hello_stream_store.c
@@ -359,6 +359,7 @@ static int reopen_container(){
 		rc = ENOENT;
 		goto err1;
 	}
+	rc = 0;
 
 	streamfile = fopen_perm(path, "a+", LDMSD_DEFAULT_FILE_PERM);
 	if (!streamfile){


### PR DESCRIPTION
Otherwise the store fails if the dir exists, even though the dir can be reused.