### PR TITLE
Not put back a prd_set reference when the push updater stops

### DIFF
--- a/ldms/src/ldmsd/ldmsd_updtr.c
+++ b/ldms/src/ldmsd/ldmsd_updtr.c
@@ -446,7 +446,6 @@ static int cancel_set_updates(ldmsd_prdcr_set_t prd_set, ldmsd_updtr_t updtr)
 	}
 	/* Put the push reference */
 	prd_set->push_flags &= ~LDMSD_PRDCR_SET_F_PUSH_REG;
-	ldmsd_prdcr_set_ref_put(prd_set);
 	return rc;
 }
 


### PR DESCRIPTION
A push updater does not take any producer set references when it starts.
Putting a producer set reference back when it stops will cause a
use-after-free issue.