### PR TITLE
Fix endpoint ref count issue in CONNECT_ERROR path

### DIFF
--- a/lib/src/zap/sock/zap_sock.c
+++ b/lib/src/zap/sock/zap_sock.c
@@ -1473,7 +1473,7 @@ static void sock_event(ovis_event_t ev)
 		sep->ep.state = ZAP_EP_ERROR;
 		if (sep->app_accepted) {
 			zev.type = ZAP_EVENT_CONNECT_ERROR;
-			do_cb = drop_conn_ref = 1;
+			do_cb = 1;
 		}
 		break;
 	case ZAP_EP_CONNECTING:


### PR DESCRIPTION
The passive side CONNECT_ERROR path drops an extra reference
that causes the zap_interpose_cb to crash when it de-references
the endpoint.

Also took the connect reference before the call to zap_accept to ensure
that the reference is taken before the callback provided in zap_accept
is called.

The bug is triggered when the remote peer disconnects before the
zap_accept ACCEPT/ACK sequence is completed resulting in a
CONNECT_ERROR event being delivered to ldms_zap_auto_cb
