### PR TITLE
Refactor Slurm notifier and sampler event handling

### DIFF
--- a/ldms/src/sampler/papi/papi_sampler.c
+++ b/ldms/src/sampler/papi/papi_sampler.c
@@ -844,42 +844,27 @@ static int stream_recv_cb(ldmsd_stream_client_t c, void *ctxt,
 
 	pthread_mutex_lock(&job_lock);
 	if (0 == strncmp(event_name->str, "init", 4)) {
-		job = get_job_data(job_id); /* protect against duplicate entries */
+		job = get_job_data(job_id);
 		if (job) {
 			msglog(LDMSD_LINFO,
 			       "papi_sampler[%d]: ignoring duplicate init event "
 			       "received for job %d.\n",
 			       __LINE__, job_id);
-			goto out_0;
+			goto out_1;
 		}
 		rc = handle_job_init(job_id, entity);
 	} else if (0 == strncmp(event_name->str, "task_init_priv", 14)) {
 		job = get_job_data(job_id);
-		if (!job) {
-			msglog(LDMSD_LINFO, "papi_sampler: '%s' event "
-			       "was received for job %d with no job_data\n",
-			       event_name->str, job_id);
-			goto out_1;
-		}
-		handle_task_init(job, entity);
+		if (job)
+			handle_task_init(job, entity);
 	} else if (0 == strncmp(event_name->str, "task_exit", 9)) {
 		job = get_job_data(job_id);
-		if (!job) {
-			msglog(LDMSD_LINFO, "papi_sampler: '%s' event "
-			       "was received for job %d with no job_data\n",
-			       event_name->str, job_id);
-			goto out_1;
-		}
-		handle_task_exit(job, entity);
+		if (job)
+			handle_task_exit(job, entity);
 	} else if (0 == strncmp(event_name->str, "exit", 4)) {
 		job = get_job_data(job_id);
-		if (!job) {
-			msglog(LDMSD_LINFO, "papi_sampler: '%s' event "
-			       "was received for job %d with no job_data\n",
-			       event_name->str, job_id);
-			goto out_1;
-		}
-		handle_job_exit(job, entity);
+		if (job)
+			handle_job_exit(job, entity);
 	} else {
 		msglog(LDMSD_LDEBUG,
 		       "papi_sampler: ignoring event '%s'\n", event_name->str);


### PR DESCRIPTION
slurm_notifier Spank plugin changes

* Bind "init"/"exit" events to prolog/epilog spank callbacks
  * PrologFlags=Alloc will cause prolog events to be delivered
    immediately as opposed to at the 1st job step. This is
    particularly useful for ```salloc -N x bash``` jobs. 
  * At prolog time NTASKS and NNODES is not available and
    therefore before the first job step is launched, the
    nnodes and ntasks values are zero

* Add "step_init"/"step_exit" events
  * These events contain accurate values for ntasks and nnodes

slurm_sampler changes

* Sampler binds job start/end times to the "init"/"exit"
  events
* Job step start/end events do not modify the job start
  and end times
* Caveats:
  * Job task PID are updated at each job step and overwrite
    any previous value
  * Job size begins at zero at salloc time and is updated
    at each job-step

papi_sampler changes

* Remove chatty messages that result from papi_sampler data
  missing from subscriber_data