### PR TITLE
Support for multi-step jobs in PAPI sampler.

### DIFF
--- a/ldms/src/sampler/papi/papi_sampler.h
+++ b/ldms/src/sampler/papi/papi_sampler.h
@@ -89,8 +89,10 @@ typedef struct job_data {
 	int task_pids_mid;
 	int task_ranks_mid;
 
-	uint64_t job_id;
-	uint64_t app_id;
+	struct job_key {
+		uint64_t job_id;
+		uint64_t step_id;
+	} key;
 	enum job_state job_state;
 	uint64_t job_state_time; /* Last time the state was changed */
 	uint64_t job_start;


### PR DESCRIPTION
These changes move the SUBSCRIBER_DATA field to the step_init event so that each job step can have it's own SUBSCRIBER_DATA value.

The PAPI sampler is updated to support multi-step jobs. Each step in the job has it's own metric set; the set name is constructed with a suffix of <job_id> "." <step_id>.

Both serial and overlapping job steps are supported.
