### PR TITLE
Fix build-test-ubuntu.yaml workflow

### DIFF
--- a/.github/workflows/build-test-ubuntu.yaml
+++ b/.github/workflows/build-test-ubuntu.yaml
@@ -27,7 +27,7 @@ jobs:
     - run: ./configure
     - run: make distcheck
 
-  build:
+  build-with-rdma:
     runs-on: ubuntu-20.04
     container:
         image: ovishpc/ovis-ubuntu-build


### PR DESCRIPTION
The workflow had two jobs with the same name, which hid the fact
that the rdma build on the ubuntu docker container was not working.

Fix the name of the rdma job.