### PR TITLE
Fix big ldmsd_stream

### DIFF
--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -560,6 +560,15 @@ extern int ldms_xprt_send(ldms_t x, char *msg_buf, size_t msg_len);
  */
 size_t ldms_xprt_msg_max(ldms_t x);
 
+/**
+ * \brief Determine whether the send queue is empty.
+ * \param x The transport handle.
+ * \retval 0 If the sq is empty.
+ * \retval EBUSY If the sq is not empty.
+ * \retval ENOSYS If this feature is not yet supported.
+ */
+int ldms_xprt_sq_status(ldms_t x);
+
 /** \} */
 
 /**
@@ -911,7 +920,7 @@ struct ldms_xprt_rate_data {
 
 /**
  * Query daemon telemetry data across transports
- * 
+ *
  * \param data A pointer to the ldms_xprt_rate_data structure in which
  *             the results will be returned
  * \param reset Set to a non-zero value to reset the stats after

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -3871,6 +3871,19 @@ int ldms_xprt_sockaddr(ldms_t _x, struct sockaddr *local_sa,
 	return 0;
 }
 
+int ldms_xprt_sq_status(ldms_t x)
+{
+	zap_err_t zerr;
+	if (!x->zap_ep)
+		return 0;
+	zerr = zap_sq_status(x->zap_ep);
+	if (zerr == ZAP_ERR_OK)
+		return 0;
+	if (zerr == ZAP_ERR_BUSY)
+		return EBUSY;
+	return ENOSYS;
+}
+
 static void __attribute__ ((constructor)) cs_init(void)
 {
 	pthread_mutex_init(&xprt_list_lock, 0);

--- a/ldms/src/ldmsd/ldmsd_request_util.c
+++ b/ldms/src/ldmsd/ldmsd_request_util.c
@@ -873,7 +873,7 @@ ldmsd_req_attr_t ldmsd_req_attr_get_by_id(char *request, uint32_t attr_id)
 {
 	ldmsd_req_hdr_t req = (ldmsd_req_hdr_t)request;
 	ldmsd_req_attr_t attr = ldmsd_first_attr(req);
-	while (attr->discrim) {
+	while (attr && attr->discrim == 1) {
 		if (attr->attr_id == attr_id) {
 			return attr;
 		}
@@ -951,7 +951,7 @@ void ldmsd_ntoh_req_msg(ldmsd_req_hdr_t req)
 		return;
 
 	attr = ldmsd_first_attr(req);
-	while (attr && attr->discrim) {
+	while (attr && attr->discrim == ntohl(1)) {
 		ldmsd_ntoh_req_attr(attr);
 		attr = ldmsd_next_attr(attr);
 	}
@@ -983,7 +983,7 @@ void ldmsd_hton_req_msg(ldmsd_req_hdr_t resp)
 		return;
 
 	attr = ldmsd_first_attr(resp);
-	while (attr && attr->discrim) {
+	while (attr && attr->discrim == 1) {
 		next_attr = ldmsd_next_attr(attr);
 		ldmsd_hton_req_attr(attr);
 		attr = next_attr;

--- a/ldms/src/ldmsd/ldmsd_stream.c
+++ b/ldms/src/ldmsd/ldmsd_stream.c
@@ -447,6 +447,10 @@ int ldmsd_stream_publish_file(const char *stream, const char *type,
 		}
 	}
 
+	while (ldms_xprt_sq_status(x) == EBUSY) {
+		sleep(1);
+	}
+
 	ldms_xprt_close(x);
  err:
 	return rc;

--- a/ldms/src/ldmsd/test/Makefile.am
+++ b/ldms/src/ldmsd/test/Makefile.am
@@ -8,6 +8,7 @@ COMMON_LD_ADD = ../../core/libldms.la \
 		../libldmsd_request.la \
 		../libldmsd_stream.la \
 		$(top_builddir)/lib/src/ovis_json/libovis_json.la \
+		$(top_builddir)/lib/src/coll/libcoll.la \
 		$(top_builddir)/lib/src/ovis_util/libovis_util.la
 
 sbin_PROGRAMS += ldmsd_stream_publish
@@ -17,4 +18,4 @@ ldmsd_stream_publish_LDADD = $(COMMON_LD_ADD)
 sbin_PROGRAMS += ldmsd_stream_subscribe
 ldmsd_stream_subscribe_SOURCES = ldmsd_stream_subscribe.c
 ldmsd_stream_subscribe_LDADD = $(COMMON_LD_ADD)
-ldmsd_stream_subscribe_LDFLAGS = $(AM_LDFLAGS) -pthread 
+ldmsd_stream_subscribe_LDFLAGS = $(AM_LDFLAGS) -pthread

--- a/lib/src/zap/sock/zap_sock.c
+++ b/lib/src/zap/sock/zap_sock.c
@@ -1977,6 +1977,21 @@ err0:
 	return zerr;
 }
 
+static zap_err_t z_sock_sq_status(zap_ep_t ep)
+{
+	struct z_sock_ep *sep = (struct z_sock_ep *)ep;
+	zap_err_t s = ZAP_ERR_OK;
+	pthread_mutex_lock(&ep->lock);
+	if (ep->state != ZAP_EP_CONNECTED)
+		goto out;
+	if (TAILQ_EMPTY(&sep->sq))
+		goto out;
+	s = ZAP_ERR_BUSY;
+ out:
+	pthread_mutex_unlock(&ep->lock);
+	return s;
+}
+
 zap_err_t zap_transport_get(zap_t *pz, zap_log_fn_t log_fn,
 			    zap_mem_info_fn_t mem_info_fn)
 {
@@ -2011,6 +2026,7 @@ zap_err_t zap_transport_get(zap_t *pz, zap_log_fn_t log_fn,
 	z->unmap = z_sock_unmap;
 	z->share = z_sock_share;
 	z->get_name = z_get_name;
+	z->sq_status = z_sock_sq_status;
 
 	/* is it needed? */
 	z->mem_info_fn = mem_info_fn;

--- a/lib/src/zap/ugni/zap_ugni.c
+++ b/lib/src/zap/ugni/zap_ugni.c
@@ -2933,6 +2933,21 @@ out:
 	return zerr;
 }
 
+static zap_err_t z_ugni_sq_status(zap_ep_t ep)
+{
+	struct z_ugni_ep *uep = (struct z_ugni_ep *)ep;
+	zap_err_t s = ZAP_ERR_OK;
+	pthread_mutex_lock(&ep->lock);
+	if (ep->state != ZAP_EP_CONNECTED)
+		goto out;
+	if (STAILQ_EMPTY(&uep->sq))
+		goto out;
+	s = ZAP_ERR_BUSY;
+ out:
+	pthread_mutex_unlock(&ep->lock);
+	return s;
+}
+
 zap_err_t zap_transport_get(zap_t *pz, zap_log_fn_t log_fn,
 			    zap_mem_info_fn_t mem_info_fn)
 {
@@ -2967,6 +2982,7 @@ zap_err_t zap_transport_get(zap_t *pz, zap_log_fn_t log_fn,
 	z->unmap = z_ugni_unmap;
 	z->share = z_ugni_share;
 	z->get_name = z_get_name;
+	z->sq_status = z_ugni_sq_status;
 
 	/* is it needed? */
 	z->mem_info_fn = mem_info_fn;

--- a/lib/src/zap/zap.c
+++ b/lib/src/zap/zap.c
@@ -994,6 +994,13 @@ void zap_thrstat_free_result(struct zap_thrstat_result *res)
 	free(res);
 }
 
+zap_err_t zap_sq_status(zap_ep_t ep)
+{
+	if (ep->z->sq_status)
+		return ep->z->sq_status(ep);
+	return ZAP_ERR_OK;
+}
+
 static void init_atfork(void)
 {
 	int i;

--- a/lib/src/zap/zap.h
+++ b/lib/src/zap/zap.h
@@ -680,11 +680,11 @@ int zap_term(int timeout_sec);
 
 /**
  * \brief The zap_thrstat_t handle maintains thread utilization data
- * 
+ *
  * This handle is created with the zap_thrstat_new() function and
  * freed with the zap_thrstat_free() function. The measurement
  * state can be reset with the zap_thrstat_reset() function.
- * 
+ *
  * Internally, zap_thrstat_t maintains a measurement window defined
  * by the window_size parameter to the zap_thrstat_new() function.
  * The window is an array of wait and processing time
@@ -714,7 +714,7 @@ zap_thrstat_t zap_thrstat_new(const char *name, int window_size);
 void zap_thrstat_free(zap_thrstat_t stats);
 /**
  * \brief Reset the thread utlization state data
- * 
+ *
  * Reset the measurement data held in the zap_thrstat_t instance.
  * Immediately after calling this function the internal sample_count
  * and window data are zero. It is not necessary to call this function
@@ -729,15 +729,15 @@ void zap_thrstat_reset_all();
 
 /**
  * \brief Begin an I/O wait measurement interval
- * 
+ *
  * The zap_thrstat_wait_start() and zap_thrstat_wait_end() annotate the
  * logic in the code that is waiting for I/O events. The time between
  * calls to zap_thrstat_wait_start() and zap_thrstat_wait_end() is the I/O
  * thread wait interval. The time between the call to zap_thrstat_wait_end()
  * and zap_thrstat_wait_start() is the processing interval.
- * 
+ *
  * Example usage:
- * 
+ *
  * void *io_thread_proc(void *)
  * {
  *    ...
@@ -777,13 +777,13 @@ struct zap_thrstat_result_entry {
 };
 
 struct zap_thrstat_result {
-	int count;	
+	int count;
 	struct zap_thrstat_result_entry entries[0];
 };
 
 /**
  * \brief Return thread utilization information
- * 
+ *
  * Returns a zap_thrstat_result structure or NULL on memory
  * allocation failure. This result must be freed with the
  * zap_thrstat_free_result() function.
@@ -799,7 +799,7 @@ void zap_thrstat_free_result(struct zap_thrstat_result *result);
 
 /**
  * \brief Return the name of the Zap stats handle
- * 
+ *
  * \returns The name provided to the zap_thrstat_new() function
  */
 const char *zap_thrstat_get_name(zap_thrstat_t stats);
@@ -822,5 +822,13 @@ static inline int64_t zap_timespec_diff_us(struct timespec *start, struct timesp
 	nsecs = end->tv_nsec - start->tv_nsec;
 	return (secs_ns + nsecs) / 1000;
 }
+
+/**
+ * Check if sq is empty or busy.
+ *
+ * \retval ZAP_ERR_OK If sq is empty.
+ * \retval ZAP_ERR_BUSY If sq is busy (some work left in sq).
+ */
+zap_err_t zap_sq_status(zap_ep_t ep);
 
 #endif

--- a/lib/src/zap/zap_priv.h
+++ b/lib/src/zap/zap_priv.h
@@ -246,6 +246,14 @@ struct zap {
 
 	/** Pointer to the transport's private data */
 	void *private;
+
+	/**
+	 * Check if sq is empty or busy.
+	 *
+	 * \retval ZAP_ERR_OK If sq is empty.
+	 * \retval ZAP_ERR_BUSY If sq is busy (some work left in sq).
+	 */
+	zap_err_t (*sq_status)(zap_ep_t ep);
 };
 
 static inline zap_err_t


### PR DESCRIPTION
This pull request contains 2 commits:
- "Fix big ldmsd_stream data." This commit contains a (quite big) patch addressing ldmsd_stream with data too big to fit in a message. It also addresses the record splitting mechanisms of ldmsd_stream request that is mismatch that of the ldmsd_request.
- "Add sq status check." This commit addresses the issue of when to disconnect the xprt in ldmsd_stream_publish_file. Even though a new zap API is added, I believe it does not make it incompatible with ldmsd 4.3.6.

NOTE1: This pull request has passed all test cases in `ldms-test` repository.
NOTE2: A manual test between `ldmsd_stream_subscribe` and `ldmsd_stream_publish` is also performed, with `SOCKBUF_SZ 256` (see `zap_sock.h`) to encourage a lot of record splitting:
```sh
$ python3 <<EOF
> import json
> f = open('data.json', 'w')
> print(json.dumps([i for i in range(0, 65536)]), file=f)
> f.close()
> EOF

$ ldmsd_stream_subscribe -x sock -p 10000 -s test -f out.txt

$ ldmsd_stream_publish -h localhost -x sock -p 10000 -s test -t ${FORMAT} -f ${FILE}

# NOTE: The FORMAT being tested are both json and string.
```