### PR TITLE
Fix `listen` on the same port, different interface

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -47,6 +47,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define _GNU_SOURCE
+
 #include <unistd.h>
 #include <inttypes.h>
 #include <stdarg.h>
@@ -1511,18 +1513,16 @@ void ldmsd_listen___del(ldmsd_cfgobj_t obj)
 ldmsd_listen_t ldmsd_listen_new(char *xprt, char *port, char *host, char *auth)
 {
 	char *name;
-	size_t len;
+	int len;
 	struct ldmsd_listen *listen = NULL;
 	ldmsd_auth_t auth_dom = NULL;
 
 	if (!port)
 		port = LDMSD_STR_WRAP(LDMS_DEFAULT_PORT);
 
-	len = strlen(xprt) + strlen(port) + 2; /* +1 for ':' and +1 for \0 */
-	name = malloc(len);
-	if (!name)
+	len = asprintf(&name, "%s:%s:%s", xprt, port, host?host:"");
+	if (len < 0)
 		return NULL;
-	(void) snprintf(name, len, "%s:%s", xprt, port);
 	listen = (struct ldmsd_listen *)
 		ldmsd_cfgobj_new_with_auth(name, LDMSD_CFGOBJ_LISTEN,
 				sizeof *listen, ldmsd_listen___del,


### PR DESCRIPTION
Listening on the same port but different interfaces was not allowed due
to the key construction of the listen config object that used only
"XPRT:PORT". This patch fixes the issue by using "XPRT:PORT:HOST" as the
key instead.

With the following config:
```
auth_add name=dom1 plugin=munge
listen  xprt=sock port=10001 host=node-1 auth=dom1
listen  xprt=sock port=10001 host=localhost
load name=meminfo
config name=meminfo component_id=1 instance=node-1/meminfo producer=node-1 perm=0777
start name=meminfo interval=1000000 offset=0
load name=vmstat
config name=vmstat component_id=1 instance=node-1/vmstat producer=node-1 perm=0700
start name=vmstat interval=1000000 offset=0
```

and the following CLI (on node-1):
```
$ ldmsd -c /etc/ldmsd.conf -l /var/log/ldmsd.log -v INFO
```

The `ldms_ls` shows that the listening on the same port, different
interfaces works correctly:
```
$ ldms_ls -x sock -p 10001 -a munge -h node-1
node-1/vmstat
node-1/meminfo

$ ldms_ls -x sock -p 10001 -h node-1
Connection failed/rejected.

$ ldms_ls -x sock -p 10001 -a munge -h localhost
Connection failed/rejected.

$ ldms_ls -x sock -p 10001 -h localhost
node-1/vmstat
node-1/meminfo

```