### PR TITLE
Remove EAGAIN check when read returns 0 (EOF)

### DIFF
--- a/lib/src/zap/ugni/zap_ugni.c
+++ b/lib/src/zap/ugni/zap_ugni.c
@@ -947,8 +947,6 @@ static int __recv_msg(struct z_ugni_ep *uep)
 		rqsz = sizeof(struct zap_ugni_msg_hdr) - buff->len;
 		rsz = read(uep->sock, buff->data + buff->len, rqsz);
 		if (rsz == 0) {
-			if (errno == EAGAIN)
-				return errno;
 			/* peer close */
 			rc = ENOTCONN;
 			from_line = __LINE__;
@@ -998,8 +996,6 @@ static int __recv_msg(struct z_ugni_ep *uep)
 		rqsz = mlen - buff->len;
 		rsz = read(uep->sock, buff->data + buff->len, rqsz);
 		if (rsz == 0) {
-			if (errno == EAGAIN)
-				return errno;
 			/* peer close */
 			rc = ENOTCONN;
 			from_line = __LINE__;


### PR DESCRIPTION
This can cause the I/O thread to spin when the peer
closes the connection.