### PR TITLE
Change the deafult auth reference to "auth_default"

### DIFF
--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -1224,7 +1224,7 @@ typedef struct ldmsd_auth {
 
 /* Key (name) of the default auth -- intentionally including SPACE as it is not
  * allowed in user-defined names */
-#define DEFAULT_AUTH " _DEFAULT_AUTH_ "
+#define DEFAULT_AUTH "auth_default"
 
 ldmsd_auth_t
 ldmsd_auth_new_with_auth(const char *name, const char *plugin,


### PR DESCRIPTION
Change the default authentication reference to `auth_default` so that
users can explicitly specify it in `listen` and `prdcr_add`
configuration commands.