### PR TITLE
[PLS-REVIEW] New zap thread model

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -3900,7 +3900,16 @@ void __ldms_xprt_term(struct ldms_xprt *x)
 
 int ldms_xprt_term(int sec)
 {
-	return zap_term(sec);
+	int i, rc, tmp;
+	zap_t z;
+	rc = 0;
+	for (i = 0; i < ldms_zap_tbl_n; i++) {
+		z = ldms_zap_tbl[i].zap;
+		tmp = zap_term(z, sec);
+		if (tmp)
+			rc = tmp;
+	}
+	return rc;
 }
 
 int ldms_xprt_sockaddr(ldms_t _x, struct sockaddr *local_sa,

--- a/ldms/src/ldmsd/ldms_ls.c
+++ b/ldms/src/ldmsd/ldms_ls.c
@@ -733,7 +733,7 @@ int main(int argc, char *argv[])
 			free(xprt);
 			xprt = strdup(optarg);
 			if (!xprt) {
-				printf("ERROR: out of memory\n"); 
+				printf("ERROR: out of memory\n");
 				exit(1);
 			}
 			break;
@@ -1036,6 +1036,12 @@ done:
 		free(dir);
 	}
 
+	/* gracefully close, and wait at most 2 seconds before exit */
 	ldms_xprt_close(ldms);
+	struct timespec _t;
+	clock_gettime(CLOCK_REALTIME, &_t);
+	_t.tv_sec += 2;
+	sem_timedwait(&conn_sem, &_t);
+
 	exit(0);
 }

--- a/ldms/src/ldmsd/ldmsd_prdcr.c
+++ b/ldms/src/ldmsd/ldmsd_prdcr.c
@@ -548,10 +548,31 @@ static void __prdcr_remote_set_delete(ldmsd_prdcr_t prdcr, ldms_set_t set)
 	prdcr_reset_set(prdcr, prdcr_set);
 }
 
+const char *_conn_state_str[] = {
+	[LDMSD_PRDCR_STATE_STOPPED]       =  "LDMSD_PRDCR_STATE_STOPPED",
+	[LDMSD_PRDCR_STATE_DISCONNECTED]  =  "LDMSD_PRDCR_STATE_DISCONNECTED",
+	[LDMSD_PRDCR_STATE_CONNECTING]    =  "LDMSD_PRDCR_STATE_CONNECTING",
+	[LDMSD_PRDCR_STATE_CONNECTED]     =  "LDMSD_PRDCR_STATE_CONNECTED",
+	[LDMSD_PRDCR_STATE_STOPPING]      =  "LDMSD_PRDCR_STATE_STOPPING",
+};
+
+static const char *conn_state_str(int state)
+{
+	if (LDMSD_PRDCR_STATE_STOPPED<=state && state<=LDMSD_PRDCR_STATE_STOPPING)
+		return _conn_state_str[state];
+	return "UNKNOWN_STATE";
+}
+
 static void prdcr_connect_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 {
 	ldmsd_prdcr_t prdcr = cb_arg;
 	ldmsd_prdcr_lock(prdcr);
+	ldmsd_log(LDMSD_LINFO, "%s:%d Producer %s (%s %s:%d) conn_state: %d %s\n",
+				__func__, __LINE__,
+				prdcr->obj.name, prdcr->xprt_name,
+				prdcr->host_name, (int)prdcr->port_no,
+				prdcr->conn_state,
+				conn_state_str(prdcr->conn_state));
 	switch(e->type) {
 	case LDMS_XPRT_EVENT_DISCONNECTED:
 		x->disconnected = 1;
@@ -620,10 +641,19 @@ reset_prdcr:
 	case LDMSD_PRDCR_STATE_STOPPED:
 		assert(0 == "STOPPED shouldn't have xprt event");
 		break;
+	default:
+		assert(0 == "BAD STATE");
 	}
 	if (prdcr->xprt)
 		ldms_xprt_put(prdcr->xprt);
 	prdcr->xprt = NULL;
+	ldmsd_log(LDMSD_LINFO, "%s:%d Producer (after reset) %s (%s %s:%d)"
+				" conn_state: %d %s\n",
+				__func__, __LINE__,
+				prdcr->obj.name, prdcr->xprt_name,
+				prdcr->host_name, (int)prdcr->port_no,
+				prdcr->conn_state,
+				conn_state_str(prdcr->conn_state));
 	ldmsd_prdcr_unlock(prdcr);
 }
 

--- a/lib/src/zap/ZAP_THREAD_NOTE.md
+++ b/lib/src/zap/ZAP_THREAD_NOTE.md
@@ -1,0 +1,84 @@
+NOTE on `zap_thread`
+===================
+
+zap handles endpoint IO via `zap_io_thread`. The following outlines the
+interactions among libzap, `zap_io_thread`, zap transport plugin, and zap
+endpoints.
+
+1. The application starts and `libzap` is loaded. `zap_io_thread` is not
+   created yet.
+2. The application loads a transport plugin (e.g. `zap_sock`).
+   `zap_transport_get()` is called, but no `zap_io_thread` is created yet.
+3. The application creates a zap endpoint (`zap_new()`).
+4. The application calls `zap_connect()` or `zap_listen()`. The transport plugin
+   shall call `zap_io_thread_ep_assign()` in its implementation of `zap->new()`
+   and `zap->listen()` respectively (libzap service function) telling
+   libzap to find the least-busy `zap_io_thread` and assign the endpoint to it.
+   In addition, when a new passive endpoint is created (by connection request),
+   the transport plugin shall also call `zap_io_thread_ep_assign()` to assign
+   the endpoint to the least-busy thread.
+   - If there is no `zap_io_thread` or the least-busy thread is too busy, libzap
+     asks the transport plugin to create a new thread by calling
+     `zap->io_thread_create()`, and the transport plugin shall:
+     - allocate a `zap_io_thread` structure (or an extension of it),
+     - call `zap_io_thread_init()` to initialize the `zap_io_thread` structure,
+     - perform additional transport-specific IO thread initialization,
+     - create and start a thread, and
+     - returns the `zap_io_thread` handle.
+   - The purpose of the `zap_io_thread` is to process IO events from the
+     associated endpoints.
+   - `zap_io_thread` is transport-specific. For example, the `zap_io_thread`
+     created by `zap_sock` won't be assigned to `zap_rdma` endpoint.
+   - When libzap obtained the least-busy thread, libzap add the endpoint into
+     the endpoint list in the `zap_io_thread` structure. Then, it notifies the
+     transport plugin about the assignment by calling
+     `zap->io_thread_ep_assign()`. The transport plugin then add the endpoint
+     into its back-end notification system (e.g. `EPOLL_CTL_ADD`) which shall
+     notify the associated thread when an event is ready to be processed on the
+     endpoint.
+5. When the `zap_io_thread` wakes up, the transport plugin shall call
+   `zap_thrstat_wait_end()`. When the thread is done processing the events, it
+   shall call `zap_thrstat_wait_start()` before sleeping. The timestamps from
+   `zap_thrstat_wait_end()` and `zap_thrstat_wait_start()` are used to calculate
+   the busy-ness of the thread.
+6. REMARK: Calling `ep->cb()` directly invokes the application callback
+   function. zap event application callback interposer is eliminated.
+7. The transport plugin shall call `zap_io_thread_ep_release()` after the
+   endpoint is no longer used, i.e. after `DISCONNECTED` or `CONNECT_ERROR` is
+   delivered to the application. By calling `zap_io_thread_ep_release()`, libzap
+   removes the endpoint from the thread and notifies the transport plugin by
+   calling `zap->io_thread_ep_release()`. The transport plugin then removes the
+   endpoint from its notification system (e.g. `EPOLL_CTL_DEL`).
+8. In the current implementation, the thread is not terminated when all
+   endpoints leave the thread. If we terminate the thread right away, in the
+   case that an `ldmsd` aggregator collecting data from N other daemons that
+   were not up yet, new threads will be created at connect time, and will all be
+   destroyed on connect errors. The application will create-destroy threads in
+   loop.
+9. However, `zap_term(z)` call by application will terminate all
+   `zap_io_threads` in the transport plugin. libzap will call transport plugin
+   `zap->io_thread_cancel()` to request the thread cancellation. The transport
+   shall call `zap_io_thread_release()` right before the thread exited to
+   release resources allocated by `zap_io_thread_init()`.
+
+SEE ALSO
+========
+- `zap_priv.h`
+  - `struct zap_ep`
+  - `struct zap`
+  - `struct zap_io_thread`
+- `zap.c`
+  - `zap_io_thread_init()`
+  - `zap_io_thread_release()`
+  - `zap_io_thread_ep_assign()`
+  - `zap_io_thread_ep_release()`
+- `zap_sock.{c,h}`
+  - `sock_ev_cb()`
+  - `io_thread_proc()`
+  - `z_sock_connect()`
+  - `z_sock_listen()`
+  - `__z_sock_conn_request()`
+  - `z_sock_io_thread_create()`
+  - `z_sock_io_thread_ep_assign()`
+  - `z_sock_io_thread_ep_release()`
+  - `z_sock_io_thread_cancel()`

--- a/lib/src/zap/fabric/zap_fabric.c
+++ b/lib/src/zap/fabric/zap_fabric.c
@@ -83,8 +83,6 @@
 static struct {
 	struct z_fi_fabdom	dom[ZAP_FI_MAX_DOM];
 	int			dom_count;
-	int			cq_fd;
-	int			cm_fd;
 	uint64_t		mr_key;
 	zap_log_fn_t		log_fn;
 	pthread_mutex_t		lock;
@@ -107,6 +105,12 @@ static const char *z_fi_op_str[] = {
  *    For surfacing endpoint errors. Calls the endpoint's logging fn specified
  *    in zap_new.
  */
+/*
+#ifndef DEBUG
+#define DEBUG
+#endif
+*/
+
 #ifdef DEBUG
 static void dlog_(const char *func, int line, char *fmt, ...)
 {
@@ -123,6 +127,17 @@ static void dlog_(const char *func, int line, char *fmt, ...)
 	free(buf);
 }
 #endif
+
+#define LOG(FMT, ...) g.log_fn("[zap_fabric] " FMT, ##__VA_ARGS__)
+#define LLOG(FMT, ...) g.log_fn("[zap_fabric:%s():%d] " FMT, __func__, __LINE__, ##__VA_ARGS__)
+#define TLOG(FMT, ...) do { \
+	struct timespec _t; \
+	pid_t _tid = (pid_t) syscall (SYS_gettid); \
+	clock_gettime(CLOCK_REALTIME, &_t); \
+	g.log_fn("[zap_fabric:%s():%d %ld.%09ld %d] " FMT, __func__, __LINE__, \
+			_t.tv_sec, _t.tv_nsec, _tid, ##__VA_ARGS__); \
+} while(0)
+
 #define LOG_(rep, fmt, ...) do { \
 	if (rep && rep->ep.z && rep->ep.z->log_fn) \
 		rep->ep.z->log_fn(fmt, ##__VA_ARGS__); \
@@ -133,6 +148,12 @@ static void dlog_(const char *func, int line, char *fmt, ...)
 #else
 #define DLOG(fmt, ...)
 #endif
+
+/*
+#ifndef EP_DEBUG
+#define EP_DEBUG
+#endif
+*/
 
 #ifdef EP_DEBUG
 #define __zap_get_ep( _EP, _REASON ) do {			      \
@@ -157,11 +178,6 @@ static void dlog_(const char *func, int line, char *fmt, ...)
 #endif
 
 #ifdef CTXT_DEBUG
-#define __flush_io_q( _REP ) do { \
-	LOG_(_REP, "TMP_DEBUG: %s() flush_io_q %p, state %s\n", \
-			__func__, _REP, __zap_ep_state_str(_REP->ep.state)); \
-	flush_io_q(_REP); \
-} while (0)
 #define __context_alloc( _REP, _CTXT, _OP ) ({ \
 	void *_ctxt; \
 	_ctxt = _context_alloc(_REP, _CTXT, _OP); \
@@ -173,7 +189,6 @@ static void dlog_(const char *func, int line, char *fmt, ...)
 	_context_free(_CTXT); \
 })
 #else
-#define __flush_io_q(_REP) flush_io_q(_REP)
 #define __context_alloc( _REP, _CTXT, _OP ) _context_alloc(_REP, _CTXT, _OP)
 #define __context_free( _CTXT ) _context_free(_CTXT)
 #endif
@@ -213,14 +228,16 @@ static char *op_str[] = {
 static int		init_once();
 static int		z_fi_fill_rq(struct z_fi_ep *ep);
 static zap_err_t	z_fi_unmap(zap_ep_t ep, zap_map_t map);
-static void		*cm_thread_proc(void *arg);
-static void		*cq_thread_proc(void *arg);
 static void		_context_free(struct z_fi_context *ctxt);
 static int		_buffer_init_pool(struct z_fi_ep *ep);
 static void		__buffer_free(struct z_fi_buffer *rbuf);
 static int		send_credit_update(struct z_fi_ep *ep);
 static void		_deliver_disconnected(struct z_fi_ep *rep);
 static void		*__map_addr(struct z_fi_ep *ep, zap_map_t map, void *addr);
+static void		z_fi_flush(struct z_fi_ep *rep);
+
+static void _buffer_pool_free(struct z_fi_ep *rep, struct z_fi_buffer_pool *p);
+static struct z_fi_buffer_pool * _buffer_pool_new(struct z_fi_ep *rep, int num_bufs);
 
 static inline int fi_info_dom_cmp(struct fi_info *a, struct fi_info *b)
 {
@@ -300,38 +317,17 @@ static struct z_fi_fabdom *z_fi_fabdom_get(struct fi_info *info)
 	return NULL;
 }
 
-static int __enable_cq_events(struct z_fi_ep *rep)
-{
-	/* handle CQ events */
-	struct epoll_event cq_event = {
-		.events = EPOLLIN,
-		.data.ptr = rep,
-	};
-
-	__zap_get_ep(&rep->ep, "CQFD");
-	if (epoll_ctl(g.cq_fd, EPOLL_CTL_ADD, rep->cq_fd, &cq_event)) {
-		LOG_(rep, "error %d adding CQ to epoll wait set\n", errno);
-		__zap_put_ep(&rep->ep, "CQFD");
-		return errno;
-	}
-
-	return 0;
-}
-
 static void __teardown_conn(struct z_fi_ep *ep)
 {
 	int ret;
 	struct z_fi_ep *rep = (struct z_fi_ep *)ep;
-	struct epoll_event ignore;
+	struct z_fi_buffer_pool *p;
 
 	DLOG("rep %p\n", rep);
 
 	assert (!rep->cm_fd || (rep->ep.state != ZAP_EP_CONNECTED));
 
-	if (rep->cm_fd) {
-		if (epoll_ctl(g.cm_fd, EPOLL_CTL_DEL, rep->cm_fd, &ignore))
-			LOG_(rep, "error %d removing EQ from epoll wait set\n", errno);
-	}
+	z_fi_flush(ep);
 
 	if (ep->fi_ep) {
 		ret = fi_close(&rep->fi_ep->fid);
@@ -353,11 +349,14 @@ static void __teardown_conn(struct z_fi_ep *ep)
 		if (ret)
 			LOG_(rep, "error %d closing EQ\n", ret);
 	}
-	if (ep->buf_pool_mr) {
-		ret = fi_close(&ep->buf_pool_mr->fid);
-		if (ret)
-			LOG_(rep, "error %d closing buffer pool\n", ret);
+	pthread_mutex_lock(&rep->buf_free_list_lock);
+	while ((p = LIST_FIRST(&rep->vacant_pool))) {
+		_buffer_pool_free(rep, p);
 	}
+	while ((p = LIST_FIRST(&rep->full_pool))) {
+		_buffer_pool_free(rep, p);
+	}
+	pthread_mutex_unlock(&rep->buf_free_list_lock);
 	if (rep->fi)
 		fi_freeinfo(rep->fi);
 	if (rep->provider_name)
@@ -371,16 +370,9 @@ static void __teardown_conn(struct z_fi_ep *ep)
 	rep->domain = NULL;
 	rep->cq = NULL;
 	rep->eq = NULL;
-	rep->buf_pool_mr = NULL;
-	rep->buf_pool = NULL;
-	rep->buf_objs = NULL;
 	rep->rem_rq_credits = RQ_DEPTH;
 	rep->sq_credits = SQ_DEPTH;
 	rep->lcl_rq_credits = 0;
-	LIST_INIT(&rep->buf_free_list);
-
-	free(ep->buf_pool);
-	free(ep->buf_objs);
 }
 
 static void z_fi_destroy(zap_ep_t zep)
@@ -536,6 +528,14 @@ static int __fi_init(struct z_fi_ep *rep, int active, struct sockaddr *sin, size
 	return ret;
 }
 
+/* check ret before calling `ret = fn_call`, and log if ret != 0 */
+#define _XCALL(ret, fn_call) if (ret == 0) { \
+	ret = fn_call;\
+	if (ret) \
+		LLOG("%s returns %d\n", #fn_call, ret); \
+}
+
+/* ep->lock must NOT be held */
 static int
 __setup_conn(struct z_fi_ep *rep, struct sockaddr *sin, socklen_t sa_len)
 {
@@ -557,29 +557,29 @@ __setup_conn(struct z_fi_ep *rep, struct sockaddr *sin, socklen_t sa_len)
 	cq_attr.wait_cond        = FI_CQ_COND_NONE;
 	cq_attr.wait_set         = NULL;
 
-	ret = 0;
+	ret  = 0;
 	if (rep->parent_ep) {
 		// we get here if fi_accept() called
 		rep->fi->rx_attr->size = RQ_DEPTH + 2;
 		rep->fi->tx_attr->size = SQ_DEPTH + 2;
-		ret = ret || fi_endpoint(rep->domain, rep->fi, &rep->fi_ep, NULL);
+		_XCALL(ret, fi_endpoint(rep->domain, rep->fi, &rep->fi_ep, NULL));
 	} else {
 		// we get here if fi_connect() called
-		ret = fi_endpoint(rep->domain, rep->fi, &rep->fi_ep, NULL);
+		_XCALL(ret, fi_endpoint(rep->domain, rep->fi, &rep->fi_ep, NULL));
 		DLOG("using fabric '%s' provider '%s' domain '%s'\n",
 		     rep->fi->fabric_attr->name,
 		     rep->fi->fabric_attr->prov_name,
 		     rep->fi->domain_attr->name);
 	}
-	ret = ret || fi_eq_open(rep->fabric, &eq_attr, &rep->eq, NULL);
-	ret = ret || fi_cq_open(rep->domain, &cq_attr, &rep->cq, NULL);
-	ret = ret || fi_control(&rep->eq->fid, FI_GETWAIT, &rep->cm_fd);
-	ret = ret || fi_control(&rep->cq->fid, FI_GETWAIT, &rep->cq_fd);
-	ret = ret || fi_ep_bind(rep->fi_ep, &rep->eq->fid, 0);
-	ret = ret || fi_ep_bind(rep->fi_ep, &rep->cq->fid, FI_RECV|FI_TRANSMIT);
-	ret = ret || fi_enable(rep->fi_ep);
-	ret = ret || _buffer_init_pool(rep);
-	ret = ret || z_fi_fill_rq(rep);
+	_XCALL(ret, fi_eq_open(rep->fabric, &eq_attr, &rep->eq, NULL));
+	_XCALL(ret, fi_cq_open(rep->domain, &cq_attr, &rep->cq, NULL));
+	_XCALL(ret, fi_control(&rep->eq->fid, FI_GETWAIT, &rep->cm_fd));
+	_XCALL(ret, fi_control(&rep->cq->fid, FI_GETWAIT, &rep->cq_fd));
+	_XCALL(ret, fi_ep_bind(rep->fi_ep, &rep->eq->fid, 0));
+	_XCALL(ret, fi_ep_bind(rep->fi_ep, &rep->cq->fid, FI_RECV|FI_TRANSMIT));
+	_XCALL(ret, fi_enable(rep->fi_ep));
+	_XCALL(ret, _buffer_init_pool(rep));
+	_XCALL(ret, z_fi_fill_rq(rep));
 	if (ret) {
 		rep->ep.state = ZAP_EP_ERROR;
 		return ret;
@@ -587,70 +587,155 @@ __setup_conn(struct z_fi_ep *rep, struct sockaddr *sin, socklen_t sa_len)
 	return ret;
 }
 
+/* caller MUST hold rep->buf_free_list_lock */
+static struct z_fi_buffer_pool *
+_buffer_pool_new(struct z_fi_ep *rep, int num_bufs)
+{
+	struct z_fi_buffer_pool *p;
+	size_t sz;
+	int i, ret;
+	char *b;
+	struct z_fi_buffer *rb;
+
+	/* sz of each buf */
+	sz = rep->fi->ep_attr->msg_prefix_size + RQ_BUF_SZ;
+	sz = ( (sz-1) | 0x3F ) + 1; /* 64-byte aligned */
+	/* total size */
+	sz = sizeof(*p) + num_bufs*sizeof(p->buf_obj[0]) + num_bufs*sz;
+	p = malloc(sz);
+	if (!p)
+		goto err_0;
+
+	/* initialize pool structure */
+	bzero(p, sizeof(*p));
+	p->num_bufs = num_bufs;
+	p->buf_sz = rep->fi->ep_attr->msg_prefix_size + RQ_BUF_SZ;
+	p->buf_pool = (void*)&p->buf_obj[num_bufs];
+	LIST_INIT(&p->buf_free_list);
+
+	/* register memory */
+	ret = fi_mr_reg(rep->domain, p->buf_pool, p->num_bufs*p->buf_sz,
+			FI_SEND|FI_RECV, 0,
+			__atomic_add_fetch(&g.mr_key, 1, __ATOMIC_RELAXED),
+			0, &p->buf_pool_mr, NULL);
+	if (ret) {
+		LLOG("fi_reg_mr() failed: %d, sz: %ld\n", ret, p->num_bufs*p->buf_sz);
+		goto err_1;
+	}
+
+	/* initialize buffers */
+	b = p->buf_pool;
+	rb = p->buf_obj;
+	for (i = 0; i < num_bufs; i++) {
+		rb->buf = b;
+		rb->rep = rep;
+		rb->pool = p;
+		rb->msg = (struct z_fi_message_hdr *)(b + rep->fi->ep_attr->msg_prefix_size);
+		rb->buf_len = p->buf_sz; /* total size of buffer */
+		rb->data_len = 0; /* # bytes of buffer used */
+		LIST_INSERT_HEAD(&p->buf_free_list, rb, free_link);
+		rb++;
+		b += p->buf_sz;
+	}
+
+	/* insert into the vacant_pool list */
+	LIST_INSERT_HEAD(&rep->vacant_pool, p, entry);
+	rep->num_empty_pool++;
+
+	return p;
+
+ err_1:
+	free(p);
+ err_0:
+	return NULL;
+}
+
+/* caller MUST hold buf_free_list_lock */
+static void
+_buffer_pool_free(struct z_fi_ep *rep, struct z_fi_buffer_pool *p)
+{
+	int ret;
+	LIST_REMOVE(p, entry);
+	ret = fi_close(&p->buf_pool_mr->fid);
+	if (ret) {
+		LLOG("fi_close(mr) failed: %d\n", ret);
+		assert(0 == "fi_close(mr) failed");
+		return;
+	}
+	free(p);
+}
+
 /* Allocate and register an endpoint's send and recv buffers. */
 static int
 _buffer_init_pool(struct z_fi_ep *rep)
 {
-	int			i, ret;
-	char			*p;
-	struct z_fi_buffer	*rb;
-
-	rep->num_bufs = RQ_DEPTH + SQ_DEPTH + 4;  // +4 for credit updates
-	rep->buf_sz   = RQ_BUF_SZ;
-	rep->buf_pool = calloc(1, rep->num_bufs * rep->buf_sz);
-	rep->buf_objs = calloc(1, rep->num_bufs * sizeof(struct z_fi_buffer));
-	if (!rep->buf_pool || !rep->buf_objs)
-		return -ENOMEM;
-	ret = fi_mr_reg(rep->domain, rep->buf_pool, rep->num_bufs*rep->buf_sz, FI_SEND|FI_RECV, 0,
-			++g.mr_key, 0, &rep->buf_pool_mr, NULL);
-	if (ret) {
-		free(rep->buf_pool);
-		free(rep->buf_objs);
-		return -ENOMEM;
-	}
-
-	LIST_INIT(&rep->buf_free_list);
-	pthread_mutex_init(&rep->buf_free_list_lock, NULL);
-	p  = rep->buf_pool;
-	rb = rep->buf_objs;
-	for (i = 0; i < rep->num_bufs; ++i) {
-		rb->rep      = rep;
-		rb->buf      = p;
-		rb->msg      = (struct z_fi_message_hdr *)(p + rep->fi->ep_attr->msg_prefix_size);
-		rb->buf_len  = rep->buf_sz;  /* total size of buffer */
-		rb->data_len = 0;            /* # bytes of buffer used */
-		LIST_INSERT_HEAD(&rep->buf_free_list, rb, free_link);
-		++rb;
-		p += rep->buf_sz;
-	}
+	struct z_fi_buffer_pool *p;
+	pthread_mutex_lock(&rep->buf_free_list_lock);
+	p = _buffer_pool_new(rep, RQ_DEPTH + SQ_DEPTH + 4);
+	pthread_mutex_unlock(&rep->buf_free_list_lock);
+	if (!p)
+		return errno;
 	return 0;
 }
 
 static struct z_fi_buffer *
 __buffer_alloc(struct z_fi_ep *rep)
 {
-	struct z_fi_buffer	*rb;
+	struct z_fi_buffer *rb;
+	struct z_fi_buffer_pool *p;
 
 	pthread_mutex_lock(&rep->buf_free_list_lock);
-	if (LIST_EMPTY(&rep->buf_free_list)) {
-		rb = NULL;
-	} else {
-		rb = LIST_FIRST(&rep->buf_free_list);
-		LIST_REMOVE(rb, free_link);
-		rb->data_len = 0;  /* # bytes of buffer used */
+	p = LIST_FIRST(&rep->vacant_pool);
+	if (!p) {
+		p = _buffer_pool_new(rep, 64);
+		if (!p) {
+			rb = NULL;
+			goto out;
+		}
 	}
+	rb = LIST_FIRST(&p->buf_free_list);
+	assert(rb);
+	LIST_REMOVE(rb, free_link);
+	rb->data_len = 0;  /* # bytes of buffer used */
+	if (!p->num_alloc) {
+		/* the pool was empty, and now it is not */
+		rep->num_empty_pool--;
+	}
+	p->num_alloc++;
+	if (LIST_EMPTY(&p->buf_free_list)) {
+		/* pool is full (no vacancy), move it to `full_pool` list.  */
+		LIST_REMOVE(p, entry);
+		LIST_INSERT_HEAD(&rep->full_pool, p, entry);
+	}
+ out:
 	pthread_mutex_unlock(&rep->buf_free_list_lock);
-
 	return rb;
 }
 
 static void
 __buffer_free(struct z_fi_buffer *rb)
 {
-	struct z_fi_ep	*rep = rb->rep;
+	struct z_fi_ep *rep = rb->rep;
+	struct z_fi_buffer_pool *p;
 
 	pthread_mutex_lock(&rep->buf_free_list_lock);
-	LIST_INSERT_HEAD(&rep->buf_free_list, rb, free_link);
+	p = rb->pool;
+	if (LIST_EMPTY(&p->buf_free_list)) {
+		/* pool was full, now it has a vacancy */
+		LIST_REMOVE(p, entry);
+		LIST_INSERT_HEAD(&rep->vacant_pool, p, entry);
+	}
+	LIST_INSERT_HEAD(&p->buf_free_list, rb, free_link);
+	p->num_alloc--;
+	if (p->num_alloc == 0) {
+		/* the pool becomes empty */
+		if (rep->num_empty_pool >= 1) {
+			/* we have enough empty pools */
+			_buffer_pool_free(rep, p);
+		} else {
+			rep->num_empty_pool++;
+		}
+	}
 	pthread_mutex_unlock(&rep->buf_free_list_lock);
 }
 
@@ -697,41 +782,43 @@ static void _context_free(struct z_fi_context *ctxt)
 	free(ctxt);
 }
 
-/* Must be called with the credit lock held */
-static void flush_io_q(struct z_fi_ep *rep)
+/* MUST hold rep->ep.lock . */
+static void z_fi_flush(struct z_fi_ep *rep)
 {
+	/* Flush all outstanding requests. */
 	struct z_fi_context *ctxt;
 	struct zap_event ev = {
 		.status = ZAP_ERR_FLUSH,
 	};
-
-	while (!TAILQ_EMPTY(&rep->io_q)) {
-		ctxt = TAILQ_FIRST(&rep->io_q);
-		TAILQ_REMOVE(&rep->io_q, ctxt, pending_link);
-		DLOG("op %s rep %p ctxt %p\n", z_fi_op_str[ctxt->op], rep, ctxt);
+	while ((ctxt = LIST_FIRST(&rep->active_ctxt_list))) {
 		switch (ctxt->op) {
-		    case ZAP_WC_SEND:
+		case ZAP_WC_SEND:
 			/*
 			 * Zap version 1.3.0.0 doesn't have the SEND_COMPLETE event
 			 */
 			if (ctxt->u.send.rb)
 				__buffer_free(ctxt->u.send.rb);
-			__context_free(ctxt);
-			continue;
-		    case ZAP_WC_RDMA_WRITE:
+			goto ctxt_free;
+		case ZAP_WC_RECV:
+			/* RECV buffer is handled by the xprt, no callbacks. */
+			goto ctxt_free;
+		case ZAP_WC_RDMA_WRITE:
 			ev.type = ZAP_EVENT_WRITE_COMPLETE;
-			ev.context = ctxt->usr_context;
-			break;
-		    case ZAP_WC_RDMA_READ:
+			goto do_cb;
+		case ZAP_WC_RDMA_READ:
 			ev.type = ZAP_EVENT_READ_COMPLETE;
-			ev.context = ctxt->usr_context;
-			break;
-		    case ZAP_WC_RECV:
-		    default:
+			goto do_cb;
+		default:
 			LOG_(rep, "invalid op type %d in queued i/o\n", ctxt->op);
-			break;
+			assert(0 == "Invalid op type\n");
+			goto ctxt_free;
 		}
+	do_cb:
+		ev.context = ctxt->usr_context;
+		pthread_mutex_unlock(&rep->ep.lock);
 		rep->ep.cb(&rep->ep, &ev);
+		pthread_mutex_lock(&rep->ep.lock);
+	ctxt_free:
 		__context_free(ctxt);
 	}
 }
@@ -753,7 +840,7 @@ post_wr(struct z_fi_ep *rep, struct z_fi_context *ctxt)
 		rep->lcl_rq_credits = 0;
 		SEND_LOG(rep, ctxt);
 		len = rb->data_len + rep->fi->ep_attr->msg_prefix_size;
-		rc = fi_send(rep->fi_ep, rb->buf, len, fi_mr_desc(rb->rep->buf_pool_mr), 0, ctxt);
+		rc = fi_send(rep->fi_ep, rb->buf, len, fi_mr_desc(rb->pool->buf_pool_mr), 0, ctxt);
 
 		DLOG("ZAP_WC_SEND rep %p ctxt %p rb %p len %d with %d credits rc %d\n",
 		     rep, ctxt, rb, len, rep->lcl_rq_credits, rc);
@@ -856,6 +943,13 @@ static void submit_pending(struct z_fi_ep *rep)
 	int is_rdma;
 	struct z_fi_context *ctxt;
 
+	pthread_mutex_lock(&rep->ep.lock);
+	if (rep->ep.state != ZAP_EP_CONNECTED) {
+		pthread_mutex_unlock(&rep->ep.lock);
+		return;
+	}
+	pthread_mutex_unlock(&rep->ep.lock);
+
 	pthread_mutex_lock(&rep->credit_lock);
 	while (!TAILQ_EMPTY(&rep->io_q)) {
 		ctxt = TAILQ_FIRST(&rep->io_q);
@@ -949,11 +1043,6 @@ static zap_err_t z_fi_connect(zap_ep_t ep,
 	int rc;
 	zap_err_t zerr;
 	struct z_fi_ep *rep = (struct z_fi_ep *)ep;
-	struct zap_event zev;
-	struct epoll_event cm_event = {
-		.events = EPOLLIN,
-		.data.ptr = rep,
-	};
 
 	memset(&rep->conn_data, 0, sizeof(rep->conn_data));
 	ZAP_VERSION_SET(rep->conn_data.v);
@@ -979,30 +1068,27 @@ static zap_err_t z_fi_connect(zap_ep_t ep,
 	rc = __setup_conn(rep, sin, sa_len);
 	if (rc)
 		goto err_1;
-
 	__zap_get_ep(&rep->ep, "CONNECT");
-	rc = epoll_ctl(g.cm_fd, EPOLL_CTL_ADD, rep->cm_fd, &cm_event);
-	if (rc) {
-		zerr = ZAP_ERR_RESOURCE;
-		goto err_2;
-	}
 
 	rc = fi_connect(rep->fi_ep, rep->fi->dest_addr,
 			&rep->conn_data,
 			rep->conn_data.data_len + sizeof(rep->conn_data));
 	if (rc) {
-		(void)epoll_ctl(g.cm_fd, EPOLL_CTL_DEL, rep->cm_fd, NULL);
-		zev.type = ZAP_EVENT_CONNECT_ERROR;
-		zev.status = ZAP_ERR_ROUTE;
-		rep->ep.state = ZAP_EP_ERROR;
-		rep->ep.cb(&rep->ep, &zev);
-		__zap_put_ep(&rep->ep, "CONNECT");
+		/* rc is -errno */
+		zerr = zap_errno2zerr(-rc);
+		goto err_2;
 	}
+	zerr = zap_io_thread_ep_assign(&rep->ep);
+	if (zerr)
+		goto err_2;
 
 	return ZAP_ERR_OK;
 
 	/* These are all synchronous errors. */
  err_2:
+	pthread_mutex_lock(&rep->ep.lock);
+	__teardown_conn(rep);
+	pthread_mutex_unlock(&rep->ep.lock);
 	__zap_put_ep(&rep->ep, "CONNECT");
  err_1:
 	zap_ep_change_state(&rep->ep, ZAP_EP_CONNECTING, ZAP_EP_INIT);
@@ -1010,12 +1096,12 @@ static zap_err_t z_fi_connect(zap_ep_t ep,
 	return zerr;
 }
 
+/* rep->ep.lock MUST be held */
 static int __post_recv(struct z_fi_ep *rep, struct z_fi_buffer *rb)
 {
 	struct z_fi_context *ctxt;
 	int rc;
 
-	pthread_mutex_lock(&rep->ep.lock);
 	ctxt = __context_alloc(rep, NULL, ZAP_WC_RECV);
 	if (!ctxt) {
 		rc = ZAP_ERR_RESOURCE;
@@ -1023,14 +1109,13 @@ static int __post_recv(struct z_fi_ep *rep, struct z_fi_buffer *rb)
 	}
 	ctxt->u.recv.rb = rb;
 
-	rc = fi_recv(rep->fi_ep, rb->buf, rb->buf_len, fi_mr_desc(rb->rep->buf_pool_mr), 0, ctxt);
+	rc = fi_recv(rep->fi_ep, rb->buf, rb->buf_len, fi_mr_desc(rb->pool->buf_pool_mr), 0, ctxt);
 	if (rc) {
 		__context_free(ctxt);
 		rc = zap_errno2zerr(rc);
 	}
 	DLOG("fi_recv %d, rep %p ctxt %p rb %p buf %p len %d\n", rc, rep, ctxt, rb, rb->buf, rb->buf_len);
 out:
-	pthread_mutex_unlock(&rep->ep.lock);
 	return rc;
 }
 
@@ -1228,9 +1313,21 @@ static void process_recv_wc(struct z_fi_ep *rep, struct fi_cq_err_entry *entry)
 		break;
 	}
 
-	ret = __post_recv(rep, rb);
-	if (ret) {
-		LOG_(rep, "error %d (%s) posting recv buffers\n", ret, zap_err_str(ret));
+	pthread_mutex_lock(&rep->ep.lock);
+	switch (rep->ep.state) {
+	case ZAP_EP_CONNECTED:
+	case ZAP_EP_CONNECTING:
+	case ZAP_EP_ACCEPTING:
+		ret = __post_recv(rep, rb);
+		pthread_mutex_unlock(&rep->ep.lock);
+		if (ret) {
+			LOG_(rep, "error %d (%s) posting recv buffers\n", ret, zap_err_str(ret));
+			__buffer_free(rb);
+			goto out;
+		}
+		break;
+	default:
+		pthread_mutex_unlock(&rep->ep.lock);
 		__buffer_free(rb);
 		goto out;
 	}
@@ -1265,7 +1362,9 @@ static int z_fi_fill_rq(struct z_fi_ep *rep)
 		rbuf = __buffer_alloc(rep);
 		if (!rbuf)
 			return ENOMEM;
+		pthread_mutex_lock(&rep->ep.lock);
 		rc = __post_recv(rep, rbuf);
+		pthread_mutex_unlock(&rep->ep.lock);
 		if (rc) {
 			__buffer_free(rbuf);
 			return rc;
@@ -1305,10 +1404,6 @@ static zap_err_t z_fi_accept(zap_ep_t ep, zap_cb_fn_t cb,
 	int ret;
 	struct z_fi_ep *rep = (struct z_fi_ep *)ep;
 	struct z_fi_accept_msg *msg;
-	struct epoll_event cm_event = {
-		.events = EPOLLIN,
-		.data.ptr = rep,
-	};
 
 	if (data_len > ZAP_ACCEPT_DATA_MAX - sizeof(*msg)) {
 		return ZAP_ERR_PARAMETER;
@@ -1328,19 +1423,26 @@ static zap_err_t z_fi_accept(zap_ep_t ep, zap_cb_fn_t cb,
 
 	__zap_get_ep(&rep->ep, "ACCEPT");
 	ret = __setup_conn(rep, NULL, 0);
-	ret = ret || epoll_ctl(g.cm_fd, EPOLL_CTL_ADD, rep->cm_fd, &cm_event);
 	if (ret)
 		goto err_0;
 
 	ret = fi_accept(rep->fi_ep, msg, len);
 	if (ret) {
 		ret = zap_errno2zerr(errno);
-		goto err_0;
+		goto err_1;
 	}
+
+	ret = zap_io_thread_ep_assign(&rep->ep);
+	if (ret)
+		goto err_1;
 
 	rep->conn_req_decision = Z_FI_PASSIVE_ACCEPT;
 	free(msg);
 	return ZAP_ERR_OK;
+err_1:
+	pthread_mutex_lock(&rep->ep.lock);
+	__teardown_conn(rep);
+	pthread_mutex_unlock(&rep->ep.lock);
 err_0:
 	__zap_put_ep(&rep->ep, "ACCEPT");
 	free(msg);
@@ -1423,61 +1525,6 @@ static void scrub_cq(struct z_fi_ep *rep)
 	DLOG("done with rep %p\n", rep);
 }
 
-static void *cq_thread_proc(void *arg)
-{
-	int ret, i, n;
-	struct z_fi_ep *rep;
-	struct epoll_event cq_events[16], ignore;
-	sigset_t sigset;
-
-	sigfillset(&sigset);
-	ret = pthread_sigmask(SIG_BLOCK, &sigset, NULL);
-	assert(ret == 0);
-
-	while (1) {
-		n = epoll_wait(g.cq_fd, cq_events, 16, -1);
-		DLOG("got %d events\n", n);
-		if (n < 0) {
-			if (errno == EINTR)
-				continue;
-			break;
-		}
-		for (i = 0; i < n; i++) {
-			rep = cq_events[i].data.ptr;
-			__zap_get_ep(&rep->ep, "CQE");
-			scrub_cq(rep);
-			pthread_mutex_lock(&rep->ep.lock);
-			/*
-			 * We know an endpoint is shut down when the
-			 * active ctxt list becomes empty. This is the
-			 * only condition under which *all* posted
-			 * wr's are completed (flushed), given how
-			 * SQ and RQ credits are exchanged.
-			 */
-			if (LIST_EMPTY(&rep->active_ctxt_list)) {
-				DLOG("rep %p ctxts drained\n", rep);
-				if (epoll_ctl(g.cq_fd, EPOLL_CTL_DEL, rep->cq_fd, &ignore)) {
-					LOG_(rep, "error %d removing CQ from epoll wait set\n", errno);
-				} else {
-					__zap_put_ep(&rep->ep, "CQFD");
-				}
-				if (rep->deferred_disconnected == 1) {
-					pthread_mutex_unlock(&rep->ep.lock);
-					__deliver_disconnected(rep);
-					rep->deferred_disconnected = -1;
-				} else {
-					pthread_mutex_unlock(&rep->ep.lock);
-				}
-			} else {
-				pthread_mutex_unlock(&rep->ep.lock);
-				submit_pending(rep);
-			}
-			__zap_put_ep(&rep->ep, "CQE");
-		}
-	}
-	return NULL;
-}
-
 static zap_ep_t z_fi_new(zap_t z, zap_cb_fn_t cb)
 {
 	struct z_fi_ep *rep;
@@ -1492,6 +1539,14 @@ static zap_ep_t z_fi_new(zap_t z, zap_cb_fn_t cb)
 	rep->rem_rq_credits = RQ_DEPTH;
 	rep->lcl_rq_credits = 0;
 	rep->sq_credits = SQ_DEPTH;
+
+	rep->cm_epoll_ctxt.rep = rep;
+	rep->cm_epoll_ctxt.type = Z_FI_EPOLL_CM;
+	rep->cq_epoll_ctxt.rep = rep;
+	rep->cq_epoll_ctxt.type = Z_FI_EPOLL_CQ;
+
+	rep->cm_fd = -1;
+	rep->cq_fd = -1;
 
 	TAILQ_INIT(&rep->io_q);
 	LIST_INIT(&rep->active_ctxt_list);
@@ -1527,7 +1582,7 @@ static void handle_connect_request(struct z_fi_ep *rep, struct fi_eq_cm_entry *e
 		zev.data = (void*)conn_data->data;
 	}
 
-	new_ep = zap_new(rep->ep.z, rep->ep.app_cb);
+	new_ep = zap_new(rep->ep.z, rep->ep.cb);
 	if (!new_ep) {
 		LOG_(rep, "error creating new endpoint\n");
 		fi_reject(rep->fi_pep, newfi->handle, NULL, 0);
@@ -1559,11 +1614,14 @@ static void handle_conn_error(struct z_fi_ep *rep, zap_err_t err)
 	zap_ep_state_t oldstate;
 
 	zev.status = err;
-	if (rep->cq_fd != -1)
-		__enable_cq_events(rep);
 
+	zap_io_thread_ep_release(&rep->ep);
+
+	pthread_mutex_lock(&rep->ep.lock);
 	oldstate = rep->ep.state;
 	rep->ep.state = ZAP_EP_ERROR;
+	z_fi_flush(rep); /* Flush the RECV posted in __setup_conn() */
+	pthread_mutex_unlock(&rep->ep.lock);
 
 	switch (oldstate) {
 	    case ZAP_EP_ACCEPTING:
@@ -1628,8 +1686,10 @@ static void handle_rejected(struct z_fi_ep *rep, struct fi_eq_err_entry *entry)
 	zev.data = (uint8_t *)rej_msg->msg;
 	zev.type = ZAP_EVENT_REJECTED;
 
-	__enable_cq_events(rep);
+	pthread_mutex_lock(&rep->ep.lock);
 	rep->ep.state = ZAP_EP_ERROR;
+	z_fi_flush(rep);
+	pthread_mutex_unlock(&rep->ep.lock);
 	rep->ep.cb(&rep->ep, &zev);
 	__zap_put_ep(&rep->ep, "CONNECT");
 }
@@ -1666,7 +1726,6 @@ static void handle_established(struct z_fi_ep *rep, struct fi_eq_cm_entry *entry
 	}
 
 	rep->ep.cb(&rep->ep, &zev);
-	__enable_cq_events(rep);
 }
 
 static void _deliver_disconnected(struct z_fi_ep *rep)
@@ -1715,21 +1774,12 @@ static void handle_disconnected(struct z_fi_ep *rep, struct fi_eq_cm_entry *entr
 		LOG_(rep, "unexpected disconnect in state %d\n", rep->ep.state);
 		break;
 	}
+	/* Flush outstanding requests. */
+	z_fi_flush(rep);
 	pthread_mutex_unlock(&rep->ep.lock);
 
-	pthread_mutex_lock(&rep->credit_lock);
-	__flush_io_q(rep);
-	pthread_mutex_unlock(&rep->credit_lock);
-
-	pthread_mutex_lock(&rep->ep.lock);
-
-	if (!LIST_EMPTY(&rep->active_ctxt_list)) {
-		rep->deferred_disconnected = 1;
-		pthread_mutex_unlock(&rep->ep.lock);
-	} else {
-		pthread_mutex_unlock(&rep->ep.lock);
-		__deliver_disconnected(rep);
-	}
+	zap_io_thread_ep_release(&rep->ep);
+	__deliver_disconnected(rep);
 }
 
 static void cm_event_handler(struct z_fi_ep *rep,
@@ -1798,30 +1848,6 @@ static void scrub_eq(struct z_fi_ep *rep)
 	}
 	__zap_put_ep(&rep->ep, "EQE");
 	DLOG("done with rep %p\n", rep);
-}
-
-static void *cm_thread_proc(void *arg)
-{
-	int ret, i, n;
-	struct epoll_event cm_events[16];
-	sigset_t sigset;
-
-	sigfillset(&sigset);
-	ret = pthread_sigmask(SIG_BLOCK, &sigset, NULL);
-	assert(ret == 0);
-
-	while (1) {
-		n = epoll_wait(g.cm_fd, cm_events, 16, -1);
-		DLOG("got %d events\n", n);
-		if (n < 0) {
-			if (errno == EINTR)
-				continue;
-			break;
-		}
-		for (i = 0; i < n; ++i)
-			scrub_eq(cm_events[i].data.ptr);
-	}
-	return NULL;
 }
 
 #define MIN(a,b) ((a)<(b)?(a):(b))
@@ -1970,7 +1996,6 @@ static zap_err_t z_fi_listen(zap_ep_t ep, struct sockaddr *saddr, socklen_t sa_l
 	zap_err_t zerr;
 	int rc;
 	struct z_fi_ep *rep = (struct z_fi_ep *)ep;
-	struct epoll_event cm_event;
 	struct fi_eq_attr eq_attr = { .wait_obj = FI_WAIT_FD };
 	char buf[512] = "";
 	size_t len = sizeof(buf);
@@ -2004,21 +2029,17 @@ static zap_err_t z_fi_listen(zap_ep_t ep, struct sockaddr *saddr, socklen_t sa_l
 			   rep->fi->fabric_attr->prov_name,
 			   rep->fi->domain_attr->name);
 
-	cm_event.events = EPOLLIN;
-	cm_event.data.ptr = rep;
-	rc = epoll_ctl(g.cm_fd, EPOLL_CTL_ADD, rep->cm_fd, &cm_event);
+	rc = fi_listen(rep->fi_pep);
 	if (rc)
 		goto err_1;
 
-	rc = fi_listen(rep->fi_pep);
-	if (rc)
+	zerr = zap_io_thread_ep_assign(&rep->ep);
+	if (zerr != ZAP_ERR_OK)
 		goto err_1;
 
 	return ZAP_ERR_OK;
 
  err_1:
-	rc = epoll_ctl(g.cm_fd, EPOLL_CTL_DEL, rep->cm_fd, NULL);
-	fi_close(&rep->cq->fid);
 	fi_close(&rep->eq->fid);
 	fi_close(&rep->fi_pep->fid);
 	rep->fi_ep = NULL;
@@ -2315,32 +2336,202 @@ static void z_fi_cleanup(void)
 	}
 }
 
-static int init_once()
+static void z_fi_io_thread_cleanup(void *arg)
+{
+	struct z_fi_io_thread *thr = arg;
+	if (thr->efd >= 0)
+		close(thr->efd);
+	zap_io_thread_release(&thr->zap_io_thread);
+	free(thr);
+}
+
+static void *z_fi_io_thread_proc(void *arg)
+{
+	struct z_fi_io_thread *thr = arg;
+	int rc, n, i;
+	sigset_t sigset;
+	const int N_EV = 16;
+	int n_cq, n_cm;
+	struct epoll_event ev[N_EV];
+	struct z_fi_ep *cq_reps[N_EV];
+	struct z_fi_ep *cm_reps[N_EV];
+	struct z_fi_epoll_ctxt *ctxt;
+
+	sigfillset(&sigset);
+	rc = pthread_sigmask(SIG_BLOCK, &sigset, NULL);
+	if (rc) {
+		LOG("ERROR: pthread_sigmask errno: %d\n", errno);
+		assert(0);
+		return NULL;
+	}
+
+	pthread_cleanup_push(z_fi_io_thread_cleanup, arg);
+ loop:
+	zap_thrstat_wait_start(thr->zap_io_thread.stat);
+	n = epoll_wait(thr->efd, ev, N_EV, -1);
+	zap_thrstat_wait_end(thr->zap_io_thread.stat);
+	n_cq = 0;
+	n_cm = 0;
+
+	/* CQ events */
+	for (i = 0; i < n; i++) {
+		ctxt = ev[i].data.ptr;
+		switch (ctxt->type) {
+		case Z_FI_EPOLL_CM:
+			/* CM events will be processed after CQ events */
+			__zap_get_ep(&ctxt->rep->ep, "CM_Q");
+			cm_reps[n_cm++] = ctxt->rep;
+			break;
+		case Z_FI_EPOLL_CQ:
+			__zap_get_ep(&ctxt->rep->ep, "PENDING_Q");
+			cq_reps[n_cq++] = ctxt->rep;
+			scrub_cq(ctxt->rep);
+			break;
+		default:
+			assert(0 == "Unexpected epoll event type");
+			break;
+		}
+	}
+
+	/* CM events */
+	for (i = 0; i < n_cm; i++) {
+		scrub_eq(cm_reps[i]);
+		__zap_put_ep(&cm_reps[i]->ep, "CM_Q");
+	}
+
+	/* Submit pending */
+	for (i = 0; i < n_cq; i++) {
+		submit_pending(cq_reps[i]);
+		__zap_put_ep(&cq_reps[i]->ep, "PENDING_Q");
+	}
+	goto loop;
+
+	pthread_cleanup_pop(1);
+	return NULL;
+}
+
+static zap_io_thread_t z_fi_io_thread_create(zap_t z)
+{
+	zap_err_t zerr;
+	int rc;
+	struct z_fi_io_thread *thr;
+
+	thr = malloc(sizeof(*thr));
+	if (!thr) {
+		LLOG("malloc() failed: %d\n", errno);
+		goto out;
+	}
+	zerr = zap_io_thread_init(&thr->zap_io_thread, z, "z_fi_io", ZAP_ENV_INT(ZAP_THRSTAT_WINDOW));
+	if (zerr) {
+		LLOG("zap_io_thread_init() failed, zerr: %d\n", zerr);
+		goto err1;
+	}
+	thr->efd = epoll_create1(EPOLL_CLOEXEC);
+	if (thr->efd < 0) {
+		LLOG("epoll_create1() failed, errno: %d\n", errno);
+		goto err2;
+	}
+	rc = pthread_create(&thr->zap_io_thread.thread, NULL, z_fi_io_thread_proc, thr);
+	if (rc) {
+		LLOG("pthread_create() failed, errno: %d\n", rc);
+		goto err3;
+	}
+	pthread_setname_np(thr->zap_io_thread.thread, "z_fi_io");
+	goto out;
+
+ err3:
+	close(thr->efd);
+ err2:
+	zap_io_thread_release(&thr->zap_io_thread);
+ err1:
+	free(thr);
+ out:
+	return &thr->zap_io_thread;
+}
+
+static zap_err_t z_fi_io_thread_cancel(zap_io_thread_t t)
 {
 	int rc;
+	rc = pthread_cancel(t->thread);
+	switch (rc) {
+	case ESRCH: /* cleaning up structure w/o running thread b/c of fork */
+		((z_fi_io_thread_t)t)->efd = -1; /* b/c of CLOEXEC */
+		z_fi_io_thread_cleanup(t);
+	case 0:
+		return ZAP_ERR_OK;
+	default:
+		return ZAP_ERR_LOCAL_OPERATION;
+	}
+}
+
+static zap_err_t z_fi_io_thread_ep_assign(zap_io_thread_t t, zap_ep_t ep)
+{
+	/* listening endpoint will only have cm_fd, while active/passive
+	 * endpoints will have both cm_fd and cq_fd */
+	struct z_fi_io_thread *thr = (void*)t;
+	struct z_fi_ep *rep = (void*)ep;
+	int rc;
+	zap_err_t zerr = ZAP_ERR_OK;
+	struct epoll_event ev = { .events = EPOLLIN };
+
+	__zap_get_ep(ep, "IO_THREAD");
+
+	/* Add cm_fd to thread's epoll */
+	assert(rep->cm_fd >= 0);
+	ev.data.ptr = &rep->cm_epoll_ctxt;
+	rc = epoll_ctl(thr->efd, EPOLL_CTL_ADD, rep->cm_fd, &ev);
+	if (rc) {
+		LLOG("epoll_ctl() error: %d\n", errno);
+		zerr = zap_errno2zerr(errno);
+		goto err_0;
+	}
+
+	/* Add cq_fd to thread's epoll */
+	if (rep->cq_fd < 0) /* skip cq for listening endpoint */
+		goto out;
+	ev.data.ptr = &rep->cq_epoll_ctxt;
+	rc = epoll_ctl(thr->efd, EPOLL_CTL_ADD, rep->cq_fd, &ev);
+	if (rc) {
+		LLOG("epoll_ctl() error: %d\n", errno);
+		zerr = zap_errno2zerr(errno);
+		goto err_1;
+	}
+ out:
+	return ZAP_ERR_OK;
+
+ err_1:
+	epoll_ctl(thr->efd, EPOLL_CTL_DEL, rep->cm_fd, &ev);
+ err_0:
+	__zap_put_ep(ep, "IO_THREAD");
+	return zerr;
+}
+
+static zap_err_t z_fi_io_thread_ep_release(zap_io_thread_t t, zap_ep_t ep)
+{
+	struct z_fi_io_thread *thr = (void*)t;
+	struct z_fi_ep *rep = (void*)ep;
+	int rc;
+	struct epoll_event ev = { .events = EPOLLIN }; /* ignored */
+	assert(rep->cm_fd >= 0);
+	rc = epoll_ctl(thr->efd, EPOLL_CTL_DEL, rep->cm_fd, &ev);
+	if (rc)
+		LLOG("Warning: EPOLL_CTL_DEL cm_fd error: %d\n", errno);
+	if (rep->cq_fd >= 0) {
+		rc = epoll_ctl(thr->efd, EPOLL_CTL_DEL, rep->cq_fd, &ev);
+		if (rc)
+			LLOG("Warning: EPOLL_CTL_DEL cq_fd error: %d\n", errno);
+	}
+	__zap_put_ep(ep, "IO_THREAD");
+	return ZAP_ERR_OK;
+}
+
+static int init_once()
+{
 	static int init_complete = 0;
 	const char *env;
 
 	if (init_complete)
 		return 0;
-
-	g.cq_fd = epoll_create(512);
-	if (!g.cq_fd)
-		goto err_0;
-
-	g.cm_fd = epoll_create(512);
-	if (!g.cm_fd)
-		goto err_1;
-
-	rc = pthread_create(&cq_thread, NULL, cq_thread_proc, NULL);
-	if (rc)
-		goto err_2;
-	pthread_setname_np(cq_thread, "z_fi_cq");
-
-	rc = pthread_create(&cm_thread, NULL, cm_thread_proc, NULL);
-	if (rc)
-		goto err_3;
-	pthread_setname_np(cm_thread, "z_fi_cm");
 
 	env = getenv(ZAP_FABRIC_INFO_LOG);
 	if (env)
@@ -2350,14 +2541,6 @@ static int init_once()
 	atexit(z_fi_cleanup);
 	return 0;
 
- err_3:
-	pthread_cancel(cq_thread);
- err_2:
-	close(g.cm_fd);
- err_1:
-	close(g.cq_fd);
- err_0:
-	return 1;
 }
 
 zap_err_t zap_transport_get(zap_t *pz, zap_log_fn_t log_fn,
@@ -2391,6 +2574,10 @@ zap_err_t zap_transport_get(zap_t *pz, zap_log_fn_t log_fn,
 	z->unmap = z_fi_unmap;
 	z->share = z_fi_share;
 	z->get_name = z_get_name;
+	z->io_thread_create = z_fi_io_thread_create;
+	z->io_thread_cancel = z_fi_io_thread_cancel;
+	z->io_thread_ep_assign = z_fi_io_thread_ep_assign;
+	z->io_thread_ep_release = z_fi_io_thread_ep_release;
 
 	*pz = z;
 	return ZAP_ERR_OK;

--- a/lib/src/zap/fabric/zap_fabric.h
+++ b/lib/src/zap/fabric/zap_fabric.h
@@ -52,6 +52,7 @@
 #include <sys/queue.h>
 #include <semaphore.h>
 #include <rdma/fabric.h>
+#include <sys/epoll.h>
 #include "../zap.h"
 #include "../zap_priv.h"
 
@@ -129,7 +130,28 @@ struct z_fi_buffer {
 	size_t buf_len;
 	size_t data_len;
 	struct z_fi_ep *rep;
+	struct z_fi_buffer_pool *pool;
 	LIST_ENTRY(z_fi_buffer) free_link;  /* for per-ep free list */
+};
+
+/*
+ * buffer_pool memory allocation format:
+ *     z_fi_buffer_pool|[buf_obj ...]|<pad (if needed)>|[buf ...]
+ *
+ * When the buffer poll is fully allocated, the pool is moved into the
+ * `full_pool` list. When it has at least one available slot, it is moved back
+ * to the `vacant_pool` list.
+ *
+ */
+struct z_fi_buffer_pool {
+	char *buf_pool;
+	int num_bufs;   /* total number of buf */
+	int num_alloc; /* number of allocated buf */
+	size_t buf_sz; /* size of each buf */
+	struct fid_mr *buf_pool_mr;
+	LIST_ENTRY(z_fi_buffer_pool) entry; /* for `full_pool` or `vacant_pool` */
+	LIST_HEAD(, z_fi_buffer) buf_free_list; /* to maintain free buf in the pool */
+	struct z_fi_buffer buf_obj[];
 };
 
 enum z_fi_op {
@@ -177,6 +199,16 @@ struct z_fi_conn_data {
 #define ACCEPT_DATA_MAX (196)
 #define ZAP_ACCEPT_DATA_MAX ACCEPT_DATA_MAX
 
+typedef struct z_fi_io_thread *z_fi_io_thread_t;
+
+struct z_fi_epoll_ctxt {
+	enum {
+		Z_FI_EPOLL_CM,
+		Z_FI_EPOLL_CQ,
+	} type;
+	struct z_fi_ep *rep;
+};
+
 struct z_fi_ep {
 	struct zap_ep ep;
 
@@ -195,13 +227,21 @@ struct z_fi_ep {
 	int cq_fids_idx;
 	int eq_fids_idx;
 	int num_ctxts;
+
+	/*
 	int num_bufs;
 	size_t buf_sz;
 	char *buf_pool;
 	struct z_fi_buffer *buf_objs;
 	struct fid_mr *buf_pool_mr;
 	LIST_HEAD(buf_free_list, z_fi_buffer) buf_free_list;
+	*/
+
 	pthread_mutex_t	buf_free_list_lock;
+
+	LIST_HEAD(, z_fi_buffer_pool) vacant_pool;
+	LIST_HEAD(, z_fi_buffer_pool) full_pool;
+	int num_empty_pool; /* number of pools with full vacancy */
 
 	union {
 		struct z_fi_conn_data conn_data; /* flexi */
@@ -250,6 +290,16 @@ struct z_fi_ep {
 #endif /* ZAP_DEBUG */
 
 	LIST_ENTRY(z_fi_ep) ep_link;
+
+	struct z_fi_epoll_ctxt cm_epoll_ctxt;
+	struct z_fi_epoll_ctxt cq_epoll_ctxt;
 };
+
+struct z_fi_io_thread {
+	struct zap_io_thread zap_io_thread;
+	int efd; /* epoll fd */
+};
+
+#define Z_FI_THR(p) ((struct z_fi_io_thread *)(p))
 
 #endif

--- a/lib/src/zap/rdma/zap_rdma.h
+++ b/lib/src/zap/rdma/zap_rdma.h
@@ -147,6 +147,17 @@ struct z_rdma_conn_data {
 
 LIST_HEAD(z_rdma_buffer_list, z_rdma_buffer);
 
+struct z_rdma_epoll_ctxt {
+	enum {
+		Z_RDMA_EPOLL_CM = 1,
+		Z_RDMA_EPOLL_CQ,
+	} type;
+	union {
+		struct rdma_event_channel *cm_channel;
+		struct z_rdma_ep *cq_rep;
+	};
+};
+
 struct z_rdma_ep {
 	struct zap_ep ep;
 	struct ibv_comp_channel *cq_channel;
@@ -210,6 +221,18 @@ struct z_rdma_ep {
 	} dev_type;
 	int cm_channel_enabled;
 	int cq_channel_enabled;
+
+	struct z_rdma_epoll_ctxt cq_ctxt;
 };
+
+typedef struct z_rdma_io_thread {
+	struct zap_io_thread zap_io_thread;
+	int efd; /* epoll fd */
+	struct z_rdma_epoll_ctxt cm_ctxt;
+	int devices_len; /* number of devices */
+} *z_rdma_io_thread_t;
+
+/* Get z_rdma_io_thread from struct z_rdma_ep */
+#define Z_RDMA_EP_THR(ep) ((z_rdma_io_thread_t)((struct zap_ep *)(ep))->thread)
 
 #endif

--- a/lib/src/zap/sock/zap_sock.h
+++ b/lib/src/zap/sock/zap_sock.h
@@ -51,7 +51,7 @@
 #define __LDMS_XPRT_SOCK_H__
 #include <semaphore.h>
 #include <sys/queue.h>
-#include "ovis_event/ovis_event.h"
+#include <sys/epoll.h>
 #include "ovis-ldms-config.h"
 #include "coll/rbt.h"
 #include "zap.h"
@@ -279,7 +279,8 @@ struct z_sock_ep {
 	int sock_connected;
 	int app_accepted;
 
-	struct ovis_event_s ev;
+	struct epoll_event ev;
+	void (*ev_fn)(struct epoll_event *);
 	struct z_sock_buff_s buff;
 
 	pthread_mutex_t q_lock;
@@ -288,6 +289,14 @@ struct z_sock_ep {
 	TAILQ_HEAD(, z_sock_send_wr_s) sq; /* send queue */
 	LIST_ENTRY(z_sock_ep) link;
 };
+
+#define ZAP_SOCK_EV_SIZE 4096
+
+typedef struct z_sock_io_thread {
+	struct zap_io_thread zap_io_thread;
+	int efd; /* epoll fd */
+	struct epoll_event ev[ZAP_SOCK_EV_SIZE];
+} *z_sock_io_thread_t;
 
 static inline struct z_sock_ep *z_sock_from_ep(zap_ep_t *ep)
 {

--- a/lib/src/zap/ugni/zap_ugni.c
+++ b/lib/src/zap/ugni/zap_ugni.c
@@ -1,8 +1,9 @@
 /* -*- c-basic-offset: 8 -*-
- * Copyright (c) 2014-2017,2019 National Technology & Engineering Solutions
+ * Copyright (c) 2014-2017,2019-2021 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
- * Copyright (c) 2014-2017,2019 Open Grid Computing, Inc. All rights reserved.
+ * Copyright (c) 2014-2017,2019-2021 Open Grid Computing, Inc. All rights
+ * reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -73,6 +74,203 @@
 
 #include "zap_ugni.h"
 
+/*
+ * NOTE on `zap_ugni`
+ * ==================
+ *
+ * The TCP sockets are used to initiate connections, and to listen. In a near
+ * future, the sockets will be removed entirely.
+ *
+ *
+ * Threads and endpoints
+ * ---------------------
+ *
+ * `io_thread_proc()` is the thread procedure of all zap thread for `zap_ugni`.
+ * The thread uses `epoll` to manage events from 1) sockets, 2) the GNI
+ * Completion Queue (CQ) via Completion Channel, and 3) the `zap_ugni` event
+ * queue `zq` for timeout events and connection events.
+ *
+ * Currently, when an endpoint is assigned to a thread, it stays there
+ * until it is destroyed (no thread migration).
+ *
+ * Regarding GNI resources, each thread has 1 completion channel, 1 local CQ,
+ * and 1 remote (smsg recv) CQ which are shared among the endpoints assigned to
+ * the thread. We need to use 2 CQs because the documentation of
+ * `GNI_CqCreate()` said so. We also tried it out with 1 CQ and found out that
+ * the remote completion entry cannot be used to determine the type of the
+ * completion (GNI_CQ_GET_TYPE()). It reported `GNI_CQ_EVENT_TYPE_POST` instead
+ * of `GNI_CQ_EVENT_TYPE_SMSG`.
+ *
+ * The completion channel has a file descriptor that can be used with epoll. The
+ * CQs are attached to the completion channel. After the CQs are armed, they
+ * will notify the completion channel when a completion entry is available to be
+ * processed. This makes completion channel file descriptor ready to be read and
+ * epoll wakes the thread up to process the completion events.
+ *
+ * `zq` is an additional event queue for each thread that manages timeout events
+ * and connection events (CONNECTED, CONN_ERROR and DISCONNECTED). The
+ * connection events could result in a recursive application callback
+ * or calling application callback from a thread other than the associated io
+ * thread are put into `zq` to avoid such situations. An example would be a
+ * synchronous error of send/read/write that may be called from other theads or
+ * from within the application callback path. The synchronous error immediately
+ * put the endpoint in error state, then result in either DISCONNECT or
+ * CONN_ERROR events in `zq`.
+ *
+ *
+ * Connecting mechanism
+ * --------------------
+ *
+ * The following describes interactions between the active side and the passive
+ * side of `zap_ugni` in connecting mechanism.
+ *
+ * - [passive] listens on a TCP socket (host/port).
+ * - [active] creates an endpoint and TCP `connect()` to the passive side.
+ * - [passive] creates an endpoint and TCP `accept()` the TCP connection.
+ * - [active] becomes TCP-connected and send a `z_ugni_sock_msg_conn_req`
+ *            message over the socket. The message contains information needed
+ *            by the passive side to setup the GNI SMSG.
+ * - [passive] becomes TCP-connected, and receives `z_ugni_sock_msg_conn_req`
+ *             message over the socket. Then, if the protocol version matched,
+ *             setup GNI SMSG (also bind GNI endpoint) according to the
+ *             information in the received message, and replies with
+ *             `z_ugni_sock_msg_conn_accept` message over the socket that
+ *             contain similar data needed to setup the SMSG on the active side.
+ *             Next, close the TCP socket as it is not needed anymore. The
+ *             communication from this point will use GNI SMSG. If the protocol
+ *             version does not match or other errors occur, terminates the TCP
+ *             connection.
+ * - [active] receives `z_ugni_sock_msg_conn_accept` and setup GNI SMSG. Then,
+ *            the active side closes the TCP socket as GNI SMSG is established.
+ * - [NOTE] At this point both sides can use GNI SMSG to send/recv messages.
+ *          The TCP socket part will soon be replaced with `GNI_EpPostData()`
+ *          mechanisms. The application data supplied in `zap_connect()`,
+ *          `zap_accept()`, or `zap_reject()` happened over GNI SMSG. The
+ *          GNI-SMSG-based connection procedure continues as follows.
+ * - [active] SMSG-sends the `ZAP_UGNI_MSG_CONNECT` message containing
+ *            application connect data. A timeout event is also added into `zq`.
+ *            If the connection procedure could not complete (rejected, accepted
+ *            or error) within the timeout limit, connection timeout will be
+ *            processed and `CONN_ERROR` is delivered to the application.
+ * - [passive] SMSG-recv the `ZAP_UGNI_MSG_CONNECT` message and notify the
+ *             application about connection request with the data. The
+ *             application may `zap_accept()` or `zap_reject()` the connection
+ *             request, which results in the passive side SMSG-sending
+ *             `ZAP_UGNI_MSG_ACCEPTED` with application-supplied data or
+ *             `ZAP_UGNI_MSG_REJECTED` respectively. In the case of ACCEPTED,
+ *             also notify the application the CONENCTED event.
+ * - [active] SMSG-recv either `ZAP_UGNI_MSG_ACCEPTED` or
+ *            `ZAP_UGNI_MSG_REJECTED` and notifies the application accordingly
+ *            (CONNECTED or REJECTED event).
+ * - [NOTE] After this point, both active and passive sides can `zap_send()`,
+ *          `zap_read()`, and `zap_write()`.
+ *
+ *
+ * Disconnecting mechanism over GNI SMSG
+ * -------------------------------------
+ *
+ * `ZAP_UGNI_MSG_TERM` is a message to notify the peer that the local process
+ * wants to terminate the connection. The local process shall not send any more
+ * messages other than `ZAP_UGNI_MSG_ACK_TERM` to acknowledge the
+ * `ZAP_UGNI_MSG_TERM` that the peer may also send. When the peer replies with
+ * `ZAP_UGNI_MSG_ACK_TERM`, the peer will not to send any further messages and
+ * the local process can deem the endpoint DISCONNECTED. In the case that one
+ * side actively close the connection, it plays out as follows.
+ *
+ * ```
+ *                   .-------.                     .-------.
+ *                   | peer0 |                     | peer1 |
+ *                   '-------'                     '-------'
+ *                       |                             |
+ *          Send TERM(0) |            TERM(0)          |
+ *                       |---------------------------->|--.
+ *                       |                             |  | Process TERM(0)
+ *                       |            TERM(1)          |  | -Send TERM(1)
+ *                    .--|<----------------------------|<-' -Send ACK_TERM(0)
+ *                    |  |                             |
+ *  Process TERM(1)   |  |          ACK_TERM(0)        |
+ *  -Send ACK_TERM(1) |  |<----------------------------|
+ *                    |  |                             |
+ *                    |  |                             |
+ *                    |  |                             |
+ *                    '->|---------------------------->|--.
+ *                       |          ACK_TERM(1)        |  | Process ACK_TERM(1)
+ *  Process ACK_TERM(0)  |                             |<-' -DISCONNECT
+ *  -DISCONNECT       .--|                             |
+ *                    |  |                             |
+ *                    '->|                             |
+ *                       |                             |
+ *                       v                             v
+ * ```
+ *
+ * - [peer0] calls `zap_close()`. The endpoint state is changed to CLOSE and
+ *           SMSG-send `ZAP_UGNI_MSG_TERM(0)` to peer1. A timeout event is also
+ *           added to zq to force-terminate the connection when the timeout
+ *           occurs before `ZAP_UGNI_MSG_ACK_TERM(0)` is received.
+ * - [peer1] SMSG-recv `ZAP_UGNI_MSG_TERM(0)`. The ep state is changed to
+ *           PEER_CLOSE (to prevent future application send/read/write
+ *           requests). Since peer1 has never sent `ZAP_UGNI_MSG_TERM(1)`,
+ *           it send the message to peer0, expecting a
+ *           `ZAP_UGNI_MSG_ACK_TERM(1)` back (with timeout). Then,
+ *           `ZAP_UGNI_MSG_ACK_TERM(0)` is SMSG-sent to peer0 to acknowledge the
+ *           TERM peer1 received from peer0. No messages will be sent any
+ *           further from peer1.
+ * - [peer0] SMSG-recv `ZAP_UGNI_MSG_TERM(1)`. peer0 does not send another
+ *           `ZAP_UGNI_MSG_TERM(0)` because it knows that it has already sent its
+ *           TERM message. Then, peer0 GNI-sends `ZAP_UGNI_MSG_ACK_TERM(1)` to
+ *           peer1.
+ * - [peer0+peer1] SMSG-recv `ZAP_UGNI_MSG_ACK_TERM(0)` and
+ *                 `ZAP_UGNI_MSG_ACK_TERM(1)` respectively. The DISCONNECTED
+ *                 event is then delivered to the application.
+ *
+ * In the case of both peers terminate the connection simultaneously, the
+ * mechanism works the same way, except that both peers know that they have
+ * alread sent TERM and won't have to send it when they receive TERM from peer.
+ *
+ *
+ * ```
+ *                   .-------.                     .-------.
+ *                   | peer0 |                     | peer1 |
+ *                   '-------'                     '-------'
+ *                       |    TERM(0)        TERM(1)   |
+ *          Send TERM(0) |--------.              .-----| Send TERM(1)
+ *                       |         \            /      |
+ *                       |          '----------/------>|--.
+ *                       |<-------------------'        |  | Process TERM(0)
+ *                    .--|                             |  | -Send ACK_TERM(0)
+ *                    |  |                             |  |
+ *  Process TERM(1)   |  |          ACK_TERM(0)        |  |
+ *  -Send ACK_TERM(1) |  |<----------------------------|<-'
+ *                    |  |                             |
+ *                    |  |                             |
+ *                    |  |                             |
+ *                    '->|---------------------------->|--.
+ *                       |          ACK_TERM(1)        |  | Process ACK_TERM(1)
+ *  Process ACK_TERM(0)  |                             |<-' -DISCONNECT
+ *  -DISCONNECT       .--|                             |
+ *                    |  |                             |
+ *                    '->|                             |
+ *                       |                             |
+ *                       v                             v
+ * ```
+ *
+ * REMARK: GNI SMSG guarantees the order to process messages. The messages on
+ *         the wire may arrive out of order, but `GNI_SmsgGetNext()` guarantees
+ *         the order. For example, if `msgN+1` arrives but `msgN` has not
+ *         arrived yet, `GNI_SmsgGetNext()` will return `GNI_RC_NOT_DONE`. When
+ *         `msgN` arrives, the first call to `GNI_SmsgGetNext()` yields `msgN`,
+ *         and the next call yields `msgN+1`. In `zap_ugni`,
+ *         `z_ugni_handle_rcq_smsg()` keeps calling `GNI_SmsgGetNext()` and
+ *         process the message until it returns `GNI_RC_NOT_DONE`.
+ *
+ *
+ * NOTE on slow connection: `GNI_MemRegister()` with recv CQ for SMSG mbox took
+ * 0.6-0.7 sec. Fortunately this occurs only once in each io thread. Short-lived
+ * zap application like `ldms_ls` would see the effect of this slow connection
+ * the most.
+ *
+ */
+
 #define VERSION_FILE "/proc/version"
 
 #define ZUGNI_LIST_REMOVE(elm, link) do { \
@@ -80,6 +278,8 @@
 	(elm)->link.le_next = 0; \
 	(elm)->link.le_prev = 0; \
 } while(0)
+
+#define __container_of(ptr, type, field) (((void*)(ptr)) - offsetof(type, field))
 
 static char *format_4tuple(struct zap_ep *ep, char *str, size_t len)
 {
@@ -118,6 +318,11 @@ static char *format_4tuple(struct zap_ep *ep, char *str, size_t len)
 	zap_ugni_log("zap_ugni: " __VA_ARGS__); \
 } while(0);
 
+/* log with file, function name, and line number */
+#define LLOG(FMT, ...) do { \
+	zap_ugni_log("zap_ugni: %s():%d " FMT, __func__, __LINE__, ##__VA_ARGS__); \
+} while(0)
+
 #ifdef DEBUG
 #define DLOG_(uep, fmt, ...) do { \
 	if ((uep) && (uep)->ep.z && (uep)->ep.z->log_fn) { \
@@ -133,6 +338,65 @@ static char *format_4tuple(struct zap_ep *ep, char *str, size_t len)
 #else
 #define DLOG_(UEP, ...)
 #define DLOG(...)
+#endif
+
+#if 0
+#define CONN_DEBUG
+#endif
+#ifdef CONN_DEBUG
+#define CONN_LOG(FMT, ...) do { \
+	struct timespec __t; \
+	clock_gettime(CLOCK_REALTIME, &__t); \
+	LLOG( "[CONN_LOG] [%ld.%09ld] " FMT, __t.tv_sec, __t.tv_nsec, ## __VA_ARGS__); \
+} while (0)
+#define zap_get_ep(ep) do { \
+	LLOG("zap_get_ep(%p), ref_count: %d\n", ep, (ep)->ref_count); \
+	zap_get_ep(ep); \
+} while (0)
+
+#define zap_put_ep(ep) do { \
+	LLOG("zap_put_ep(%p), ref_count: %d\n", ep, (ep)->ref_count); \
+	zap_put_ep(ep); \
+} while (0)
+#else
+#define CONN_LOG(...)
+#endif
+
+/* For LOCK/UNLOCK GNI API calls.
+ *
+ * NOTE:
+ * - When using no GNI API lock, ldmsd aggregator run for a little while and got
+ *   SIGSEGV or SIGABRT, even with just 1 zap_io_thread. Seems like ldmsd
+ *   updtr thread (posting RDMA read) and zap_io_thread race to modify the
+ *   completion queue.
+ * - When using Z_GNI_API_THR_LOCK which use zap_io_thread->mutex to protect GNI
+ *   API calls, the case of 1 zap_io_thread works. However, when we have
+ *   multiple zap_io_threads (1 local CQ per thread), the aggregator hangs in
+ *   GNII_DlaDrain(). Since all CQs share the same nic handle, even though the
+ *   CQ is protected by our API lock, the resources in the nic handle would not
+ *   be protected by them (two io threads can take their own locks and
+ *   access/modify nic handle resources at the same time). And, it looks like
+ *   the nic handle also needs mutex protection.
+ * - When using Z_GNI_API_GLOBAL_LOCK, i.e. using our global `ugni_lock` to
+ *   protect all GNI calls, everything seems to be working fine with multiple io
+ *   threads. At the least, it apssed the following setup: 32 samps ->
+ *   agg11 + agg12 -> agg2. When the samplers were killed/restarted, agg2 still
+ *   get the updated data. When agg11+agg12 were killed/restarted, agg2 also get
+ *   the updated data.
+ */
+#define Z_GNI_API_GLOBAL_LOCK
+#if defined Z_GNI_API_THR_LOCK
+/* use io_thread lock */
+#define Z_GNI_API_LOCK(thr) pthread_mutex_lock(&(thr)->mutex)
+#define Z_GNI_API_UNLOCK(thr) pthread_mutex_unlock(&(thr)->mutex)
+#elif defined Z_GNI_API_GLOBAL_LOCK
+/* use global ugni_lock */
+#define Z_GNI_API_LOCK(thr) pthread_mutex_lock(&ugni_lock)
+#define Z_GNI_API_UNLOCK(thr) pthread_mutex_unlock(&ugni_lock)
+#else
+/* no GNI API lock */
+#define Z_GNI_API_LOCK(thr)
+#define Z_GNI_API_UNLOCK(thr)
 #endif
 
 int init_complete = 0;
@@ -179,26 +443,20 @@ static int zap_ugni_disconnect_timeout;
 static int zap_ugni_max_num_ep;
 static uint32_t *zap_ugni_ep_id;
 
-static int reg_count;
-static LIST_HEAD(mh_list, ugni_mh) mh_list;
 static pthread_mutex_t ugni_mh_lock;
+gni_mem_handle_t global_mh;
+int global_mh_initialized = 0;
+static gni_return_t ugni_get_mh(zap_t z, gni_mem_handle_t *mh);
 
-static ovis_scheduler_t io_sched;
-static pthread_t io_thread;
-static pthread_t cq_thread;
 static pthread_t error_thread;
 
-static void *io_thread_proc(void *arg);
-static void *cq_thread_proc(void *arg);
 static void *error_thread_proc(void *arg);
 
-static void ugni_sock_event(ovis_event_t ev);
-static void ugni_sock_read(ovis_event_t ev);
-static void ugni_sock_write(ovis_event_t ev);
-static void ugni_sock_connect(ovis_event_t ev);
+static zap_err_t z_ugni_smsg_send(struct z_ugni_ep *uep, zap_ugni_msg_t msg,
+			     const char *data, size_t data_len);
 
-static void stalled_timeout_cb(ovis_event_t ev);
-static zap_err_t __setup_connection(struct z_ugni_ep *uep);
+static int z_ugni_enable_sock(struct z_ugni_ep *uep);
+static int z_ugni_disable_sock(struct z_ugni_ep *uep);
 
 static int __get_nodeid(struct sockaddr *sa, socklen_t sa_len);
 static int __check_node_state(int node_id);
@@ -208,7 +466,6 @@ static void z_ugni_destroy(zap_ep_t ep);
 static LIST_HEAD(, z_ugni_ep) z_ugni_list = LIST_HEAD_INITIALIZER(0);
 static pthread_mutex_t z_ugni_list_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-static struct zap_ugni_post_desc_list stalled_desc_list = LIST_HEAD_INITIALIZER(0);
 #define ZAP_UGNI_STALLED_TIMEOUT	60 /* 1 minute */
 static int zap_ugni_stalled_timeout;
 
@@ -217,16 +474,10 @@ static LIST_HEAD(, z_ugni_ep) deferred_list = LIST_HEAD_INITIALIZER(0);
 static pthread_mutex_t deferred_list_mutex = PTHREAD_MUTEX_INITIALIZER;
 static uint32_t ugni_io_count = 0;
 #endif /* DEBUG */
-static uint32_t ugni_post_count;
-static uint32_t ugni_leaked_count;
-static uint32_t ugni_post_max;
-static uint32_t ugni_post_id;
-static gni_cq_handle_t ugni_old_cq; /* CQ replaced due to leaking descriptors */
+static uint32_t ugni_post_id __attribute__((unused));
 
 static pthread_mutex_t ugni_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t inst_id_cond = PTHREAD_COND_INITIALIZER;
-static pthread_mutex_t cq_full_lock = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t cq_full_cond = PTHREAD_COND_INITIALIZER;
 
 static int zap_ugni_dom_initialized = 0;
 static struct zap_ugni_dom {
@@ -236,12 +487,17 @@ static struct zap_ugni_dom {
 	uint32_t cookie;
 	uint32_t pe_addr;
 	uint32_t inst_id;
-	uint32_t cq_depth;
 	gni_job_limits_t limits;
 	gni_cdm_handle_t cdm;
 	gni_nic_handle_t nic;
-	gni_cq_handle_t cq;
 } _dom = {0};
+
+static void z_ugni_flush(struct z_ugni_ep *uep);
+static void z_ugni_zq_post(struct z_ugni_io_thread *thr, struct z_ugni_ev *uev);
+static void z_ugni_zq_rm(struct z_ugni_io_thread *thr, struct z_ugni_ev *uev);
+static void z_ugni_deliver_conn_error(struct z_ugni_ep *uep);
+static void z_ugni_ep_release(struct z_ugni_ep *uep);
+static void z_ugni_zq_try_post(struct z_ugni_ep *uep, uint64_t ts_msec, int type, int status);
 
 static void zap_ugni_default_log(const char *fmt, ...)
 {
@@ -272,6 +528,118 @@ const char *zap_ugni_type_str(zap_ugni_type_t type)
 	return __zap_ugni_type_str[type];
 }
 
+int gni_rc_to_errno(gni_return_t grc)
+{
+	switch (grc) {
+	case GNI_RC_SUCCESS: return 0;
+        case GNI_RC_NOT_DONE: return EAGAIN;
+        case GNI_RC_INVALID_PARAM: return EINVAL;
+        case GNI_RC_ERROR_RESOURCE: return ENOMEM;
+        case GNI_RC_TIMEOUT: return ETIMEDOUT;
+        case GNI_RC_PERMISSION_ERROR: return EACCES;
+        case GNI_RC_DESCRIPTOR_ERROR: return EBADF;
+        case GNI_RC_ALIGNMENT_ERROR: return EINVAL;
+        case GNI_RC_INVALID_STATE: return EINVAL;
+        case GNI_RC_NO_MATCH: return ENOENT;
+        case GNI_RC_SIZE_ERROR: return EINVAL;
+        case GNI_RC_TRANSACTION_ERROR: return EIO;
+        case GNI_RC_ILLEGAL_OP: return ENOTSUP;
+        case GNI_RC_ERROR_NOMEM: return ENOMEM;
+	}
+	return EINVAL;
+}
+
+static void z_ugni_ep_idx_init(struct z_ugni_io_thread *thr)
+{
+	struct z_ugni_ep_idx *ep_idx = thr->ep_idx;
+	int i;
+	for (i = 0; i < ZAP_UGNI_THREAD_EP_MAX; i++) {
+		ep_idx[i].idx = i;
+		ep_idx[i].next_idx = i+1;
+		ep_idx[i].uep = NULL;
+	}
+	ep_idx[ZAP_UGNI_THREAD_EP_MAX-1].next_idx = 0;
+	thr->ep_idx_head = &ep_idx[0];
+	thr->ep_idx_tail = &ep_idx[ZAP_UGNI_THREAD_EP_MAX-1];
+}
+
+/* assign a free ep_idx to uep. Must hold thr->zap_io_thread.mutex */
+static int z_ugni_ep_idx_assign(struct z_ugni_ep *uep)
+{
+	struct z_ugni_io_thread *thr = (void*)uep->ep.thread;
+	struct z_ugni_ep_idx *ep_idx = thr->ep_idx;
+	int idx;
+	struct z_ugni_ep_idx *curr, *next;
+	if (uep->ep_idx) {
+		/* should not happen */
+		LOG("%s() warning: uep->ep_idx is not NULL\n", __func__);
+		assert(0 == "uep->ep_idx is NOT NULL");
+		return 0;
+	}
+	idx = thr->ep_idx_head->next_idx;
+	if (!idx)
+		return ENOMEM;
+	curr = &ep_idx[idx];
+	next = &ep_idx[curr->next_idx];
+
+	/* remove curr from the free list */
+	thr->ep_idx_head->next_idx = next->idx;
+	curr->next_idx = 0;
+
+	if (next->idx == 0) { /* also reset tail if list depleted */
+		thr->ep_idx_tail = thr->ep_idx_head;
+	}
+
+	/* assign curr to uep */
+	zap_get_ep(&uep->ep);
+	curr->uep = uep;
+	uep->ep_idx = curr;
+
+	CONN_LOG("%p got ep_idx %d (%p)\n", uep, curr->idx, curr);
+
+	return 0;
+}
+
+/* release the ep_idx assigned to the uep, put it back into the free list.
+ * Caller must hold thr->zap_io_thread.mutex */
+static void z_ugni_ep_idx_release(struct z_ugni_ep *uep)
+{
+	struct z_ugni_io_thread *thr = (void*)uep->ep.thread;
+	if (!uep->ep_idx) {
+		LOG("%s(): warning: uep->ep_idx is NULL\n", __func__);
+		assert(0 == "uep->ep_idx is NULL");
+		return;
+	}
+
+	/* insert tail */
+	thr->ep_idx_tail->next_idx = uep->ep_idx->idx;
+	uep->ep_idx->next_idx = 0;
+	/* update tail */
+	thr->ep_idx_tail = uep->ep_idx;
+
+	/* release uep/ep_idx */
+	uep->ep_idx->uep = NULL;
+	uep->ep_idx = NULL;
+
+	zap_put_ep(&uep->ep);
+}
+
+/* uep->ep.lock must be held */
+static int z_ugni_get_post_credit(struct z_ugni_ep *uep)
+{
+	if (STAILQ_EMPTY(&uep->pending_wrq) && uep->post_credit) {
+		uep->post_credit--;
+		return 1;
+	}
+	return 0;
+}
+
+/* uep->ep.lock must be held */
+static void z_ugni_put_post_credit(struct z_ugni_ep *uep)
+{
+	uep->post_credit++;
+}
+
 /*
  * Use KEEP-ALIVE packets to shut down a connection if the remote peer fails
  * to respond for 10 minutes
@@ -280,39 +648,10 @@ const char *zap_ugni_type_str(zap_ugni_type_t type)
 #define ZAP_SOCK_KEEPIDLE	10	/* Start probing after 10s of inactivity */
 #define ZAP_SOCK_KEEPINTVL	2	/* Probe couple seconds after idle */
 
-static int __set_keep_alive(int sock)
+static int __set_nonblock(int fd)
 {
-	int rc;
-	int optval;
-
-	optval = ZAP_SOCK_KEEPCNT;
-	rc = setsockopt(sock, SOL_TCP, TCP_KEEPCNT, &optval, sizeof(int));
-
-	optval = ZAP_SOCK_KEEPIDLE;
-	rc = setsockopt(sock, SOL_TCP, TCP_KEEPIDLE, &optval, sizeof(int));
-
-	optval = ZAP_SOCK_KEEPINTVL;
-	rc = setsockopt(sock, SOL_TCP, TCP_KEEPINTVL, &optval, sizeof(int));
-
-	optval = 1;
-	rc = setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &optval, sizeof(int));
-	return rc;
-}
-
-static int __set_sockbuf_sz(int sockfd)
-{
-	int rc;
-	size_t optval = UGNI_SOCKBUF_SZ;
-	rc = setsockopt(sockfd, SOL_SOCKET, SO_SNDBUF, &optval, sizeof(optval));
-	if (rc)
-		return rc;
-	rc = setsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, &optval, sizeof(optval));
-	return rc;
-}
-static int __sock_nonblock(int fd)
-{
-	int rc;
 	int fl;
+	int rc;
 	fl = fcntl(fd, F_GETFL);
 	if (fl == -1)
 		return errno;
@@ -322,24 +661,16 @@ static int __sock_nonblock(int fd)
 	return 0;
 }
 
-/* caller must have uep->ep.lock held */
-static int __enable_epoll_out(struct z_ugni_ep *uep)
+static int __set_sock_opts(int fd)
 {
 	int rc;
-	if (uep->io_ev.param.epoll_events & EPOLLOUT)
-		return 0; /* already enabled */
-	rc = ovis_scheduler_epoll_event_mod(io_sched, &uep->io_ev, EPOLLIN|EPOLLOUT);
-	return rc;
-}
 
-/* caller must have uep->ep.lock held */
-static int __disable_epoll_out(struct z_ugni_ep *uep)
-{
-	int rc;
-	if ((uep->io_ev.param.epoll_events & EPOLLOUT) == 0)
-		return 0; /* already disabled */
-	rc = ovis_scheduler_epoll_event_mod(io_sched, &uep->io_ev, EPOLLIN);
-	return rc;
+	/* nonblock */
+	rc = __set_nonblock(fd);
+	if (rc)
+		return rc;
+
+	return 0;
 }
 
 uint32_t zap_ugni_get_ep_gn(int id)
@@ -352,6 +683,44 @@ int zap_ugni_is_ep_gn_matched(int id, uint32_t gn)
 	if (zap_ugni_ep_id[id] == gn)
 		return 1;
 	return 0;
+}
+
+/* setting up mailboxes for GNI Smsg */
+int z_ugni_io_thread_mbox_setup(struct z_ugni_io_thread *thr)
+{
+	gni_return_t grc;
+	uint32_t sz;
+	struct gni_smsg_attr attr;
+
+	attr.msg_type = GNI_SMSG_TYPE_MBOX_AUTO_RETRANSMIT;
+	attr.mbox_maxcredit = ZAP_UGNI_RCQ_DEPTH;
+	attr.msg_maxsize = ZAP_UGNI_MSG_SZ_MAX;
+
+	/* size of mbox/ep */
+        grc = GNI_SmsgBufferSizeNeeded(&attr, &sz);
+	if (grc) {
+		LLOG("GNI_SmsgBufferSizeNeeded() error: %d\n", grc);
+		errno = gni_rc_to_errno(grc);
+		goto err_0;
+	}
+	thr->mbox_sz = ((sz - 1)|0x3f) + 1; /* align to cache line: 64 bytes */
+	/* allocate mailboxes serving endpoints in this thread */
+	sz = ZAP_UGNI_THREAD_EP_MAX * thr->mbox_sz;
+	thr->mbox = malloc(sz);
+	if (!thr->mbox) {
+		LLOG("malloc() error: %d\n", errno);
+		goto err_0;
+	}
+
+	return 0;
+
+ err_0:
+	return errno;
+}
+
+/* releasing resources for GNI SMSG mailbox */
+void z_ugni_mbox_release(struct z_ugni_ep *uep)
+{
 }
 
 /*
@@ -383,95 +752,143 @@ int zap_ugni_get_ep_id()
 }
 
 /* Must be called with the endpoint lock held */
-static struct zap_ugni_post_desc *__alloc_post_desc(struct z_ugni_ep *uep)
+static struct z_ugni_wr *z_ugni_alloc_send_wr(struct z_ugni_ep *uep,
+					 zap_ugni_msg_t msg,
+					 const char *data, size_t data_len)
 {
-	struct zap_ugni_post_desc *d = calloc(1, sizeof(*d));
-	if (!d)
+	int hdr_sz;
+
+	switch (ntohs(msg->hdr.msg_type)) {
+	case ZAP_UGNI_MSG_CONNECT:
+		hdr_sz = sizeof(msg->connect);
+		msg->connect.data_len = htonl(data_len);
+		break;
+	case ZAP_UGNI_MSG_RENDEZVOUS:
+		hdr_sz = sizeof(msg->rendezvous);
+		break;
+	case ZAP_UGNI_MSG_ACCEPTED:
+		hdr_sz = sizeof(msg->accepted);
+		msg->accepted.data_len = htonl(data_len);
+		break;
+	case ZAP_UGNI_MSG_ACK_ACCEPTED: /* use `regular` format */
+	case ZAP_UGNI_MSG_REJECTED: /* use `regular` format */
+	case ZAP_UGNI_MSG_TERM: /* use `regular` format */
+	case ZAP_UGNI_MSG_ACK_TERM: /* use `regular` format */
+	case ZAP_UGNI_MSG_REGULAR:
+		hdr_sz = sizeof(msg->regular);
+		msg->regular.data_len = htonl(data_len);
+		break;
+	default:
+		LLOG("WARNING: Invalid send message.\n");
+		errno = EINVAL;
 		return NULL;
+	}
+	msg->hdr.msg_len = htonl(hdr_sz + data_len);
+
+	struct z_ugni_wr *wr = malloc(sizeof(*wr) +
+				      sizeof(*wr->send_wr) +
+				      hdr_sz + data_len);
+	if (!wr)
+		return NULL;
+	wr->type = Z_UGNI_WR_SMSG;
+	wr->state = Z_UGNI_WR_INIT;
+	wr->send_wr->msg_len = hdr_sz + data_len;
+	memcpy(wr->send_wr->msg, msg, hdr_sz);
+	if (data && data_len)
+		memcpy(((void*)wr->send_wr->msg) + hdr_sz, data, data_len);
+	wr->send_wr->msg_id = (uep->ep_idx->idx << 16)|(uep->next_msg_seq++);
+	return wr;
+}
+
+static void z_ugni_free_send_wr(struct z_ugni_wr *wr)
+{
+	free(wr);
+}
+
+/* Must be called with the endpoint lock held */
+static struct z_ugni_wr *z_ugni_alloc_post_desc(struct z_ugni_ep *uep)
+{
+	struct zap_ugni_post_desc *d;
+	struct z_ugni_wr *wr = calloc(1, sizeof(*wr) + sizeof(*wr->post_desc));
+	if (!wr)
+		return NULL;
+	wr->type = Z_UGNI_WR_RDMA;
+	wr->state = Z_UGNI_WR_INIT;
+	d = wr->post_desc;
 	d->uep = uep;
-	zap_get_ep(&uep->ep);
+	//zap_get_ep(&uep->ep);
 #ifdef DEBUG
 	d->ep_gn = zap_ugni_get_ep_gn(uep->ep_id);
 #endif /* DEBUG */
 	format_4tuple(&uep->ep, d->ep_name, ZAP_UGNI_EP_NAME_SZ);
-	LIST_INSERT_HEAD(&uep->post_desc_list, d, ep_link);
-	return d;
+	//LIST_INSERT_HEAD(&uep->post_desc_list, d, ep_link);
+	return wr;
 }
 
-/* Must be called with the endpoint lock held */
-static void __free_post_desc(struct zap_ugni_post_desc *d)
+static void z_ugni_free_post_desc(struct z_ugni_wr *wr)
 {
-	struct z_ugni_ep *uep = d->uep;
-	ZUGNI_LIST_REMOVE(d, ep_link);
-	zap_put_ep(&uep->ep);
-	free(d);
+	assert(wr->type == Z_UGNI_WR_RDMA);
+	free(wr);
 }
 
-gni_return_t ugni_get_mh(struct z_ugni_ep *uep, void *addr,
-				size_t size, gni_mem_handle_t *mh)
+static gni_return_t ugni_get_mh(zap_t z, gni_mem_handle_t *mh)
 {
 	gni_return_t grc = GNI_RC_SUCCESS;
-	struct ugni_mh *umh;
-	int need_mh = 0;
-	unsigned long start;
-	unsigned long end;
+	zap_mem_info_t mmi;
+
+	if (__builtin_expect(global_mh_initialized, 1)) {
+		*mh = global_mh;
+		return GNI_RC_SUCCESS;
+	}
 
 	pthread_mutex_lock(&ugni_mh_lock);
-	umh = LIST_FIRST(&mh_list);
-	if (!umh) {
-		zap_mem_info_t mmi;
-		mmi = uep->ep.z->mem_info_fn();
-		start = (unsigned long)mmi->start;
-		end = start + mmi->len;
-		need_mh = 1;
-	}
-	if (!need_mh)
+	if (global_mh_initialized) {
+		/* the other thread won the race */
 		goto out;
-
-	umh = malloc(sizeof *umh);
-	umh->start = start;
-	umh->end = end;
-	umh->ref_count = 0;
-
-	grc = GNI_MemRegister(_dom.nic, umh->start, end - start,
+	}
+	mmi = z->mem_info_fn();
+	grc = GNI_MemRegister(_dom.nic, (uint64_t)mmi->start, mmi->len,
 			      NULL,
 			      GNI_MEM_READWRITE | GNI_MEM_RELAXED_PI_ORDERING,
-			      -1, &umh->mh);
-	if (grc != GNI_RC_SUCCESS) {
-		free(umh);
-		goto out;
-	}
-	LIST_INSERT_HEAD(&mh_list, umh, link);
-	reg_count++;
-out:
-	*mh = umh->mh;
-	umh->ref_count++;
+			      -1, &global_mh);
+	if (grc != GNI_RC_SUCCESS)
+		goto err;
+	global_mh_initialized = 1;
+ out:
+	*mh = global_mh;
+ err:
 	pthread_mutex_unlock(&ugni_mh_lock);
 	return grc;
 }
 
 /* The caller must hold the endpoint lock */
-static void __shutdown_on_error(struct z_ugni_ep *uep)
+static void z_ugni_ep_error(struct z_ugni_ep *uep)
 {
-	DLOG_(uep, "%s\n", __func__);
-	if (uep->ep.state == ZAP_EP_CONNECTED)
-		uep->ep.state = ZAP_EP_CLOSE;
-	shutdown(uep->sock, SHUT_RDWR);
+	if (uep->sock >= 0)
+		shutdown(uep->sock, SHUT_RDWR);
+	z_ugni_ep_release(uep);
+	switch (uep->ep.state) {
+	case ZAP_EP_CONNECTED:
+		z_ugni_zq_try_post(uep, 0, ZAP_EVENT_DISCONNECTED, ZAP_ERR_ENDPOINT);
+	case ZAP_EP_CLOSE:
+	case ZAP_EP_PEER_CLOSE:
+		z_ugni_zq_try_post(uep, 0, uep->zap_connected?ZAP_EVENT_DISCONNECTED:ZAP_EVENT_CONNECT_ERROR, ZAP_ERR_ENDPOINT);
+		break;
+	case ZAP_EP_CONNECTING:
+		/* need to remove the connect timeout event first */
+		z_ugni_zq_rm((void*)uep->ep.thread, &uep->uev);
+		/* let through */
+	case ZAP_EP_ACCEPTING:
+		z_ugni_zq_try_post(uep, 0, ZAP_EVENT_CONNECT_ERROR, ZAP_ERR_ENDPOINT);
+		break;
+	default:
+		break;
+	}
+	uep->ep.state = ZAP_EP_ERROR;
 }
 
 void z_ugni_cleanup(void)
 {
-	if (io_sched)
-		ovis_scheduler_term(io_sched);
-	if (io_thread) {
-		pthread_cancel(io_thread);
-		pthread_join(io_thread, NULL);
-	}
-	if (io_sched) {
-		ovis_scheduler_free(io_sched);
-		io_sched = NULL;
-	}
-
 	if (node_state_sched)
 		ovis_scheduler_term(node_state_sched);
 
@@ -492,18 +909,80 @@ void z_ugni_cleanup(void)
 		free(zap_ugni_ep_id);
 }
 
-static void __ep_release(struct z_ugni_ep *uep)
+static void z_ugni_ep_release(struct z_ugni_ep *uep)
 {
 	gni_return_t grc;
 	if (uep->gni_ep) {
+#if 0
 		grc = GNI_EpUnbind(uep->gni_ep);
 		if (grc)
-			LOG_(uep, "GNI_EpUnbind() error: %s\n", gni_ret_str(grc));
+			LLOG("GNI_EpUnbind() error: %s\n", gni_ret_str(grc));
+#endif
+		Z_GNI_API_LOCK(uep->ep.thread);
 		grc = GNI_EpDestroy(uep->gni_ep);
+		Z_GNI_API_UNLOCK(uep->ep.thread);
 		if (grc != GNI_RC_SUCCESS)
-			LOG_(uep, "GNI_EpDestroy() error: %s\n", gni_ret_str(grc));
+			LLOG("GNI_EpDestroy() error: %s\n", gni_ret_str(grc));
 		uep->gni_ep = NULL;
 	}
+}
+
+uint64_t __ts_msec(uint64_t delay_msec)
+{
+	struct timespec ts;
+	uint64_t ts_msec;
+	clock_gettime(CLOCK_REALTIME, &ts);
+	ts_msec = ts.tv_sec*1000 + ts.tv_nsec/1000000 + delay_msec;
+	return ts_msec;
+}
+
+/*
+ * Telling peer that we're terminating the connection. When peer ACK_TERM, we
+ * can safely release the mbox (peer won't send anything after ACK_TERM).
+ *
+ * If peer won't ACK within TIMEOUT ... the connection will be force-terminated.
+ */
+static zap_err_t z_ugni_send_term(struct z_ugni_ep *uep)
+{
+	struct zap_ugni_msg msg = {.hdr.msg_type = htons(ZAP_UGNI_MSG_TERM)};
+	uint64_t ts_msec;
+	zap_err_t zerr = ZAP_ERR_OK;
+	if (uep->ugni_term_sent) {
+		goto out;
+	}
+	uep->ugni_term_sent = 1;
+	zerr = z_ugni_smsg_send(uep, &msg, NULL, 0);
+	if (zerr == ZAP_ERR_OK) {
+		/* timeout */
+		ts_msec = __ts_msec(zap_ugni_disconnect_timeout*1000);
+		if (uep->ep.state == ZAP_EP_CONNECTED) {
+			z_ugni_zq_try_post(uep, ts_msec, ZAP_EVENT_DISCONNECTED, 0);
+		} else {
+			z_ugni_zq_try_post(uep, ts_msec, ZAP_EVENT_CONNECT_ERROR,
+					ZAP_ERR_ENDPOINT);
+		}
+	} else {
+		/* could not send, immediate disconnect/conn_error */
+		z_ugni_ep_error(uep);
+	}
+ out:
+	return zerr;
+}
+
+static zap_err_t z_ugni_send_ack_term(struct z_ugni_ep *uep)
+{
+	struct zap_ugni_msg msg = {.hdr.msg_type = htons(ZAP_UGNI_MSG_ACK_TERM)};
+	zap_err_t zerr;
+	if (uep->ugni_ack_term_sent) {
+		LLOG("WARNING: Multiple sends of ACK_TERM message.\n");
+		goto out;
+	}
+	zerr = z_ugni_smsg_send(uep, &msg, NULL, 0);
+	if (zerr != ZAP_ERR_OK)
+		return zerr;
+	uep->ugni_ack_term_sent = 1;
+ out:
+	return ZAP_ERR_OK;
 }
 
 static zap_err_t z_ugni_close(zap_ep_t ep)
@@ -515,14 +994,26 @@ static zap_err_t z_ugni_close(zap_ep_t ep)
 	pthread_mutex_lock(&uep->ep.lock);
 	switch (uep->ep.state) {
 	case ZAP_EP_LISTENING:
+		z_ugni_disable_sock(uep);
+		uep->ep.state = ZAP_EP_CLOSE;
+		break;
 	case ZAP_EP_CONNECTED:
-	case ZAP_EP_PEER_CLOSE:
-	case ZAP_EP_ERROR:
+		z_ugni_send_term(uep);
+		uep->ep.state = ZAP_EP_CLOSE;
+		break;
 	case ZAP_EP_CONNECTING:
 	case ZAP_EP_ACCEPTING:
-		shutdown(uep->sock, SHUT_RDWR);
+	case ZAP_EP_PEER_CLOSE:
+		if (uep->ugni_ep_bound) {
+			z_ugni_send_term(uep);
+		} else {
+			z_ugni_disable_sock(uep);
+		}
+		uep->ep.state = ZAP_EP_CLOSE;
 		break;
+	case ZAP_EP_ERROR:
 	case ZAP_EP_CLOSE:
+		/* don't change state */
 		break;
 	default:
 		ZAP_ASSERT(0, ep, "%s: Unexpected state '%s'\n",
@@ -559,7 +1050,7 @@ static zap_err_t z_ugni_connect(zap_ep_t ep,
 	struct z_ugni_ep *uep = (void*)ep;
 	zerr = zap_ep_change_state(&uep->ep, ZAP_EP_INIT, ZAP_EP_CONNECTING);
 	if (zerr)
-		goto out;
+		goto err_0;
 
 	if (_node_state.check_state) {
 		if (uep->node_id == -1)
@@ -568,7 +1059,7 @@ static zap_err_t z_ugni_connect(zap_ep_t ep,
 			if (__check_node_state(uep->node_id)) {
 				DLOG("Node %d is in a bad state\n", uep->node_id);
 				zerr = ZAP_ERR_CONNECT;
-				goto out;
+				goto err_0;
 			}
 		}
 	}
@@ -576,35 +1067,21 @@ static zap_err_t z_ugni_connect(zap_ep_t ep,
 	uep->sock = socket(sa->sa_family, SOCK_STREAM, 0);
 	if (uep->sock == -1) {
 		zerr = ZAP_ERR_RESOURCE;
-		goto out;
+		goto err_0;
 	}
 
-	if (__set_sockbuf_sz(uep->sock)) {
+	if (__set_sock_opts(uep->sock)) {
 		zerr = ZAP_ERR_TRANSPORT;
-		LOG_(uep, "Error %d: setting the sockbuf sz in %s.\n",
-				errno, __func__);
-		goto out;
+		goto err_0;
 	}
 
-	if (__set_keep_alive(uep->sock)) {
-		zerr = ZAP_ERR_TRANSPORT;
-		LOG_(uep, "Error %d: enabling keep-alive in %s.\n",
-				errno, __func__);
-		goto out;
-	}
-
-	rc = __sock_nonblock(uep->sock);
-	if (rc) {
-		zerr = ZAP_ERR_RESOURCE;
-		goto out;
-	}
 	if (data_len) {
 		uep->conn_data = malloc(data_len);
 		if (uep->conn_data) {
 			memcpy(uep->conn_data, data, data_len);
 		} else {
 			zerr = ZAP_ERR_RESOURCE;
-			goto out;
+			goto err_0;
 		}
 		uep->conn_data_len = data_len;
 	}
@@ -612,63 +1089,32 @@ static zap_err_t z_ugni_connect(zap_ep_t ep,
 	rc = connect(uep->sock, sa, sa_len);
 	if (rc && errno != EINPROGRESS) {
 		zerr = ZAP_ERR_CONNECT;
-	} else {
-		zerr = ZAP_ERR_OK;
+		goto err_1;
 	}
 
-	zerr = __setup_connection(uep);
-	if (!zerr)
-		return ZAP_ERR_OK;
- out:
+	zerr = zap_io_thread_ep_assign(&uep->ep);
+	if (zerr)
+		goto err_1;
+	rc = z_ugni_enable_sock(uep);
+	if (rc) {
+		zerr = zap_errno2zerr(errno);
+		goto err_2;
+	}
+
+	return 0;
+ err_2:
+	zap_io_thread_ep_release(&uep->ep);
+ err_1:
+	free(uep->conn_data);
+	uep->conn_data = NULL;
+	uep->conn_data_len = 0;
+	zap_put_ep(&uep->ep);
+ err_0:
 	if (uep->sock >= 0) {
 		close(uep->sock);
 		uep->sock = -1;
 	}
 	return zerr;
-}
-
-static void ugni_sock_write(ovis_event_t ev)
-{
-	struct z_ugni_ep *uep = ev->param.ctxt;
-
-	ssize_t wsz;
-	struct zap_ugni_send_wr *wr;
-
-	pthread_mutex_lock(&uep->ep.lock);
- next:
-	wr = STAILQ_FIRST(&uep->sq);
-	if (!wr) {
-		/* sq empty, disable epoll out */
-		__disable_epoll_out(uep);
-		goto out;
-	}
-
-	wsz = write(uep->sock, wr->data + wr->off, wr->alen);
-	if (wsz < 0) {
-		if (errno == EAGAIN || errno == EWOULDBLOCK)
-			goto out;
-		/* bad error */
-		goto err;
-	}
-
-	if (wsz < wr->alen) {
-		wr->alen -= wsz;
-		wr->off += wsz;
-		goto out;
-	}
-
-	/* reaching here means wr->alen == 0 */
-	STAILQ_REMOVE_HEAD(&uep->sq, link);
-	free(wr);
-	goto next;
-
- out:
-	pthread_mutex_unlock(&uep->ep.lock);
-	return;
-
- err:
-	__shutdown_on_error(uep);
-	pthread_mutex_unlock(&uep->ep.lock);
 }
 
 /**
@@ -678,7 +1124,7 @@ static void process_uep_msg_unknown(struct z_ugni_ep *uep)
 {
 	LOG_(uep, "zap_ugni: Unknown zap message.\n");
 	pthread_mutex_lock(&uep->ep.lock);
-	__shutdown_on_error(uep);
+	z_ugni_ep_error(uep);
 	pthread_mutex_unlock(&uep->ep.lock);
 }
 
@@ -689,10 +1135,11 @@ static void process_uep_msg_regular(struct z_ugni_ep *uep)
 {
 	struct zap_ugni_msg_regular *msg;
 	struct zap_event ev = {
+			.ep = &uep->ep,
 			.type = ZAP_EVENT_RECV_COMPLETE,
 	};
 
-	msg = (void*)uep->rbuff->data;
+	msg = (void*)uep->rmsg;
 	ev.data = (void*)msg->data;
 	ev.data_len = ntohl(msg->data_len);
 	uep->ep.cb(&uep->ep, &ev);
@@ -706,14 +1153,14 @@ static void process_uep_msg_rendezvous(struct z_ugni_ep *uep)
 {
 	struct zap_ugni_msg_rendezvous *msg;
 
-	msg = (void*)uep->rbuff->data;
+	msg = (void*)uep->rmsg;
 
 	msg->hdr.msg_len = ntohl(msg->hdr.msg_len);
 	msg->hdr.reserved = 0;
 	msg->hdr.msg_type = ntohs(msg->hdr.msg_type);
-	msg->addr = be64toh(msg->addr);
+	msg->map_addr = be64toh(msg->map_addr);
 	msg->acc = ntohl(msg->acc);
-	msg->data_len = ntohl(msg->data_len);
+	msg->map_len = ntohl(msg->map_len);
 	msg->gni_mh.qword1 = be64toh(msg->gni_mh.qword1);
 	msg->gni_mh.qword2 = be64toh(msg->gni_mh.qword2);
 
@@ -734,8 +1181,8 @@ static void process_uep_msg_rendezvous(struct z_ugni_ep *uep)
 	map->map.ep = (void*)uep;
 	map->map.acc = msg->acc;
 	map->map.type = ZAP_MAP_REMOTE;
-	map->map.addr = (void*)msg->addr;
-	map->map.len = msg->data_len;
+	map->map.addr = (void*)msg->map_addr;
+	map->map.len = msg->map_len;
 	map->gni_mh = msg->gni_mh;
 
 	zap_get_ep(&uep->ep);
@@ -757,9 +1204,75 @@ err0:
 	return;
 }
 
-static zap_err_t
-__ugni_send(struct z_ugni_ep *uep, enum zap_ugni_msg_type type,
-						char *buf, size_t len);
+/* uep->ep.lock must be held.
+ * msg is in NETWORK byte order.
+ * The data length and the message lenght are conveniently set by this function.
+ */
+static zap_err_t z_ugni_smsg_send(struct z_ugni_ep *uep, zap_ugni_msg_t msg,
+			     const char *data, size_t data_len)
+{
+	gni_return_t grc;
+	struct z_ugni_wr *wr;
+
+	/* need to keep send buf until send completion */
+	wr = z_ugni_alloc_send_wr(uep, msg, data, data_len);
+	if (!wr)
+		goto err;
+
+	if (!z_ugni_get_post_credit(uep))
+		goto pending;
+
+	Z_GNI_API_LOCK(uep->ep.thread);
+	grc = GNI_SmsgSend(uep->gni_ep, wr->send_wr->msg, wr->send_wr->msg_len,
+			NULL, 0, wr->send_wr->msg_id);
+	Z_GNI_API_UNLOCK(uep->ep.thread);
+	switch (grc) {
+	case GNI_RC_SUCCESS:
+		wr->state = Z_UGNI_WR_SUBMITTED;
+		STAILQ_INSERT_TAIL(&uep->submitted_wrq, wr, entry);
+		CONN_LOG("%p smsg sent %s\n", uep, zap_ugni_msg_type_str(ntohs(msg->hdr.msg_type)));
+		goto out;
+	case GNI_RC_NOT_DONE: /* not enough smsg credit */
+		z_ugni_put_post_credit(uep);
+		goto pending;
+	default:
+		goto err;
+	}
+
+ pending:
+	wr->state = Z_UGNI_WR_PENDING;
+	STAILQ_INSERT_TAIL(&uep->pending_wrq, wr, entry);
+	CONN_LOG("%p pending smsg %s\n", uep, zap_ugni_msg_type_str(ntohs(msg->hdr.msg_type)));
+ out:
+	return ZAP_ERR_OK;
+ err:
+	return ZAP_ERR_ENDPOINT;
+}
+
+/* uep->ep.lock is held */
+static zap_err_t z_ugni_send_connect(struct z_ugni_ep *uep)
+{
+	struct zap_ugni_msg msg;
+	zap_err_t zerr;
+	uint64_t ts_msec;
+
+	msg.hdr.msg_type = htons(ZAP_UGNI_MSG_CONNECT);
+	msg.connect.ep_desc.inst_id = htonl(_dom.inst_id);
+	msg.connect.ep_desc.pe_addr = htonl(_dom.pe_addr);
+	msg.connect.ep_desc.smsg_attr = uep->local_smsg_attr;
+	memcpy(msg.connect.sig, ZAP_UGNI_SIG, sizeof(ZAP_UGNI_SIG));
+	ZAP_VERSION_SET(msg.connect.ver);
+
+	zerr = z_ugni_smsg_send(uep, &msg, uep->conn_data, uep->conn_data_len);
+	if (zerr)
+		return zerr;
+	/* Post the connect timeout event. The event is removed when the
+	 * connection is established */
+	ts_msec = __ts_msec(zap_ugni_disconnect_timeout*1000);
+	z_ugni_zq_try_post(uep, ts_msec, ZAP_EVENT_CONNECT_ERROR, ZAP_ERR_ENDPOINT);
+	return ZAP_ERR_OK;
+}
+
 static void process_uep_msg_accepted(struct z_ugni_ep *uep)
 {
 	ZAP_ASSERT(uep->ep.state == ZAP_EP_CONNECTING, &uep->ep,
@@ -767,19 +1280,18 @@ static void process_uep_msg_accepted(struct z_ugni_ep *uep)
 			"Expected state 'ZAP_EP_CONNECTING'\n",
 			__func__, __zap_ep_state_str(uep->ep.state));
 	struct zap_ugni_msg_accepted *msg;
-	zap_err_t zerr;
 
-	msg = (void*)uep->rbuff->data;
+	msg = (void*)uep->rmsg;
 
 	msg->hdr.msg_len = ntohl(msg->hdr.msg_len);
 	msg->hdr.reserved = 0;
 	msg->hdr.msg_type = ntohs(msg->hdr.msg_type);
 	msg->data_len = ntohl(msg->data_len);
-	msg->inst_id = ntohl(msg->inst_id);
-	msg->pe_addr = ntohl(msg->pe_addr);
+	msg->ep_desc.inst_id = ntohl(msg->ep_desc.inst_id);
+	msg->ep_desc.pe_addr = ntohl(msg->ep_desc.pe_addr);
 
 	DLOG_(uep, "ACCEPTED received: pe_addr: %#x, inst_id: %#x\n",
-			msg->pe_addr, msg->inst_id);
+			msg->ep_desc.pe_addr, msg->ep_desc.inst_id);
 
 #ifdef ZAP_UGNI_DEBUG
 	char *is_exit = getenv("ZAP_UGNI_CONN_EST_BEFORE_ACK_N_BINDING_TEST");
@@ -787,31 +1299,20 @@ static void process_uep_msg_accepted(struct z_ugni_ep *uep)
 		exit(0);
 #endif /* ZAP_UGNI_DEBUG */
 
-	pthread_mutex_lock(&uep->ep.lock);
-	zerr = __ugni_send(uep, ZAP_UGNI_MSG_ACK_ACCEPTED, NULL, 0);
-	pthread_mutex_unlock(&uep->ep.lock);
-	if (zerr)
-		goto err;
-
-	gni_return_t grc;
-	grc = GNI_EpBind(uep->gni_ep, msg->pe_addr, msg->inst_id);
-	if (grc) {
-		LOG_(uep, "GNI_EpBind() error: %s\n", gni_ret_str(grc));
-		goto err;
-	}
-
 #ifdef ZAP_UGNI_DEBUG
 	is_exit = getenv("ZAP_UGNI_CONN_EST_BEFORE_ACK_AFTER_BINDING_TEST");
 	if (is_exit)
 		exit(0);
 #endif /* ZAP_UGNI_DEBUG */
 
-	uep->ugni_ep_bound = 1;
 	struct zap_event ev = {
+		.ep = &uep->ep,
 		.type = ZAP_EVENT_CONNECTED,
 		.data_len = msg->data_len,
 		.data = (msg->data_len ? (void*)msg->data : NULL)
 	};
+	/* need to remove the connect timeout event first */
+	z_ugni_zq_rm((void*)uep->ep.thread, &uep->uev);
 	if (!zap_ep_change_state(&uep->ep, ZAP_EP_CONNECTING, ZAP_EP_CONNECTED)) {
 		uep->ep.cb((void*)uep, &ev);
 	} else {
@@ -822,7 +1323,6 @@ static void process_uep_msg_accepted(struct z_ugni_ep *uep)
 	return;
 
 err:
-	shutdown(uep->sock, SHUT_RDWR);
 	return;
 }
 
@@ -830,7 +1330,7 @@ static void process_uep_msg_connect(struct z_ugni_ep *uep)
 {
 	struct zap_ugni_msg_connect *msg;
 
-	msg = (void*)uep->rbuff->data;
+	msg = (void*)uep->rmsg;
 
 	pthread_mutex_lock(&uep->ep.lock);
 
@@ -854,31 +1354,37 @@ static void process_uep_msg_connect(struct z_ugni_ep *uep)
 	msg->hdr.reserved = 0;
 	msg->hdr.msg_type = ntohs(msg->hdr.msg_type);
 	msg->data_len = ntohl(msg->data_len);
-	msg->inst_id = ntohl(msg->inst_id);
-	msg->pe_addr = ntohl(msg->pe_addr);
+	msg->ep_desc.inst_id = ntohl(msg->ep_desc.inst_id);
+	msg->ep_desc.pe_addr = ntohl(msg->ep_desc.pe_addr);
+	msg->ep_desc.remote_event = ntohl(msg->ep_desc.remote_event);
 
 	DLOG_(uep, "CONN_REQ received: pe_addr: %#x, inst_id: %#x\n",
-			msg->pe_addr, msg->inst_id);
-	gni_return_t grc;
-	grc = GNI_EpBind(uep->gni_ep, msg->pe_addr, msg->inst_id);
-	if (grc) {
-		LOG_(uep, "GNI_EpBind() error: %s\n", gni_ret_str(grc));
-		goto err1;
-	}
-	uep->ugni_ep_bound = 1;
+			msg->ep_desc.pe_addr, msg->ep_desc.inst_id);
+	uep->app_owned = 1;
 	pthread_mutex_unlock(&uep->ep.lock);
 
 	struct zap_event ev = {
+		.ep = &uep->ep,
 		.type = ZAP_EVENT_CONNECT_REQUEST,
 		.data_len = msg->data_len,
 		.data = (msg->data_len)?((void*)msg->data):(NULL)
 	};
 	uep->ep.cb(&uep->ep, &ev);
+	if (uep->app_accepted) {
+		zap_err_t zerr = zap_ep_change_state(&uep->ep, ZAP_EP_ACCEPTING, ZAP_EP_CONNECTED);
+		assert(zerr == ZAP_ERR_OK);
+		if (zerr == ZAP_ERR_OK) {
+			CONN_LOG("%p delivering ZAP_EVENT_CONNECTED\n", uep);
+		}
+		ev.type = ZAP_EVENT_CONNECTED;
+		ev.data_len = 0;
+		ev.data = NULL;
+		uep->ep.cb(&uep->ep, &ev);
+	}
 
 	return;
 err1:
 	pthread_mutex_unlock(&uep->ep.lock);
-	shutdown(uep->sock, SHUT_RDWR);
 	return;
 }
 
@@ -888,19 +1394,21 @@ static void process_uep_msg_rejected(struct z_ugni_ep *uep)
 	int rc;
 	size_t data_len;
 
-	msg = (void*)uep->rbuff->data;
+	msg = (void*)uep->rmsg;
 	data_len = ntohl(msg->data_len);
 	struct zap_event ev = {
+		.ep = &uep->ep,
 		.type = ZAP_EVENT_REJECTED,
 		.data_len = data_len,
 		.data = (data_len ? (void *)msg->data : NULL)
 	};
+	/* need to remove the connect timeout event first */
+	z_ugni_zq_rm((void*)uep->ep.thread, &uep->uev);
 	rc = zap_ep_change_state(&uep->ep, ZAP_EP_CONNECTING, ZAP_EP_ERROR);
 	if (rc != ZAP_ERR_OK) {
 		return;
 	}
-	uep->ep.cb(&uep->ep, &ev);
-	shutdown(uep->sock, SHUT_RDWR);
+	zap_event_deliver(&ev);
 	return;
 }
 
@@ -910,7 +1418,6 @@ static void process_uep_msg_ack_accepted(struct z_ugni_ep *uep)
 
 	rc = zap_ep_change_state(&uep->ep, ZAP_EP_ACCEPTING, ZAP_EP_CONNECTED);
 	if (rc != ZAP_ERR_OK) {
-		shutdown(uep->sock, SHUT_RDWR);
 		return;
 	}
 	struct zap_event ev = {
@@ -921,6 +1428,104 @@ static void process_uep_msg_ack_accepted(struct z_ugni_ep *uep)
 	return;
 }
 
+static void process_uep_msg_term(struct z_ugni_ep *uep)
+{
+	zap_err_t zerr = ZAP_ERR_OK;
+	pthread_mutex_lock(&uep->ep.lock);
+	if (uep->ugni_term_recv) {
+		LLOG("ERROR: Multiple TERM messages received\n");
+		goto out;
+	}
+	uep->ugni_term_recv = 1;
+	switch (uep->ep.state) {
+	case ZAP_EP_CONNECTED:
+		/* send our term, then ack peer's term */
+		zerr = z_ugni_send_term(uep);
+		zerr = zerr?zerr:z_ugni_send_ack_term(uep);
+		uep->ep.state = ZAP_EP_PEER_CLOSE;
+		break;
+	case ZAP_EP_CLOSE:
+		zerr = z_ugni_send_ack_term(uep);
+		break;
+	case ZAP_EP_CONNECTING:
+		/* need to remove the connect timeout event first */
+		z_ugni_zq_rm((void*)uep->ep.thread, &uep->uev);
+		/* let through */
+	case ZAP_EP_ACCEPTING:
+		/* peer close before becoming CONNECTED */
+		/* send our term, then ack peer's term */
+		zerr = z_ugni_send_term(uep);
+		zerr = zerr?zerr:z_ugni_send_ack_term(uep);
+		uep->ep.state = ZAP_EP_ERROR;
+		break;
+	case ZAP_EP_ERROR:
+		/* do nothing */
+		break;
+	default:
+		LLOG("ERROR: Unexpected TERM message while endpoint "
+		     "in state %s (%d)\n",
+		     __zap_ep_state_str(uep->ep.state),
+		     uep->ep.state);
+		break;
+	}
+	if (zerr) {
+		uep->ep.state = ZAP_EP_ERROR;
+	}
+ out:
+	pthread_mutex_unlock(&uep->ep.lock);
+}
+
+static void process_uep_msg_ack_term(struct z_ugni_ep *uep)
+{
+	pthread_mutex_lock(&uep->ep.lock);
+	if (!uep->uev.in_zq) {
+		/* already timeout, skip the processing */
+		LLOG("INFO: uev timed out ... skipping\n");
+		goto err;
+	}
+	if (!uep->ugni_term_sent) {
+		LLOG("ERROR: TERM has not been sent but received ACK_TERM\n");
+		goto err;
+	}
+	if (uep->ugni_ack_term_recv) {
+		LLOG("ERROR: Multiple ACK_TERM messages received.\n");
+		goto err;
+	}
+	uep->ugni_ack_term_recv = 1;
+	/* validate ep state */
+	switch (uep->ep.state) {
+	case ZAP_EP_CLOSE:
+	case ZAP_EP_PEER_CLOSE:
+	case ZAP_EP_ERROR:
+		/* OK */
+		break;
+	default:
+		LLOG("ERROR: Unexpected ACK_TERM message while endpoint "
+		     "in state %s (%d)\n",
+		     __zap_ep_state_str(uep->ep.state),
+		     uep->ep.state);
+		goto err;
+	}
+	/*
+	 * NOTE: This does not race with z_ugni_handle_zq_events() since it is
+	 * on the same thread. However, we still need the thread->mutex (in
+	 * z_ugni_zq_rm()) to protect the tree from node insertion from the
+	 * application thread (simultaneous tree modification may corrupt the
+	 * tree).
+	 */
+	z_ugni_zq_rm((void*)uep->ep.thread, &uep->uev);
+	z_ugni_flush(uep);
+	pthread_mutex_unlock(&uep->ep.lock);
+	zap_io_thread_ep_release(&uep->ep);
+	CONN_LOG("%p delivering last event: %s\n", uep, zap_event_str(uep->uev.zev.type));
+	zap_event_deliver(&uep->uev.zev);
+	zap_put_ep(&uep->ep); /* taken in z_ugni_connect()/z_ugni_accept() */
+	return;
+
+ err:
+	pthread_mutex_unlock(&uep->ep.lock);
+}
+
 typedef void(*process_uep_msg_fn_t)(struct z_ugni_ep*);
 process_uep_msg_fn_t process_uep_msg_fns[] = {
 	[ZAP_UGNI_MSG_REGULAR]      =  process_uep_msg_regular,
@@ -929,192 +1534,11 @@ process_uep_msg_fn_t process_uep_msg_fns[] = {
 	[ZAP_UGNI_MSG_CONNECT]      =  process_uep_msg_connect,
 	[ZAP_UGNI_MSG_REJECTED]     =  process_uep_msg_rejected,
 	[ZAP_UGNI_MSG_ACK_ACCEPTED] =  process_uep_msg_ack_accepted,
+	[ZAP_UGNI_MSG_TERM]         =  process_uep_msg_term,
+	[ZAP_UGNI_MSG_ACK_TERM]     =  process_uep_msg_ack_term,
 };
 
-static int __recv_msg(struct z_ugni_ep *uep)
-{
-	int rc;
-	ssize_t rsz, rqsz;
-	struct zap_ugni_msg_hdr *hdr;
-	struct zap_ugni_recv_buff *buff = uep->rbuff;
-	uint32_t mlen;
-	int from_line = 0; /* for debugging */
-
-	if (buff->len < sizeof(struct zap_ugni_msg_hdr)) {
-		/* need to fill the header first */
-		rqsz = sizeof(struct zap_ugni_msg_hdr) - buff->len;
-		rsz = read(uep->sock, buff->data + buff->len, rqsz);
-		if (rsz == 0) {
-			/* peer close */
-			rc = ENOTCONN;
-			from_line = __LINE__;
-			goto err;
-		}
-		if (rsz < 0) {
-			if (errno == EAGAIN)
-				return errno;
-			/* error */
-			rc = errno;
-			from_line = __LINE__;
-			goto err;
-		}
-		buff->len += rsz;
-		buff->alen -= rsz;
-		if (rsz < rqsz) {
-			rc = EAGAIN;
-			from_line = __LINE__;
-			goto err;
-		}
-	}
-
-	hdr = (void*)buff->data;
-	mlen = ntohl(hdr->msg_len);
-
-	if (mlen > UGNI_SOCKBUF_SZ) {
-		rc = EINVAL;
-		from_line = __LINE__;
-		goto err;
-	}
-
-	if (mlen > buff->len + buff->alen) {
-		/* Buffer extension is needed */
-		rqsz = ((sizeof(*buff) + mlen - 1) | 0xFFFF) + 1;
-		buff = realloc(buff, rqsz);
-		if (!buff) {
-			from_line = __LINE__;
-			rc = ENOMEM;
-			goto err;
-		}
-		buff->alen = rqsz - buff->len - sizeof(*buff);
-		/* don't forget to update uep->rbuff pointer */
-		uep->rbuff = buff;
-	}
-
-	if (buff->len < mlen) {
-		rqsz = mlen - buff->len;
-		rsz = read(uep->sock, buff->data + buff->len, rqsz);
-		if (rsz == 0) {
-			/* peer close */
-			rc = ENOTCONN;
-			from_line = __LINE__;
-			goto err;
-		}
-		if (rsz < 0) {
-			if (errno == EAGAIN)
-				return errno;
-			rc = errno;
-			from_line = __LINE__;
-			goto err;
-		}
-		buff->len += rsz;
-		buff->alen -= rsz;
-		if (rsz < rqsz) {
-			rc = EAGAIN;
-			from_line = __LINE__;
-			goto err;
-		}
-	}
-	return 0;
-
- err:
-	from_line += 0; /* avoid gcc's set-but-not-used warning*/
-	return rc;
-}
-
 #define min_t(t, x, y) (t)((t)x < (t)y?(t)x:(t)y)
-static void ugni_sock_read(ovis_event_t ev)
-{
-	struct z_ugni_ep *uep = ev->param.ctxt;
-	struct zap_ugni_msg_hdr *hdr;
-	zap_ugni_msg_type_t msg_type;
-
-	int rc;
-
-	do {
-		rc = __recv_msg(uep);
-		if (rc == EAGAIN)
-			break;
-		if (rc) {
-			/* ENOTCONN or other errors */
-			goto bad;
-		}
-
-		/* message receive complete */
-		hdr = (void*)uep->rbuff->data;
-		msg_type = ntohs(hdr->msg_type);
-
-		/* validate by ep state */
-		pthread_mutex_lock(&uep->ep.lock);
-		switch (uep->ep.state) {
-		case ZAP_EP_ACCEPTING:
-			/* expecting only `connect` message */
-			if ((msg_type != ZAP_UGNI_MSG_CONNECT) &&
-			      (msg_type != ZAP_UGNI_MSG_ACK_ACCEPTED)) {
-				/* invalid */
-				pthread_mutex_unlock(&uep->ep.lock);
-				goto bad;
-			}
-			break;
-		case ZAP_EP_CONNECTING:
-			/* Expecting accept or reject */
-			if (msg_type != ZAP_UGNI_MSG_ACCEPTED &&
-					msg_type != ZAP_UGNI_MSG_REJECTED) {
-				/* invalid */
-				pthread_mutex_unlock(&uep->ep.lock);
-				goto bad;
-			}
-			break;
-		case ZAP_EP_CONNECTED:
-			/* good */
-			break;
-		case ZAP_EP_CLOSE:
-		case ZAP_EP_ERROR:
-			/*
-			 * This could happened b/c the read event has not been
-			 * disabled yet. Process the received message as usual.
-			 */
-			break;
-		case ZAP_EP_INIT:
-			assert(0 == "bad state (ZAP_EP_INIT)");
-			break;
-		case ZAP_EP_LISTENING:
-			assert(0 == "bad state (ZAP_EP_LISTENING)");
-			break;
-		case ZAP_EP_PEER_CLOSE:
-			assert(0 == "bad state (ZAP_EP_CLOSE)");
-			break;
-		}
-		pthread_mutex_unlock(&uep->ep.lock);
-		/* Then call the process function accordingly */
-		if (ZAP_UGNI_MSG_NONE < msg_type
-				&& msg_type < ZAP_UGNI_MSG_TYPE_LAST) {
-			process_uep_msg_fns[msg_type](uep);
-		} else {
-			assert(0);
-			process_uep_msg_unknown(uep);
-		}
-		/* reset recv buffer */
-		uep->rbuff->alen += uep->rbuff->len;
-		uep->rbuff->len = 0;
-	} while (1);
-	return;
- bad:
-	pthread_mutex_lock(&uep->ep.lock);
-	__shutdown_on_error(uep);
-	pthread_mutex_unlock(&uep->ep.lock);
-}
-
-static void *io_thread_proc(void *arg)
-{
-	/* Zap thread will not handle any signal */
-	int rc;
-	sigset_t sigset;
-	sigfillset(&sigset);
-	rc = pthread_sigmask(SIG_BLOCK, &sigset, NULL);
-	assert(rc == 0 && "pthread_sigmask error");
-	ovis_scheduler_loop(io_sched, 0);
-	return NULL;
-}
 
 int zap_ugni_err_handler(gni_cq_handle_t cq, gni_cq_entry_t cqe,
 			 struct zap_ugni_post_desc *desc)
@@ -1134,247 +1558,8 @@ int zap_ugni_err_handler(gni_cq_handle_t cq, gni_cq_entry_t cqe,
 	return recoverable;
 }
 
-static gni_return_t process_cq(gni_cq_handle_t cq, gni_cq_entry_t cqe_)
-{
-	struct zap_event zev;
-	gni_cq_entry_t cqe = cqe_;
-	gni_return_t grc;
-	gni_post_descriptor_t *post;
-	int count = 0;
-	do {
-		memset(&zev, 0, sizeof(zev));
-		count++;
-		if (GNI_CQ_GET_TYPE(cqe) != GNI_CQ_EVENT_TYPE_POST) {
-			zap_ugni_log("Unexepcted cqe type %d cqe"
-					" %08x on CQ %p\n",
-					GNI_CQ_GET_TYPE(cqe), cqe, cq);
-			goto skip;
-		}
-		pthread_mutex_lock(&ugni_lock);
-		post = NULL;
-
-#ifdef DEBUG
-		assert(ugni_io_count >= 0);
-		__sync_sub_and_fetch(&ugni_io_count, 1);
-#endif /* DEBUG */
-		grc = GNI_GetCompleted(cq, cqe, &post);
-		pthread_mutex_unlock(&ugni_lock);
-		if (!post) {
-			DLOG("process_cq: post is NULL\n");
-			goto skip;
-		}
-		assert((int)ugni_post_count >= 0);
-		struct zap_ugni_post_desc *desc = (void*) post;
-		if (grc) {
-			zap_ugni_log("GNI_GetCompleted returned %s\n", gni_ret_str(grc));
-			if (0 == zap_ugni_err_handler(cq, cqe, desc))
-				__shutdown_on_error(desc->uep);
-			else
-				assert(0 == "uh oh...how do we restart this");
-		}
-		pthread_mutex_lock(&z_ugni_list_mutex);
-		if (desc->is_stalled == 1) {
-			/*
-			 * The descriptor is in the stalled state.
-			 *
-			 * The completion corresponding to the descriptor
-			 * has been flushed. The corresponding endpoint
-			 * might have been freed already.
-			 */
-			LOG("%s: Received a CQ event for a stalled post "
-						"desc.\n", desc->ep_name);
-			ZUGNI_LIST_REMOVE(desc, stalled_link);
-			free(desc);
-			pthread_mutex_unlock(&z_ugni_list_mutex);
-			goto skip;
-		}
-
-		struct z_ugni_ep *uep = desc->uep;
-		if (!uep) {
-			/*
-			 * This should not happen. The code is put in to prevent
-			 * the segmentation fault and to record the situation.
-			 */
-			LOG("%s: %s: desc->uep = NULL. Drop the descriptor.\n", __func__,
-				desc->ep_name);
-			pthread_mutex_unlock(&z_ugni_list_mutex);
-			goto skip;
-		}
-		pthread_mutex_lock(&uep->ep.lock);
-#ifdef DEBUG
-		if (uep->deferred_link.le_prev)
-			LOG_(uep, "uep %p: Doh!! I'm on the deferred list.\n", uep);
-#endif /* DEBUG */
-		switch (desc->post.type) {
-		case GNI_POST_RDMA_GET:
-			DLOG_(uep, "RDMA_GET: Read complete %p with %s\n", desc, gni_ret_str(grc));
-			if (grc) {
-				zev.status = ZAP_ERR_RESOURCE;
-				LOG_(uep, "RDMA_GET: completing "
-					"with error %s.\n",
-					gni_ret_str(grc));
-			}
-			zev.type = ZAP_EVENT_READ_COMPLETE;
-			zev.context = desc->context;
-			break;
-		case GNI_POST_RDMA_PUT:
-			DLOG_(uep, "RDMA_PUT: Write complete %p with %s\n",
-						desc, gni_ret_str(grc));
-			if (grc) {
-				zev.status = ZAP_ERR_RESOURCE;
-				DLOG_(uep, "RDMA_PUT: completing "
-					"with error %s.\n",
-					gni_ret_str(grc));
-			}
-			zev.type = ZAP_EVENT_WRITE_COMPLETE;
-			zev.context = desc->context;
-			break;
-		default:
-			LOG_(uep, "Unknown completion type %d.\n",
-					 desc->post.type);
-			__shutdown_on_error(uep);
-		}
-
-		__free_post_desc(desc);
-		pthread_mutex_unlock(&uep->ep.lock);
-		pthread_mutex_unlock(&z_ugni_list_mutex);
-
-		/* Wake up threads blocked trying to post descriptors */
-		pthread_mutex_lock(&cq_full_lock);
-		if (uep->gni_cq == _dom.cq) {
-			__sync_sub_and_fetch(&ugni_post_count, 1);
-			assert((int)ugni_post_count >= 0);
-		}
-		pthread_cond_broadcast(&cq_full_cond);
-		pthread_mutex_unlock(&cq_full_lock);
-
-		uep->ep.cb(&uep->ep, &zev);
-	skip:
-		pthread_mutex_lock(&ugni_lock);
-		grc = GNI_CqGetEvent(cq, &cqe);
-		pthread_mutex_unlock(&ugni_lock);
-		if (grc == GNI_RC_ERROR_RESOURCE) {
-			zap_ugni_log("CQ overrun!\n");
-			break;
-		}
-	} while (grc != GNI_RC_NOT_DONE);
-	if (count > 1)
-		DLOG("process_cq: count %d\n", count);
-	return GNI_RC_SUCCESS;
-}
-
-/* Caller must hold the endpoint list lock */
-void __stall_post_desc(struct zap_ugni_post_desc *d, struct timeval time)
-{
-	zap_put_ep(&d->uep->ep);
-	d->is_stalled = 1;
-	d->uep = NULL;
-	d->stalled_time = time;
-	__sync_fetch_and_add(&ugni_leaked_count, 1);
-	LIST_INSERT_HEAD(&stalled_desc_list, d, stalled_link);
-}
-
-/* Caller must hold the endpoint lock. */
-void __flush_post_desc_list(struct z_ugni_ep *uep)
-{
-	struct timeval time;
-	gettimeofday(&time, NULL);
-	struct zap_ugni_post_desc *d;
-	d = LIST_FIRST(&uep->post_desc_list);
-	while (d) {
-		ZUGNI_LIST_REMOVE(d, ep_link);
-		struct zap_event zev = {0};
-		switch (d->post.type) {
-		case GNI_POST_RDMA_GET:
-			zev.type = ZAP_EVENT_READ_COMPLETE;
-			break;
-		case GNI_POST_RDMA_PUT:
-			zev.type = ZAP_EVENT_WRITE_COMPLETE;
-			break;
-		default:
-			zap_ugni_log("Unknown RDMA post "
-				     "type %d on transport %p.\n",
-				     d->post.type, uep);
-		}
-		zev.status = ZAP_ERR_FLUSH;
-		zev.context = d->context;
-		pthread_mutex_unlock(&uep->ep.lock);
-		uep->ep.cb(&uep->ep, &zev);
-		if (uep->gni_cq == _dom.cq) {
-			__sync_sub_and_fetch(&ugni_post_count, 1);
-			assert((int)ugni_post_count >= 0);
-		}
-		pthread_mutex_lock(&uep->ep.lock);
-		__stall_post_desc(d, time);
-		d = LIST_FIRST(&uep->post_desc_list);
-	}
-}
-
 static zap_thrstat_t ugni_stats;
 #define WAIT_5SECS 5000
-static void *cq_thread_proc(void *arg)
-{
-	gni_return_t grc;
-	gni_cq_entry_t cqe;
-	int oldtype;
-	int drain = 0;
-
-	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &oldtype);
-	zap_thrstat_reset(ugni_stats);
-	while (1) {
-		uint64_t timeout = WAIT_5SECS;
-		zap_thrstat_wait_start(ugni_stats);
-		grc = GNI_CqWaitEvent(_dom.cq, timeout, &cqe);
-		zap_thrstat_wait_end(ugni_stats);
-		switch (grc) {
-		case GNI_RC_SUCCESS:
-			grc = process_cq(_dom.cq, cqe);
-			if (grc)
-				zap_ugni_log("Error %d processing CQ %p.\n",
-					     grc, _dom.cq);
-		case GNI_RC_TIMEOUT:
-			if (drain) {
-				gni_cq_handle_t new_cq;
-				grc = GNI_CqCreate(_dom.nic, _dom.cq_depth, 0, GNI_CQ_BLOCKING,
-						   NULL, NULL, &new_cq);
-				if (grc == GNI_RC_SUCCESS) {
-					ugni_old_cq = _dom.cq;
-					_dom.cq = new_cq;
-					ugni_post_count = 0;
-					ugni_leaked_count = 0;
-					drain = 0;
-					zap_ugni_log("%s: Created a new CQ...resuming I/O\n", __func__);
-				} else {
-					zap_ugni_log("%s: Creating a new CQ failed with error \"%s\". "
-						     "The daemon needs to be restarted\n",
-						     __func__, gni_ret_str(grc));
-					pthread_mutex_unlock(&cq_full_lock);
-				}
-				pthread_mutex_unlock(&cq_full_lock);
-			}
-			break;
-		default:
-			zap_ugni_log("%s:%d GNI_CqWaitEvent returned %s, errno %d\n",
-				     __func__, __LINE__, gni_ret_str(grc), errno);
-			break;
-		}
-		/*
-		 * Check if the leaked descriptor count is > 1/2 the
-		 * cq depth. At that point:
-		 * - Stall all I/O (by holding the cq_full_lock)
-		 * - Wait up to 5 seconds to drain the CQ
-		 * - Create a new CQ and continue
-		 */
-		if ((drain == 0)
-		    && (ugni_leaked_count > (_dom.cq_depth / 2))) {
-			pthread_mutex_lock(&cq_full_lock);
-			drain = 1;
-			zap_ugni_log("%s: CQ has leaked %d descriptors...stalling I/O\n", __func__,
-				     ugni_leaked_count);
-		}
-	}
-	return NULL;
-}
 
 static void *error_thread_proc(void *args)
 {
@@ -1413,389 +1598,12 @@ static void *error_thread_proc(void *args)
 	return NULL;
 }
 
-/* msg hdr fields are in network-byte-order */
-/* caller must held uep->ep.lock */
-static zap_err_t __ugni_send_msg(struct z_ugni_ep *uep,
-				 struct zap_ugni_msg_hdr *msg,
-				 size_t msg_len,
-				 const void *data,
-				 size_t data_len)
-{
-	int rc;
-	struct zap_ugni_send_wr *wr;
-
-	if (data_len > uep->ep.z->max_msg) {
-		/* message too big */
-		return ZAP_ERR_NO_SPACE;
-	}
-
-	wr = malloc(sizeof(*wr) + msg_len + data_len);
-	if (!wr)
-		return ZAP_ERR_RESOURCE;
-	wr->alen = msg_len + data_len;
-	wr->off = 0;
-	memcpy(wr->data, msg, msg_len);
-	if (data && data_len)
-		memcpy(wr->data + msg_len, data, data_len);
-	STAILQ_INSERT_TAIL(&uep->sq, wr, link);
-	rc = __enable_epoll_out(uep);
-	if (rc) {
-		return ZAP_ERR_RESOURCE;
-	}
-	return ZAP_ERR_OK;
-}
-
-/* caller must held uep->ep.lock */
-static zap_err_t __ugni_send_connect(struct z_ugni_ep *uep, char *buf, size_t len)
-{
-	zap_err_t zerr;
-	struct zap_ugni_msg_connect msg = {
-		.hdr = {
-			.msg_type = htons(ZAP_UGNI_MSG_CONNECT),
-			.msg_len = htonl((uint32_t)(sizeof(msg) + len)),
-		},
-		.data_len = htonl(len),
-		.inst_id = htonl(_dom.inst_id),
-		.pe_addr = htonl(_dom.pe_addr),
-	};
-
-	ZAP_VERSION_SET(msg.ver);
-	memcpy(&msg.sig, ZAP_UGNI_SIG, sizeof(msg.sig));
-
-	zerr = __ugni_send_msg(uep, &msg.hdr, sizeof(msg), buf, len);
-	if (zerr)
-		return zerr;
-	return ZAP_ERR_OK;
-}
-
-/* caller must held uep->ep.lock */
-static zap_err_t
-__ugni_send(struct z_ugni_ep *uep, enum zap_ugni_msg_type type,
-						char *buf, size_t len)
-{
-	zap_err_t zerr;
-	struct zap_ugni_msg_regular msg = {
-		.hdr = {
-			.msg_type = htons(type),
-			.msg_len = htonl((uint32_t)(sizeof(msg) + len)),
-		},
-		.data_len = htonl(len),
-	};
-
-	zerr = __ugni_send_msg(uep, &msg.hdr, sizeof(msg), buf, len);
-	if (zerr)
-		return zerr;
-	return ZAP_ERR_OK;
-}
-
-static void __deliver_disconnect_ev(struct z_ugni_ep *uep)
-{
-	/* Deliver the disconnected event */
-	pthread_mutex_lock(&z_ugni_list_mutex);
-#ifdef DEBUG
-	zap_ugni_ep_id[uep->ep_id] = -1;
-#endif /* DEBUG */
-	pthread_mutex_lock(&uep->ep.lock);
-#ifdef DEBUG
-	/* It is in the queue already. */
-	pthread_mutex_lock(&deferred_list_mutex);
-	if (uep->deferred_link.le_prev) {
-		/* It is in the deferred list ... remove it. */
-		ZUGNI_LIST_REMOVE(uep, deferred_link);
-		uep->deferred_link.le_next = 0;
-		uep->deferred_link.le_prev = 0;
-		zap_put_ep(&uep->ep);
-	}
-	pthread_mutex_unlock(&deferred_list_mutex);
-#endif /* DEBUG */
-	if (!LIST_EMPTY(&uep->post_desc_list)) {
-		__flush_post_desc_list(uep);
-		DLOG("%s: after cleanup all rdma"
-			"post: ep %p: ref_count %d\n",
-			__func__, uep, uep->ep.ref_count);
-	}
-	pthread_mutex_unlock(&uep->ep.lock);
-	pthread_mutex_unlock(&z_ugni_list_mutex);
-	ZAP_ASSERT(uep->conn_ev.type == ZAP_EVENT_DISCONNECTED ||
-			uep->conn_ev.type == ZAP_EVENT_CONNECT_ERROR, &uep->ep,
-			"%s: uep->conn_ev.type (%s) is neither ZAP_EVENT_"
-			"DISCONNECTED nor ZAP_EVENT_CONNECT_ERROR\n", __func__,
-			zap_event_str(uep->conn_ev.type));
-	/*
-	 * If we reach here with conn_ev, we have a deferred disconnect event
-	 * the disconnect path in ugni_sock_event() has already prep conn_ev for us.
-	 */
-	/* Sending DISCONNECTED event to application */
-	close(uep->sock);
-	uep->sock = -1;
-	uep->ep.cb((void*)uep, &uep->conn_ev);
-	zap_put_ep(&uep->ep);
-}
-
-void __deferred_disconnect_cb(ovis_event_t ev)
-{
-	struct z_ugni_ep *uep = ev->param.ctxt;
-	pthread_mutex_lock(&uep->ep.lock);
-	__flush_post_desc_list(uep);
-	pthread_mutex_unlock(&uep->ep.lock);
-	ovis_scheduler_event_del(io_sched, ev);
-	__deliver_disconnect_ev(uep);
-}
-
-void __ugni_defer_disconnect_event(struct z_ugni_ep *uep)
-{
-	int rc;
-	DLOG("defer_disconnected: uep %p\n", uep);
-#ifdef DEBUG
-	pthread_mutex_lock(&uep->ep.lock);
-	pthread_mutex_lock(&deferred_list_mutex);
-	if (uep->deferred_link.le_prev == 0) {
-		/* It is not in the deferred list yet ... add it in. */
-		zap_get_ep(&uep->ep);
-		LIST_INSERT_HEAD(&deferred_list, uep, deferred_link);
-	}
-	pthread_mutex_unlock(&deferred_list_mutex);
-	pthread_mutex_unlock(&uep->ep.lock);
-#endif /* DEBUG */
-	OVIS_EVENT_INIT(&uep->deferred_ev);
-	uep->deferred_ev.param.type = OVIS_EVENT_TIMEOUT;
-	uep->deferred_ev.param.timeout.tv_sec = zap_ugni_disconnect_timeout;
-	uep->deferred_ev.param.cb_fn = __deferred_disconnect_cb;
-	uep->deferred_ev.param.ctxt = uep;
-	rc = ovis_scheduler_event_add(io_sched, &uep->deferred_ev);
-	assert(rc == 0);
-}
-
-static void ugni_sock_ev_cb(ovis_event_t ev)
-{
-	struct z_ugni_ep *uep = ev->param.ctxt;
-#if defined(ZAP_DEBUG) || defined(DEBUG)
-	uep->epoll_record[uep->epoll_record_curr++] = ev->cb.epoll_events;
-	uep->epoll_record_curr %= UEP_EPOLL_RECORD_SZ;
-#endif /* ZAP_DEBUG || DEBUG */
-
-	if (ev->cb.epoll_events & EPOLLOUT) {
-		if (uep->sock_connected) {
-			ugni_sock_write(ev);
-		} else {
-			/* just become sock-connected */
-			uep->sock_connected = 1;
-			ugni_sock_connect(ev);
-		}
-	}
-
-	if (ev->cb.epoll_events & EPOLLIN) {
-		ugni_sock_read(ev);
-	}
-
-	if ((ev->cb.epoll_events & (EPOLLERR|EPOLLHUP))) {
-		ugni_sock_event(ev);
-	}
-}
-
-static void ugni_sock_connect(ovis_event_t ev)
-{
-	zap_err_t zerr;
-	struct z_ugni_ep *uep = ev->param.ctxt;
-#ifdef ZAP_UGNI_DEBUG
-	char *is_exit = getenv("ZAP_UGNI_CONN_EST_BEFORE_CONNECT_MSG_TEST");
-	if (is_exit)
-		exit(0);
-#endif /* ZAP_UGNI_DEBUG */
-	pthread_mutex_lock(&uep->ep.lock);
-	zerr = __ugni_send_connect(uep, uep->conn_data, uep->conn_data_len);
-	if (zerr)
-		__shutdown_on_error(uep);
-	pthread_mutex_unlock(&uep->ep.lock);
-#ifdef ZAP_UGNI_DEBUG
-	is_exit = getenv("ZAP_UGNI_CONN_EST_AFTER_CONNECT_MSG_TEST");
-	if (is_exit)
-		exit(0);
-#endif /* ZAP_UGNI_DEBUG */
-	if (uep->conn_data)
-		free(uep->conn_data);
-	uep->conn_data = NULL;
-	uep->conn_data_len = 0;
-	return;
-}
-
-static void ugni_sock_event(ovis_event_t ev)
-{
-	int rc;
-	struct z_ugni_ep *uep = ev->param.ctxt;
-	struct zap_event *zev = &uep->conn_ev;
-
-	/* Reaching here means bev is one of the EOF, ERROR or TIMEOUT */
-	pthread_mutex_lock(&uep->ep.lock);
-	int defer = 0;
-	if (!LIST_EMPTY(&uep->post_desc_list))
-		defer = 1;
-	rc = ovis_scheduler_event_del(io_sched, ev);
-	assert(rc == 0); /* ev must be in the scheduler, otherwise it is a bug */
-	switch (uep->ep.state) {
-	case ZAP_EP_ACCEPTING:
-		uep->ep.state = ZAP_EP_ERROR;
-		if (uep->app_accepted) {
-			zev->type = ZAP_EVENT_CONNECT_ERROR;
-		} else {
-			/* app has rejected this, or doesn't know about this */
-			goto no_cb;
-		}
-		break;
-	case ZAP_EP_CONNECTING:
-		zev->type = ZAP_EVENT_CONNECT_ERROR;
-		uep->ep.state = ZAP_EP_ERROR;
-		shutdown(uep->sock, SHUT_RDWR);
-		break;
-	case ZAP_EP_CONNECTED:
-		/* Peer closed */
-		uep->ep.state = ZAP_EP_PEER_CLOSE;
-		shutdown(uep->sock, SHUT_RDWR);
-	case ZAP_EP_CLOSE:
-		/* Active close */
-		zev->type = ZAP_EVENT_DISCONNECTED;
-		break;
-	case ZAP_EP_ERROR:
-		goto no_cb;
-	default:
-		LOG_(uep, "Unexpected state for EOF %d.\n",
-				uep->ep.state);
-		uep->ep.state = ZAP_EP_ERROR;
-		break;
-	}
-	DLOG_(uep, "%s: ep %p: state %s\n", __func__, uep,
-				__zap_ep_state_str[uep->ep.state]);
-	pthread_mutex_unlock(&uep->ep.lock);
-	if (defer) {
-		/*
-		* Allow time for uGNI to flush outstanding
-		* completion events
-		*/
-		__ugni_defer_disconnect_event(uep);
-	} else {
-		__deliver_disconnect_ev(uep);
-	}
-	return;
-no_cb:
-	pthread_mutex_unlock(&uep->ep.lock);
-	zap_put_ep(&uep->ep);
-	return;
-}
-
-static zap_err_t
-__setup_connection(struct z_ugni_ep *uep)
-{
-	int rc;
-
-	DLOG_(uep, "setting up endpoint %p, fd: %d\n", uep, uep->sock);
-
-	/* Initialize send and recv I/O events */
-	OVIS_EVENT_INIT(&uep->io_ev);
-	uep->io_ev.param.type = OVIS_EVENT_EPOLL;
-	uep->io_ev.param.fd = uep->sock;
-	uep->io_ev.param.cb_fn = ugni_sock_ev_cb;
-	uep->io_ev.param.epoll_events = EPOLLIN|EPOLLOUT;
-	uep->io_ev.param.ctxt = uep;
-
-	rc = ovis_scheduler_event_add(io_sched, &uep->io_ev);
-	if (rc) {
-		return ZAP_ERR_RESOURCE;
-	}
-
-	return ZAP_ERR_OK;
-}
-
-/**
- * This is a callback function for evconnlistener_new_bind (in z_ugni_listen).
- */
-static void __z_ugni_conn_request(ovis_event_t ev)
-{
-	int rc;
-	struct z_ugni_ep *uep = ev->param.ctxt;
-	zap_ep_t new_ep;
-	struct z_ugni_ep *new_uep;
-	zap_err_t zerr;
-	int sockfd;
-	struct sockaddr sa;
-	socklen_t sa_len = sizeof(sa);
-
-	assert(ev->cb.epoll_events & EPOLLIN);
-	sockfd = accept(ev->param.fd, &sa, &sa_len);
-	if (sockfd < 0) {
-		LOG_(uep, "accept() error %d: in %s at %s:%d\n",
-				errno , __func__, __FILE__, __LINE__);
-		return;
-	}
-
-	rc = __set_sockbuf_sz(sockfd);
-	if (rc) {
-		close(sockfd);
-		zerr = ZAP_ERR_TRANSPORT;
-		LOG_(uep, "Error %d: fail to set the sockbuf sz in %s.\n",
-				errno, __func__);
-		return;
-	}
-
-	new_ep = zap_new(uep->ep.z, uep->ep.app_cb);
-	if (!new_ep) {
-		close(sockfd);
-		zerr = errno;
-		LOG_(uep, "Zap Error %d (%s): in %s at %s:%d\n",
-				zerr, zap_err_str(zerr) , __func__, __FILE__,
-				__LINE__);
-		return;
-	}
-
-	void *uctxt = zap_get_ucontext(&uep->ep);
-	zap_set_ucontext(new_ep, uctxt);
-	new_uep = (void*) new_ep;
-	new_uep->sock = sockfd;
-	new_uep->ep.state = ZAP_EP_ACCEPTING;
-	new_uep->sock_connected = 1;
-
-	rc = __sock_nonblock(new_uep->sock);
-	if (rc) {
-		LOG_(uep, "__sock_nonblock() error %d:"
-			  " in %s at %s:%d\n",
-				rc, __func__, __FILE__, __LINE__);
-		/* synchronous error */
-		zap_free(new_ep);
-		return;
-	}
-
-	OVIS_EVENT_INIT(&new_uep->io_ev);
-	new_uep->io_ev.param.type = OVIS_EVENT_EPOLL;
-	new_uep->io_ev.param.fd = new_uep->sock;
-	new_uep->io_ev.param.cb_fn = ugni_sock_ev_cb;
-	new_uep->io_ev.param.epoll_events = EPOLLIN;
-	new_uep->io_ev.param.ctxt = new_uep;
-
-	rc = ovis_scheduler_event_add(io_sched, &new_uep->io_ev);
-	if (rc) {
-		LOG_(uep, "ovis_scheduler_event_add() error %d:"
-			  " in %s at %s:%d\n",
-				rc, __func__, __FILE__, __LINE__);
-		/* synchronous error */
-		zap_free(new_ep);
-	}
-
-	/*
-	 * NOTE: At this point, the connection is socket-connected.  It is not
-	 * yet zap-connected. The passive side does not yet have enough GNI
-	 * information.  The active side will send a ZAP_UGNI_MSG_CONN_REQ
-	 * message to the passive side to share its GNI address information.
-	 * Then, the ZAP_EVENT_CONNECT_REQUEST will be generated. The passive
-	 * side can become zap-connected by calling zap_accept() in the zap
-	 * event call back.
-	 */
-
-	return;
-}
-
 static zap_err_t z_ugni_listen(zap_ep_t ep, struct sockaddr *sa,
 				socklen_t sa_len)
 {
 	struct z_ugni_ep *uep = (void*)ep;
+	struct epoll_event ev;
+	struct z_ugni_io_thread *thr;
 	zap_err_t zerr;
 	int rc, flags;
 
@@ -1808,7 +1616,7 @@ static zap_err_t z_ugni_listen(zap_ep_t ep, struct sockaddr *sa,
 		zerr = ZAP_ERR_RESOURCE;
 		goto err_0;
 	}
-	rc = __sock_nonblock(uep->sock);
+	rc = __set_sock_opts(uep->sock);
 	if (rc) {
 		zerr = ZAP_ERR_RESOURCE;
 		goto err_1;
@@ -1839,21 +1647,22 @@ static zap_err_t z_ugni_listen(zap_ep_t ep, struct sockaddr *sa,
 		goto err_1;
 	}
 
-	/* setup ovis event */
-	OVIS_EVENT_INIT(&uep->io_ev);
-	uep->io_ev.param.type = OVIS_EVENT_EPOLL;
-	uep->io_ev.param.fd = uep->sock;
-	uep->io_ev.param.epoll_events = EPOLLIN;
-	uep->io_ev.param.cb_fn = __z_ugni_conn_request;
-	uep->io_ev.param.ctxt = uep;
-	rc = ovis_scheduler_event_add(io_sched, &uep->io_ev);
-	if (rc) {
-		zerr = ZAP_ERR_RESOURCE;
+	zerr = zap_io_thread_ep_assign(&uep->ep);
+	if (zerr)
 		goto err_1;
+
+	thr = (void*)uep->ep.thread;
+	ev.events = EPOLLIN;
+	ev.data.ptr = &uep->sock_epoll_ctxt;
+	rc = epoll_ctl(thr->efd, EPOLL_CTL_ADD, uep->sock, &ev);
+	if (rc) {
+		zerr = zap_errno2zerr(errno);
+		goto err_2;
 	}
 
 	return ZAP_ERR_OK;
-
+ err_2:
+	zap_io_thread_ep_release(ep);
  err_1:
 	close(uep->sock);
  err_0:
@@ -1864,6 +1673,7 @@ static zap_err_t z_ugni_send(zap_ep_t ep, char *buf, size_t len)
 {
 	struct z_ugni_ep *uep = (void*)ep;
 	zap_err_t zerr;
+	struct zap_ugni_msg msg;
 
 	/* node state validation */
 	if (_node_state.check_state) {
@@ -1893,48 +1703,10 @@ static zap_err_t z_ugni_send(zap_ep_t ep, char *buf, size_t len)
 		return ZAP_ERR_NOT_CONNECTED;
 	}
 
-	zerr = __ugni_send(uep, ZAP_UGNI_MSG_REGULAR, buf, len);
+	msg.hdr.msg_type = htons(ZAP_UGNI_MSG_REGULAR);
+	zerr = z_ugni_smsg_send(uep, &msg, buf, len);
 	pthread_mutex_unlock(&uep->ep.lock);
 	return zerr;
-}
-
-static struct ovis_event_s stalled_timeout_ev;
-static void stalled_timeout_cb(ovis_event_t ev)
-{
-	struct zap_ugni_post_desc *desc;
-	struct timeval now;
-
-	pthread_mutex_lock(&z_ugni_list_mutex);
-	gettimeofday(&now, NULL);
-	desc = LIST_FIRST(&stalled_desc_list);
-	while (desc) {
-		zap_ugni_log("%s: %s: Freeing stalled post desc:\n",
-			__func__, desc->ep_name);
-		if (zap_ugni_stalled_timeout <= now.tv_sec - desc->stalled_time.tv_sec) {
-			ZUGNI_LIST_REMOVE(desc, stalled_link);
-			free(desc);
-		} else {
-			break;
-		}
-		desc = LIST_FIRST(&stalled_desc_list);
-	}
-	if (ugni_old_cq) {
-		/*
-		 * Attempt to cleanup the CQ that was replaced. This
-		 * will fail until all endpoints associated with the
-		 * old CQ are destroyed
-		 */
-		gni_return_t grc = GNI_CqDestroy(ugni_old_cq);
-		if (grc == GNI_RC_SUCCESS) {
-			zap_ugni_log("%s: Successfully destroyed old CQ\n",
-				     __func__);
-			ugni_old_cq = NULL;
-		} else {
-			zap_ugni_log("%s: Error %s destroying old CQ\n",
-				     __func__, gni_ret_str(grc));
-		}
-	}
-	pthread_mutex_unlock(&z_ugni_list_mutex);
 }
 
 static uint8_t __get_ptag()
@@ -1950,14 +1722,6 @@ static uint32_t __get_cookie()
 	const char *str = getenv("ZAP_UGNI_COOKIE");
 	if (!str)
 		return 0;
-	return strtoul(str, NULL, 0);
-}
-
-static uint32_t __get_cq_depth()
-{
-	const char *str = getenv("ZAP_UGNI_CQ_DEPTH");
-	if (!str)
-		return ZAP_UGNI_CQ_DEPTH;
 	return strtoul(str, NULL, 0);
 }
 
@@ -2325,23 +2089,6 @@ static int z_ugni_init()
 			goto out;
 		}
 	}
-	if (!_dom.cq) {
-		_dom.cq_depth = __get_cq_depth();
-		grc = GNI_CqCreate(_dom.nic, _dom.cq_depth, 0, GNI_CQ_BLOCKING,
-				NULL, NULL, &_dom.cq);
-		if (grc) {
-			zap_ugni_log("ERROR: GNI_CqCreate() failed: %s\n",
-					gni_ret_str(grc));
-			rc = grc;
-			goto out;
-		}
-	}
-	rc = pthread_create(&cq_thread, NULL, cq_thread_proc, NULL);
-	if (rc) {
-		LOG("ERROR: pthread_create() failed: %d\n", rc);
-		goto out;
-	}
-	pthread_setname_np(cq_thread, "ugni:cq_proc");
 	zap_ugni_dom_initialized = 1;
 	rc = pthread_create(&error_thread, NULL, error_thread_proc, NULL);
 	if (rc) {
@@ -2417,25 +2164,6 @@ int init_once()
 	if (rc)
 		goto err;
 
-	if (!io_sched) {
-		io_sched = ovis_scheduler_new();
-		if (!io_sched) {
-			rc = errno;
-			goto err;
-		}
-	}
-
-	OVIS_EVENT_INIT(&stalled_timeout_ev);
-	stalled_timeout_ev.param.type = OVIS_EVENT_TIMEOUT;
-	stalled_timeout_ev.param.timeout.tv_sec = zap_ugni_stalled_timeout;
-	stalled_timeout_ev.param.cb_fn = stalled_timeout_cb;
-	stalled_timeout_ev.param.ctxt = NULL;
-	rc = ovis_scheduler_event_add(io_sched, &stalled_timeout_ev);
-
-	rc = pthread_create(&io_thread, NULL, io_thread_proc, 0);
-	if (rc)
-		goto err;
-
 	init_complete = 1;
 
 	return 0;
@@ -2446,32 +2174,19 @@ err:
 
 zap_ep_t z_ugni_new(zap_t z, zap_cb_fn_t cb)
 {
-	gni_return_t grc;
 	struct z_ugni_ep *uep = calloc(1, sizeof(*uep));
 	DLOG("Creating ep: %p\n", uep);
 	if (!uep) {
 		errno = ZAP_ERR_RESOURCE;
-		goto err0;
+		goto err_0;
 	}
 	uep->sock = -1;
 	uep->ep_id = -1;
-	uep->gni_cq = _dom.cq;
-
-	uep->rbuff = malloc(ZAP_UGNI_INIT_RECV_BUFF_SZ);
-	if (!uep->rbuff)
-		goto err1;
-	uep->rbuff->len = 0;
-	uep->rbuff->alen = ZAP_UGNI_INIT_RECV_BUFF_SZ - sizeof(*uep->rbuff);
-
-	STAILQ_INIT(&uep->sq);
-	LIST_INIT(&uep->post_desc_list);
-	grc = GNI_EpCreate(_dom.nic, _dom.cq, &uep->gni_ep);
-	if (grc) {
-		LOG("GNI_EpCreate() failed: %s\n", gni_ret_str(grc));
-		errno = ZAP_ERR_RESOURCE;
-		goto err2;
-	}
 	uep->node_id = -1;
+	uep->app_owned = 1;
+	uep->post_credit = ZAP_UGNI_EP_SQ_DEPTH;
+	STAILQ_INIT(&uep->pending_wrq);
+	STAILQ_INIT(&uep->submitted_wrq);
 	pthread_mutex_lock(&z_ugni_list_mutex);
 #ifdef DEBUG
 	uep->ep_id = zap_ugni_get_ep_id();
@@ -2479,32 +2194,28 @@ zap_ep_t z_ugni_new(zap_t z, zap_cb_fn_t cb)
 		LOG_(uep, "%s: %p: Failed to get the zap endpoint ID\n",
 				__func__, uep);
 		errno = ZAP_ERR_RESOURCE;
-		pthread_mutex_unlock(&z_ugni_list_mutex);
-		grc = GNI_EpDestroy(uep->gni_ep);
-		if (grc) {
-			LOG_(uep, "%s: %p: GNI_EpDestroy() failed: %s\n",
-					__func__, uep, gni_ret_str(grc));
-		}
-		goto err2;
+		goto err_1;
 	}
 #endif /* DEBUG */
 	LIST_INSERT_HEAD(&z_ugni_list, uep, link);
 	pthread_mutex_unlock(&z_ugni_list_mutex);
-	DLOG_(uep, "Created gni_ep: %p\n", uep->gni_ep);
+	CONN_LOG("new endpoint: %p\n", uep);
 	return (zap_ep_t)uep;
-err2:
-	free(uep->rbuff);
-err1:
+
+#ifdef DEBUG
+ err_1:
+	pthread_mutex_unlock(&z_ugni_list_mutex);
 	free(uep);
-err0:
+#endif /* DEBUG */
+ err_0:
 	return NULL;
 }
 
 static void z_ugni_destroy(zap_ep_t ep)
 {
 	struct z_ugni_ep *uep = (void*)ep;
-	struct zap_ugni_send_wr *wr;
 	DLOG_(uep, "destroying endpoint %p\n", uep);
+	CONN_LOG("destroying endpoint %p\n", uep);
 	pthread_mutex_lock(&z_ugni_list_mutex);
 	ZUGNI_LIST_REMOVE(uep, link);
 #ifdef DEBUG
@@ -2512,15 +2223,6 @@ static void z_ugni_destroy(zap_ep_t ep)
 		zap_ugni_ep_id[uep->ep_id] = 0;
 #endif /* DEBUG */
 	pthread_mutex_unlock(&z_ugni_list_mutex);
-
-	while (!STAILQ_EMPTY(&uep->sq)) {
-		wr = STAILQ_FIRST(&uep->sq);
-		STAILQ_REMOVE_HEAD(&uep->sq, link);
-		free(wr);
-	}
-
-	if (uep->rbuff)
-		free(uep->rbuff);
 
 	if (uep->conn_data) {
 		free(uep->conn_data);
@@ -2530,61 +2232,39 @@ static void z_ugni_destroy(zap_ep_t ep)
 		close(uep->sock);
 		uep->sock = -1;
 	}
-	__ep_release(uep);
+	z_ugni_ep_release(uep);
 	free(ep);
-}
-
-/* caller must hold uep->ep.lock */
-static zap_err_t __ugni_send_accept(struct z_ugni_ep *uep, char *buf, size_t len)
-{
-	zap_err_t zerr;
-	struct zap_ugni_msg_accepted msg = {
-		.hdr = {
-			.msg_type = htons(ZAP_UGNI_MSG_ACCEPTED),
-			.msg_len = htonl((uint32_t)(sizeof(msg) + len)),
-		},
-		.data_len = htonl(len),
-		.inst_id = htonl(_dom.inst_id),
-		.pe_addr = htonl(_dom.pe_addr),
-	};
-
-	DLOG_(uep, "Sending ZAP_UGNI_MSG_ACCEPTED\n");
-
-	zerr = __ugni_send_msg(uep, &msg.hdr, sizeof(msg), buf, len);
-	if (zerr)
-		return zerr;
-	return ZAP_ERR_OK;
 }
 
 zap_err_t z_ugni_accept(zap_ep_t ep, zap_cb_fn_t cb, char *data, size_t data_len)
 {
 	/* ep is the newly created ep from __z_ugni_conn_request */
 	struct z_ugni_ep *uep = (struct z_ugni_ep *)ep;
+	struct zap_ugni_msg msg;
 	zap_err_t zerr;
 
 	pthread_mutex_lock(&uep->ep.lock);
 
 	if (uep->ep.state != ZAP_EP_ACCEPTING) {
 		zerr = ZAP_ERR_ENDPOINT;
-		goto err;
+		goto out;
 	}
 
+	zap_get_ep(&uep->ep); /* will be put down when disconnected/conn_error */
 	uep->ep.cb = cb;
-
-	zerr = __ugni_send_accept(uep, data, data_len);
-	if (zerr) {
-		/*
-		 * shutdown() and return ZAP_ERR_OK
-		 * and let the ugni_sock_event()
-		 * deliver the CONNECT_ERROR event and cleanup and unbind the endpoint.
-		 * This is to avoid having multiple cleanup path.
-		 */
-		shutdown(uep->sock, SHUT_RDWR);
-	}
 	uep->app_accepted = 1;
-	pthread_mutex_unlock(&uep->ep.lock);
-	return ZAP_ERR_OK;
-err:
+
+	msg.hdr.msg_type = htons(ZAP_UGNI_MSG_ACCEPTED);
+	msg.accepted.ep_desc.inst_id = htonl(_dom.inst_id);
+	msg.accepted.ep_desc.pe_addr = htonl(_dom.pe_addr);
+	msg.accepted.ep_desc.smsg_attr = uep->local_smsg_attr;
+	zerr = z_ugni_smsg_send(uep, &msg, data, data_len);
+	if (zerr)
+		goto out;
+	zerr = ZAP_ERR_OK;
+	CONN_LOG("%p zap-accepted\n", uep);
+	/* let through */
+out:
 	pthread_mutex_unlock(&uep->ep.lock);
 	return zerr;
 }
@@ -2592,17 +2272,18 @@ err:
 static zap_err_t z_ugni_reject(zap_ep_t ep, char *data, size_t data_len)
 {
 	struct z_ugni_ep *uep = (struct z_ugni_ep *)ep;
+	struct zap_ugni_msg msg;
 	zap_err_t zerr;
 
+	msg.hdr.msg_type = htons(ZAP_UGNI_MSG_REJECTED);
 	pthread_mutex_lock(&uep->ep.lock);
 	uep->ep.state = ZAP_EP_ERROR;
-	zerr = __ugni_send(uep, ZAP_UGNI_MSG_REJECTED, data, data_len);
+	zerr = z_ugni_smsg_send(uep, &msg, data, data_len);
 	if (zerr)
 		goto err;
 	pthread_mutex_unlock(&uep->ep.lock);
 	return ZAP_ERR_OK;
 err:
-	shutdown(uep->sock, SHUT_RDWR);
 	pthread_mutex_unlock(&uep->ep.lock);
 	return zerr;
 }
@@ -2618,7 +2299,7 @@ z_ugni_map(zap_ep_t ep, zap_map_t *pm, void *buf, size_t len, zap_access_t acc)
 		goto err0;
 	}
 
-	grc = ugni_get_mh((void*)ep, buf, len, &map->gni_mh);
+	grc = ugni_get_mh(ep->z, &map->gni_mh);
 	if (grc) {
 		zerr = ZAP_ERR_RESOURCE;
 		goto err1;
@@ -2644,15 +2325,11 @@ static zap_err_t z_ugni_share(zap_ep_t ep, zap_map_t map,
 				const char *msg, size_t msg_len)
 {
 	zap_err_t rc;
+	struct z_ugni_ep *uep = (void*) ep;
 
 	/* validate */
-	if (ep->state != ZAP_EP_CONNECTED)
-		return ZAP_ERR_NOT_CONNECTED;
-
 	if (map->type != ZAP_MAP_LOCAL)
 		return ZAP_ERR_INVALID_MAP_TYPE;
-
-	struct z_ugni_ep *uep = (void*) ep;
 
 	/* node state validation */
 	if (_node_state.check_state) {
@@ -2676,27 +2353,31 @@ static zap_err_t z_ugni_share(zap_ep_t ep, zap_map_t map,
 		}
 	}
 
+	pthread_mutex_lock(&uep->ep.lock);
+	if (ep->state != ZAP_EP_CONNECTED) {
+		pthread_mutex_unlock(&uep->ep.lock);
+		return ZAP_ERR_NOT_CONNECTED;
+	}
+
 	/* prepare message */
 	struct zap_ugni_map *smap = (struct zap_ugni_map *)map;
-	struct zap_ugni_msg_rendezvous msgr = {
-		.hdr = {
-			.msg_type = htons(ZAP_UGNI_MSG_RENDEZVOUS),
-			.msg_len = htonl(sizeof(msgr) + msg_len),
-		},
-		.gni_mh = {
-			.qword1 = htobe64(smap->gni_mh.qword1),
-			.qword2 = htobe64(smap->gni_mh.qword2),
-		},
-		.addr = htobe64((uint64_t)map->addr),
-		.data_len = htonl(map->len),
-		.acc = htonl(map->acc),
-
+	struct zap_ugni_msg smsg = {
+		.rendezvous = {
+			.hdr = {
+				.msg_type = htons(ZAP_UGNI_MSG_RENDEZVOUS),
+			},
+			.gni_mh = {
+				.qword1 = htobe64(smap->gni_mh.qword1),
+				.qword2 = htobe64(smap->gni_mh.qword2),
+			},
+			.map_addr = htobe64((uint64_t)map->addr),
+			.map_len = htonl(map->len),
+			.acc = htonl(map->acc),
+		}
 	};
 
-	pthread_mutex_lock(&uep->ep.lock);
-	rc = __ugni_send_msg(uep, &msgr.hdr, sizeof(msgr), msg, msg_len);
+	rc = z_ugni_smsg_send(uep, &smsg, msg, msg_len);
 	pthread_mutex_unlock(&uep->ep.lock);
-
 	return rc;
 }
 
@@ -2744,18 +2425,6 @@ static zap_err_t z_ugni_read(zap_ep_t ep, zap_map_t src_map, char *src,
 		}
 	}
 
-	pthread_mutex_lock(&cq_full_lock);
-	while (ugni_post_count > _dom.cq_depth / 2) {
-		struct timespec timeout;
-		clock_gettime(CLOCK_REALTIME, &timeout);
-		timeout.tv_sec += 1;
-		pthread_cond_timedwait(&cq_full_cond, &cq_full_lock, &timeout);
-	}
-	__sync_fetch_and_add(&ugni_post_count, 1);
-	if (ugni_post_count > ugni_post_max)
-		ugni_post_max = ugni_post_count;
-	pthread_mutex_unlock(&cq_full_lock);
-
 	pthread_mutex_lock(&ep->lock);
 	if (!uep->gni_ep || ep->state != ZAP_EP_CONNECTED) {
 		zerr = ZAP_ERR_NOT_CONNECTED;
@@ -2763,11 +2432,12 @@ static zap_err_t z_ugni_read(zap_ep_t ep, zap_map_t src_map, char *src,
 	}
 
 	gni_return_t grc;
-	struct zap_ugni_post_desc *desc = __alloc_post_desc(uep);
-	if (!desc) {
+	struct z_ugni_wr *wr = z_ugni_alloc_post_desc(uep);
+	if (!wr) {
 		zerr = ZAP_ERR_RESOURCE;
 		goto out;
 	}
+	struct zap_ugni_post_desc *desc = wr->post_desc;
 
 	desc->post.type = GNI_POST_RDMA_GET;
 	desc->post.cq_mode = GNI_CQMODE_GLOBAL_EVENT;
@@ -2784,35 +2454,35 @@ static zap_err_t z_ugni_read(zap_ep_t ep, zap_map_t src_map, char *src,
 	__sync_fetch_and_add(&ugni_io_count, 1);
 #endif /* DEBUG */
 
-	pthread_mutex_lock(&ugni_lock);
-	if (uep->gni_cq == _dom.cq)
+	if (uep->post_credit) {
+		Z_GNI_API_LOCK(uep->ep.thread);
 		grc = GNI_PostRdma(uep->gni_ep, &desc->post);
-	else
-		grc = GNI_RC_ERROR_RESOURCE;
-	if (grc != GNI_RC_SUCCESS) {
-		LOG_(uep, "%s: GNI_PostRdma() failed, grc: %s\n",
-				__func__, gni_ret_str(grc));
-		__shutdown_on_error(uep);
+		Z_GNI_API_UNLOCK(uep->ep.thread);
+		if (grc != GNI_RC_SUCCESS) {
+			LOG_(uep, "%s: GNI_PostRdma() failed, grc: %s\n",
+					__func__, gni_ret_str(grc));
+			z_ugni_ep_error(uep);
 #ifdef DEBUG
-		__sync_sub_and_fetch(&ugni_io_count, 1);
+			__sync_sub_and_fetch(&ugni_io_count, 1);
 #endif /* DEBUG */
-		__free_post_desc(desc);
-		zerr = ZAP_ERR_RESOURCE;
-		pthread_mutex_unlock(&ugni_lock);
-		goto out;
+			z_ugni_free_post_desc(wr);
+			zerr = ZAP_ERR_RESOURCE;
+			goto out;
+		}
+		uep->post_credit--;
+		wr->state = Z_UGNI_WR_SUBMITTED;
+		/* add to the submitted list */
+		STAILQ_INSERT_TAIL(&uep->submitted_wrq, wr, entry);
+	} else {
+		/* no post credit, add to the pending list */
+		wr->state = Z_UGNI_WR_PENDING;
+		STAILQ_INSERT_TAIL(&uep->pending_wrq, wr, entry);
 	}
-	pthread_mutex_unlock(&ugni_lock);
+	/* no need to copy data to wr like send b/c the application won't touch
+	 * it until it get completion event */
 	zerr = ZAP_ERR_OK;
  out:
 	pthread_mutex_unlock(&ep->lock);
-	if (zerr) {
-		/* Return the CQ credit */
-		pthread_mutex_lock(&cq_full_lock);
-		__sync_sub_and_fetch(&ugni_post_count, 1);
-		assert((int)ugni_post_count >= 0);
-		pthread_cond_broadcast(&cq_full_cond);
-		pthread_mutex_unlock(&cq_full_lock);
-	}
 	return zerr;
 }
 
@@ -2861,29 +2531,18 @@ static zap_err_t z_ugni_write(zap_ep_t ep, zap_map_t src_map, char *src,
 		}
 	}
 
-	pthread_mutex_lock(&cq_full_lock);
-	while (ugni_post_count > _dom.cq_depth / 2) {
-		struct timespec timeout;
-		clock_gettime(CLOCK_REALTIME, &timeout);
-		timeout.tv_sec += 1;
-		pthread_cond_timedwait(&cq_full_cond, &cq_full_lock, &timeout);
-	}
-	__sync_fetch_and_add(&ugni_post_count, 1);
-	if (ugni_post_count > ugni_post_max)
-		ugni_post_max = ugni_post_count;
-	pthread_mutex_unlock(&cq_full_lock);
-
 	pthread_mutex_lock(&ep->lock);
 	if (!uep->gni_ep || ep->state != ZAP_EP_CONNECTED) {
 		zerr = ZAP_ERR_NOT_CONNECTED;
 		goto out;
 	}
 
-	struct zap_ugni_post_desc *desc = __alloc_post_desc(uep);
-	if (!desc) {
+	struct z_ugni_wr *wr = z_ugni_alloc_post_desc(uep);
+	if (!wr) {
 		zerr = ZAP_ERR_RESOURCE;
 		goto out;
 	}
+	struct zap_ugni_post_desc *desc = wr->post_desc;
 
 	desc->post.type = GNI_POST_RDMA_PUT;
 	desc->post.cq_mode = GNI_CQMODE_GLOBAL_EVENT;
@@ -2899,43 +2558,1316 @@ static zap_err_t z_ugni_write(zap_ep_t ep, zap_map_t src_map, char *src,
 #ifdef DEBUG
 	__sync_fetch_and_add(&ugni_io_count, 1);
 #endif /* DEBUG */
-	pthread_mutex_lock(&ugni_lock);
-	if (uep->gni_cq == _dom.cq)
+	if (uep->post_credit) {
+		Z_GNI_API_LOCK(uep->ep.thread);
 		grc = GNI_PostRdma(uep->gni_ep, &desc->post);
-	else
-		grc = GNI_RC_ERROR_RESOURCE;
-	if (grc != GNI_RC_SUCCESS) {
-		LOG_(uep, "%s: GNI_PostRdma() failed, grc: %s\n",
-				__func__, gni_ret_str(grc));
-		__shutdown_on_error(uep);
+		Z_GNI_API_UNLOCK(uep->ep.thread);
+		if (grc != GNI_RC_SUCCESS) {
+			LOG_(uep, "%s: GNI_PostRdma() failed, grc: %s\n",
+					__func__, gni_ret_str(grc));
+			z_ugni_ep_error(uep);
 #ifdef DEBUG
-		__sync_sub_and_fetch(&ugni_io_count, 1);
+			__sync_sub_and_fetch(&ugni_io_count, 1);
 #endif /* DEBUG */
-		__free_post_desc(desc);
-		zerr = ZAP_ERR_RESOURCE;
-		pthread_mutex_unlock(&ugni_lock);
-		goto out;
+			z_ugni_free_post_desc(wr);
+			zerr = ZAP_ERR_RESOURCE;
+			goto out;
+		}
+		uep->post_credit--;
+		wr->state = Z_UGNI_WR_SUBMITTED;
+		/* add to the submitted list */
+		STAILQ_INSERT_TAIL(&uep->submitted_wrq, wr, entry);
+	} else {
+		/* no post credit, add to the pending list */
+		wr->state = Z_UGNI_WR_PENDING;
+		STAILQ_INSERT_TAIL(&uep->pending_wrq, wr, entry);
 	}
-	pthread_mutex_unlock(&ugni_lock);
 	zerr = ZAP_ERR_OK;
 out:
 	pthread_mutex_unlock(&ep->lock);
-	if (zerr) {
-		/* Return the CQ credit */
-		pthread_mutex_lock(&cq_full_lock);
-		__sync_sub_and_fetch(&ugni_post_count, 1);
-		assert((int)ugni_post_count >= 0);
-		pthread_cond_broadcast(&cq_full_cond);
-		pthread_mutex_unlock(&cq_full_lock);
-	}
 	return zerr;
+}
+
+void z_ugni_io_thread_cleanup(void *arg)
+{
+	struct z_ugni_io_thread *thr = arg;
+	if (thr->cch)
+		GNI_CompChanDestroy(thr->cch);
+	if (thr->rcq)
+		GNI_CqDestroy(thr->rcq);
+	if (thr->scq)
+		GNI_CqDestroy(thr->scq);
+	if (thr->mbox_mh.qword1 || thr->mbox_mh.qword2)
+		GNI_MemDeregister(_dom.nic, &thr->mbox_mh);
+	if (thr->efd > -1)
+		close(thr->efd);
+	if (thr->zq_fd[0] > -1)
+		close(thr->zq_fd[0]);
+	if (thr->zq_fd[1] > -1)
+		close(thr->zq_fd[1]);
+	zap_io_thread_release(&thr->zap_io_thread);
+	free(thr);
+}
+
+static int z_ugni_enable_sock(struct z_ugni_ep *uep)
+{
+	struct z_ugni_io_thread *thr = (void*)uep->ep.thread;
+	struct epoll_event ev;
+	int rc;
+	if (uep->sock < 0) {
+		LOG("ERROR: %s:%d socket closed.\n", __func__, __LINE__);
+		return EINVAL;
+	}
+	ev.events = EPOLLIN|EPOLLOUT;
+	ev.data.ptr = &uep->sock_epoll_ctxt;
+	rc = epoll_ctl(thr->efd, EPOLL_CTL_ADD, uep->sock, &ev);
+	if (rc) {
+		LOG("ERROR: %s:%d epoll ADD error: %d.\n", __func__, __LINE__, errno);
+		return errno;
+	}
+	zap_get_ep(&uep->ep);
+	return 0;
+}
+
+static int z_ugni_disable_sock(struct z_ugni_ep *uep)
+{
+	/* Must hold uep->ep.lock */
+	struct z_ugni_io_thread *thr = (void*)uep->ep.thread;
+	struct epoll_event ignore;
+	if (uep->sock < 0)
+		return EINVAL;
+	CONN_LOG("%p disabling socket\n", uep);
+	epoll_ctl(thr->efd, EPOLL_CTL_DEL, uep->sock, &ignore);
+	close(uep->sock);
+	uep->sock = -1;
+	zap_put_ep(&uep->ep);
+	return 0;
+}
+
+/* Must hold uep->ep.lock */
+static int z_ugni_submit_pending(struct z_ugni_ep *uep)
+{
+	int rc;
+	gni_return_t grc;
+	struct z_ugni_wr *wr;
+ next:
+	if (!uep->post_credit)
+		goto out;
+	wr = STAILQ_FIRST(&uep->pending_wrq);
+	if (!wr)
+		goto out;
+	switch (wr->type) {
+	case Z_UGNI_WR_RDMA:
+		Z_GNI_API_LOCK(uep->ep.thread);
+		grc = GNI_PostRdma(uep->gni_ep, &wr->post_desc->post);
+		Z_GNI_API_UNLOCK(uep->ep.thread);
+		if (grc != GNI_RC_SUCCESS) {
+			LLOG("GNI_PostRdma() error: %d\n", grc);
+			rc = EIO;
+			goto err;
+		}
+		break;
+	case Z_UGNI_WR_SMSG:
+		Z_GNI_API_LOCK(uep->ep.thread);
+		grc = GNI_SmsgSend(uep->gni_ep, wr->send_wr->msg,
+				   wr->send_wr->msg_len, NULL, 0,
+				   wr->send_wr->msg_id);
+		Z_GNI_API_UNLOCK(uep->ep.thread);
+		if (grc == GNI_RC_NOT_DONE) {
+			/* no peer recv credit */
+			goto out;
+		}
+		if (grc != GNI_RC_SUCCESS) {
+			LLOG("GNI_SmsgSend() error: %d\n", grc);
+			rc = EIO;
+			goto err;
+		}
+		CONN_LOG("%p sent pending smsg %s\n", uep, zap_ugni_msg_type_str(ntohs(wr->send_wr->msg->hdr.msg_type)));
+		break;
+	default:
+		rc = EINVAL;
+		LLOG("Unexpected z_ugni_wr: %d\n", wr->type);
+		goto err;
+	}
+	uep->post_credit--;
+	assert(wr->state == Z_UGNI_WR_PENDING);
+	STAILQ_REMOVE(&uep->pending_wrq, wr, z_ugni_wr, entry);
+	STAILQ_INSERT_TAIL(&uep->submitted_wrq, wr, entry);
+	wr->state = Z_UGNI_WR_SUBMITTED;
+	goto next;
+ out:
+	return 0;
+ err:
+	return rc;
+}
+
+static int z_ugni_handle_scq_rdma(struct z_ugni_io_thread *thr, gni_cq_entry_t cqe)
+{
+	gni_return_t grc;
+	gni_post_descriptor_t *post;
+	struct z_ugni_wr *wr;
+	struct zap_ugni_post_desc *desc;
+	struct zap_event zev = {0};
+
+	post = NULL;
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	grc = GNI_GetCompleted(thr->scq, cqe, &post);
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	if (grc != GNI_RC_SUCCESS) {
+		LOG("GNI_GetCompleted() error: %d\n", grc);
+		return -1;
+	}
+	desc = (void*)post;
+	wr = __container_of(desc, struct z_ugni_wr, post_desc);
+	if (wr->state == Z_UGNI_WR_STALLED) {
+		/*
+		 * The descriptor is in the stalled state.
+		 *
+		 * The completion corresponding to the descriptor
+		 * has been flushed. The corresponding endpoint
+		 * might have been freed already.
+		 *
+		 * desc is in thr->stalled_wrq. The thread `thr` is the only
+		 * one accessing it. So, the mutex is not required.
+		 */
+		LOG("%s: Received a CQ event for a stalled post "
+					"desc.\n", desc->ep_name);
+		STAILQ_REMOVE(&thr->stalled_wrq, wr, z_ugni_wr, entry);
+		z_ugni_free_post_desc(wr);
+		goto out;
+	}
+	struct z_ugni_ep *uep = desc->uep;
+	if (!uep) {
+		/*
+		 * This should not happen. The code is put in to prevent
+		 * the segmentation fault and to record the situation.
+		 */
+		LOG("%s: %s: desc->uep = NULL. Drop the descriptor.\n", __func__,
+			desc->ep_name);
+		goto out;
+	}
+#ifdef DEBUG
+	if (uep->deferred_link.le_prev)
+		LOG_(uep, "uep %p: Doh!! I'm on the deferred list.\n", uep);
+#endif /* DEBUG */
+	zev.ep = &uep->ep;
+	switch (desc->post.type) {
+	case GNI_POST_RDMA_GET:
+		DLOG_(uep, "RDMA_GET: Read complete %p with %s\n", desc, gni_ret_str(grc));
+		if (grc) {
+			zev.status = ZAP_ERR_RESOURCE;
+			LOG_(uep, "RDMA_GET: completing "
+				"with error %s.\n",
+				gni_ret_str(grc));
+		} else {
+			zev.status = ZAP_ERR_OK;
+		}
+		zev.type = ZAP_EVENT_READ_COMPLETE;
+		zev.context = desc->context;
+		break;
+	case GNI_POST_RDMA_PUT:
+		DLOG_(uep, "RDMA_PUT: Write complete %p with %s\n",
+					desc, gni_ret_str(grc));
+		if (grc) {
+			zev.status = ZAP_ERR_RESOURCE;
+			DLOG_(uep, "RDMA_PUT: completing "
+				"with error %s.\n",
+				gni_ret_str(grc));
+		} else {
+			zev.status = ZAP_ERR_OK;
+		}
+		zev.type = ZAP_EVENT_WRITE_COMPLETE;
+		zev.context = desc->context;
+		break;
+	default:
+		LOG_(uep, "Unknown completion type %d.\n",
+				 desc->post.type);
+		z_ugni_ep_error(uep);
+	}
+	pthread_mutex_lock(&uep->ep.lock);
+	STAILQ_REMOVE(&uep->submitted_wrq, wr, z_ugni_wr, entry);
+	z_ugni_put_post_credit(uep);
+	z_ugni_submit_pending(uep);
+	pthread_mutex_unlock(&uep->ep.lock);
+	z_ugni_free_post_desc(wr);
+	uep->ep.cb(&uep->ep, &zev);
+ out:
+	return 0;
+}
+
+static int z_ugni_handle_rcq_smsg(struct z_ugni_io_thread *thr, gni_cq_entry_t cqe)
+{
+	/* NOTE: This is GNI "remote" completion. The cqe contains `remote_data`
+	 *       we sent to peer, which is our ep_idx. */
+	uint32_t ep_idx = GNI_CQ_GET_REM_INST_ID(cqe);
+	struct z_ugni_ep *uep;
+	gni_return_t grc;
+	int msg_type;
+
+	if (!ep_idx || ep_idx >= ZAP_UGNI_THREAD_EP_MAX) {
+		LLOG("Bad ep_idx: %d\n", ep_idx);
+		return EINVAL;
+	}
+	uep = thr->ep_idx[ep_idx].uep;
+	if (!uep)
+		return 0;
+	zap_get_ep(&uep->ep);
+ next:
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	grc = GNI_SmsgGetNext(uep->gni_ep, (void*)&uep->rmsg);
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	if (grc != GNI_RC_SUCCESS)
+		goto out;
+	msg_type = ntohs(uep->rmsg->hdr.msg_type);
+	CONN_LOG("%p smsg recv: %s (%d)\n", uep, zap_ugni_msg_type_str(msg_type), msg_type);
+	if (ZAP_UGNI_MSG_NONE < msg_type && msg_type < ZAP_UGNI_MSG_TYPE_LAST) {
+		process_uep_msg_fns[msg_type](uep);
+	} else {
+		process_uep_msg_unknown(uep);
+	}
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	GNI_SmsgRelease(uep->gni_ep);
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	goto next;
+ out:
+	pthread_mutex_lock(&uep->ep.lock);
+	z_ugni_submit_pending(uep);
+	pthread_mutex_unlock(&uep->ep.lock);
+	zap_put_ep(&uep->ep);
+	return 0;
+}
+
+static int z_ugni_handle_scq_smsg(struct z_ugni_io_thread *thr, gni_cq_entry_t cqe)
+{
+	/* NOTE: This is "local" smsg completion. The cqe contains msg_id that
+	 * we supplied when calling GNI_SmsgSend(). */
+	uint32_t msg_id = GNI_CQ_GET_MSG_ID(cqe);
+	uint16_t ep_idx = msg_id >> 16;
+	struct z_ugni_ep *uep;
+	struct z_ugni_wr *wr;
+	gni_return_t grc;
+	int rc;
+
+	if (!ep_idx || ep_idx >= ZAP_UGNI_THREAD_EP_MAX) {
+		LLOG("scq ep_idx out of range: %hu\n", ep_idx);
+		errno = EINVAL;
+		goto err;
+	}
+	uep = thr->ep_idx[ep_idx].uep;
+	pthread_mutex_lock(&uep->ep.lock);
+	STAILQ_FOREACH(wr, &uep->submitted_wrq, entry) {
+		if (wr->type == Z_UGNI_WR_SMSG && wr->send_wr->msg_id == msg_id)
+			break;
+	}
+	if (!wr) {
+		LLOG("msg_id not found: %u\n", msg_id);
+		errno = ENOENT;
+		pthread_mutex_unlock(&uep->ep.lock);
+		goto err;
+	}
+	STAILQ_REMOVE(&uep->submitted_wrq, wr, z_ugni_wr, entry);
+	z_ugni_free_send_wr(wr);
+	z_ugni_put_post_credit(uep);
+
+	grc = GNI_CQ_GET_STATUS(cqe);
+	if (grc) {
+		LLOG("GNI_SmsgSend completed with status: %d\n", grc);
+		z_ugni_ep_error(uep);
+		rc = EIO;
+	} else {
+		rc = z_ugni_submit_pending(uep);
+	}
+
+	pthread_mutex_unlock(&uep->ep.lock);
+	return rc;
+ err:
+	return errno;
+}
+
+static void z_ugni_handle_rcq_events(struct z_ugni_io_thread *thr)
+{
+	gni_cq_entry_t cqe;
+	gni_return_t grc;
+ next:
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	grc = GNI_CqGetEvent(thr->rcq, &cqe);
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	if (grc == GNI_RC_NOT_DONE)
+		goto out;
+	if (grc != GNI_RC_SUCCESS) {
+		LLOG("Unexpected error from GNI_CqGetEvent(): %d\n", grc);
+		goto out;
+	}
+	z_ugni_handle_rcq_smsg(thr, cqe);
+	goto next;
+ out:
+	return;
+}
+
+static struct z_ugni_ep *__cqe_uep(struct z_ugni_io_thread *thr,
+				   gni_cq_entry_t cqe)
+{
+	int ev_type = GNI_CQ_GET_TYPE(cqe);
+	uint32_t msg_id;
+	uint16_t ep_idx;
+	switch (ev_type) {
+	case GNI_CQ_EVENT_TYPE_POST:
+		ep_idx = GNI_CQ_GET_INST_ID(cqe);
+		return thr->ep_idx[ep_idx].uep;
+	case GNI_CQ_EVENT_TYPE_SMSG:
+		msg_id = GNI_CQ_GET_MSG_ID(cqe);
+		ep_idx = msg_id >> 16;
+		return thr->ep_idx[ep_idx].uep;
+	case GNI_CQ_EVENT_TYPE_MSGQ:
+	case GNI_CQ_EVENT_TYPE_DMAPP:
+	default:
+		LOG("Unexpected cq event: %d\n", ev_type);
+		assert(0 == "Unexpected cq event.");
+		break;
+	}
+}
+
+static void z_ugni_handle_scq_events(struct z_ugni_io_thread *thr)
+{
+	gni_cq_entry_t cqe;
+	gni_return_t grc;
+	uint64_t ev_type;
+#ifdef CONN_DEBUG
+	uint64_t ev_source;
+	uint64_t ev_status;
+	uint64_t ev_overrun;
+#endif
+
+ next:
+	cqe = 0;
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	grc = GNI_CqGetEvent(thr->scq, &cqe);
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	if (grc == GNI_RC_NOT_DONE)
+		goto out;
+	if (grc != GNI_RC_SUCCESS) {
+		struct z_ugni_ep *uep = __cqe_uep(thr, cqe);
+		if (uep) {
+			pthread_mutex_lock(&uep->ep.lock);
+			z_ugni_ep_error(uep);
+			pthread_mutex_unlock(&uep->ep.lock);
+		}
+		goto out;
+	}
+	ev_type = GNI_CQ_GET_TYPE(cqe);
+#ifdef CONN_DEBUG
+	ev_source = GNI_CQ_GET_SOURCE(cqe);
+	ev_status = GNI_CQ_GET_STATUS(cqe);
+	ev_overrun = GNI_CQ_OVERRUN(cqe);
+	LLOG("ev_type: %ld\n", ev_type);
+	LLOG("ev_source: %ld\n", ev_source);
+	LLOG("ev_status: %ld\n", ev_status);
+	LLOG("ev_overrun: %ld\n", ev_overrun);
+#endif
+	switch (ev_type) {
+	case GNI_CQ_EVENT_TYPE_POST:
+		z_ugni_handle_scq_rdma(thr, cqe);
+		break;
+	case GNI_CQ_EVENT_TYPE_SMSG:
+		z_ugni_handle_scq_smsg(thr, cqe);
+		break;
+	case GNI_CQ_EVENT_TYPE_MSGQ:
+	case GNI_CQ_EVENT_TYPE_DMAPP:
+	default:
+		LOG("Unexpected cq event: %d\n", ev_type);
+		assert(0 == "Unexpected cq event.");
+		break;
+	}
+	goto next;
+ out:
+	return ;
+}
+
+static void z_ugni_handle_cq_event(struct z_ugni_io_thread *thr, int events)
+{
+	gni_return_t grc;
+	gni_cq_handle_t cq;
+
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	grc = GNI_CompChanGetEvent(thr->cch, &cq);
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	if (grc != GNI_RC_SUCCESS) {
+		LOG("Unexpected error from GNI_CompChanGenEvent(): %d\n", grc);
+		assert(0 == "Unexpected error from GNI_CompChanGenEvent()");
+		return;
+	}
+
+	if (cq == thr->rcq)
+		z_ugni_handle_rcq_events(thr);
+	else if (cq == thr->scq)
+		z_ugni_handle_scq_events(thr);
+
+	/* re-arm */
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	grc = GNI_CqArmCompChan(&cq, 1);
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	if (grc != GNI_RC_SUCCESS) {
+		LOG("Unexpected error from GNI_CqArmCompChan(): %d\n", grc);
+		assert(0 == "Unexpected error from GNI_CompChanGenEvent()");
+	}
+}
+
+static void z_ugni_sock_conn_request(struct z_ugni_ep *uep)
+{
+	int rc;
+	zap_ep_t new_ep;
+	struct z_ugni_ep *new_uep;
+	zap_err_t zerr;
+	int sockfd;
+	struct sockaddr sa;
+	socklen_t sa_len = sizeof(sa);
+
+	CONN_LOG("handling socket connection request\n");
+
+	sockfd = accept(uep->sock, &sa, &sa_len);
+	if (sockfd < 0) {
+		LOG_(uep, "accept() error %d: in %s at %s:%d\n",
+				errno , __func__, __FILE__, __LINE__);
+		return;
+	}
+
+	rc = __set_sock_opts(sockfd);
+	if (rc) {
+		close(sockfd);
+		zerr = ZAP_ERR_TRANSPORT;
+		LOG_(uep, "Error %d: fail to set the sockbuf sz in %s.\n",
+				errno, __func__);
+		return;
+	}
+
+	new_ep = zap_new(uep->ep.z, uep->ep.cb);
+	if (!new_ep) {
+		close(sockfd);
+		zerr = errno;
+		LOG_(uep, "Zap Error %d (%s): in %s at %s:%d\n",
+				zerr, zap_err_str(zerr) , __func__, __FILE__,
+				__LINE__);
+		return;
+	}
+
+	CONN_LOG("new passive endpoint: %p\n", new_ep);
+
+	void *uctxt = zap_get_ucontext(&uep->ep);
+	zap_set_ucontext(new_ep, uctxt);
+	new_uep = (void*) new_ep;
+	new_uep->sock = sockfd;
+	new_uep->ep.state = ZAP_EP_ACCEPTING;
+	new_uep->app_owned = 0;
+
+	new_uep->sock_epoll_ctxt.type = Z_UGNI_SOCK_EVENT;
+
+	rc = zap_io_thread_ep_assign(new_ep);
+	if (rc) {
+		LOG_(new_uep, "thread assignment error: %d\n", rc);
+		zap_free(new_ep);
+		return;
+	}
+
+	rc = z_ugni_enable_sock(new_uep);
+	if (rc) {
+		zap_io_thread_ep_release(new_ep);
+		zap_free(new_ep);
+		return;
+	}
+
+	/*
+	 * NOTE: At this point, the connection is socket-connected. The next
+	 * step would be setting up GNI EP and SMSG service. The active side
+	 * will send z_ugni_sock_send_conn_req message over socket to initiate
+	 * the setup.
+	 */
+
+	return;
+}
+
+static void z_ugni_deliver_conn_error(struct z_ugni_ep *uep)
+{
+	/* uep->ep.lock must NOT be held */
+	struct zap_event zev = { .type = ZAP_EVENT_CONNECT_ERROR };
+	zev.ep = &uep->ep;
+	zev.status = zap_errno2zerr(errno);
+	zap_event_deliver(&zev);
+}
+
+/* uep->ep.lock MUST be held */
+static void __flush_wrq(struct z_ugni_ep *uep, struct z_ugni_wrq *head)
+{
+	struct zap_event zev = { .status = ZAP_ERR_FLUSH, .ep = &uep->ep };
+	struct z_ugni_wr *wr;
+	while ((wr = STAILQ_FIRST(head))) {
+		STAILQ_REMOVE_HEAD(head, entry);
+		if (wr->type == Z_UGNI_WR_RDMA) {
+			switch (wr->post_desc->post.type) {
+			case GNI_POST_RDMA_GET:
+				zev.type = ZAP_EVENT_READ_COMPLETE;
+				break;
+			case GNI_POST_RDMA_PUT:
+				zev.type = ZAP_EVENT_WRITE_COMPLETE;
+				break;
+			default:
+				assert(0 == "Unexpected post type");
+				continue;
+			}
+			zev.context = wr->post_desc->context;
+			pthread_mutex_unlock(&uep->ep.lock);
+			zap_event_deliver(&zev);
+			pthread_mutex_lock(&uep->ep.lock);
+		}
+		/* zap send/recv does not have completion events */
+	}
+}
+
+/* uep->ep.lock MUST be held */
+static void z_ugni_flush(struct z_ugni_ep *uep)
+{
+	__flush_wrq(uep, &uep->submitted_wrq);
+	__flush_wrq(uep, &uep->pending_wrq);
+}
+
+static int z_ugni_sock_send_conn_req(struct z_ugni_ep *uep)
+{
+	/* uep->ep.lock is held */
+	int n;
+	struct z_ugni_sock_msg_conn_req msg;
+
+	CONN_LOG("%p sock-sending conn_req\n", uep);
+
+	assert(uep->ep.state == ZAP_EP_CONNECTING);
+
+	msg.hdr.msg_len = htonl(sizeof(msg));
+	msg.hdr.msg_type = htons(ZAP_UGNI_MSG_CONNECT);
+	msg.ep_desc.inst_id = htonl(_dom.inst_id);
+	msg.ep_desc.pe_addr = htonl(_dom.pe_addr);
+	msg.ep_desc.remote_event = htonl(uep->ep_idx->idx);
+	memcpy(&msg.ep_desc.smsg_attr, &uep->local_smsg_attr, sizeof(msg.ep_desc.smsg_attr));
+	memcpy(msg.sig, ZAP_UGNI_SIG, sizeof(ZAP_UGNI_SIG));
+	ZAP_VERSION_SET(msg.ver);
+	n = write(uep->sock, &msg, sizeof(msg));
+	if (n != sizeof(msg)) {
+		uep->ep.state = ZAP_EP_ERROR;
+		z_ugni_disable_sock(uep);
+		/* post CONN_ERR event to zq */
+		z_ugni_zq_try_post(uep, 0, ZAP_EVENT_CONNECT_ERROR, ZAP_ERR_ENDPOINT);
+		return EIO;
+	}
+	return 0;
+}
+
+static int z_ugni_sock_send_conn_accept(struct z_ugni_ep *uep)
+{
+	/* NOTE: This is not the application accept message. It is a socket
+	 *       message agreeing to establish GNI SMSG communication. */
+	/* uep->ep.lock is held */
+	int n;
+	struct z_ugni_sock_msg_conn_accept msg;
+
+	CONN_LOG("%p sock-sending conn_accept\n", uep);
+
+	assert(uep->ep.state == ZAP_EP_ACCEPTING);
+
+	msg.hdr.msg_len = htonl(sizeof(msg));
+	msg.hdr.msg_type = htons(ZAP_UGNI_MSG_ACCEPTED);
+	msg.ep_desc.inst_id = htonl(_dom.inst_id);
+	msg.ep_desc.pe_addr = htonl(_dom.pe_addr);
+	msg.ep_desc.remote_event = htonl(uep->ep_idx->idx);
+	memcpy(&msg.ep_desc.smsg_attr, &uep->local_smsg_attr, sizeof(msg.ep_desc.smsg_attr));
+	n = write(uep->sock, &msg, sizeof(msg));
+	if (n != sizeof(msg)) {
+		assert(0 == "cannot write");
+		/* REASON: msg is super small and it is the only message to be
+		 *         sent on the socket. So, we expect it to successfully
+		 *         copied over to the kernel buffer in one go. */
+		uep->ep.state = ZAP_EP_ERROR;
+		z_ugni_disable_sock(uep);
+		return EIO;
+	}
+	return 0;
+}
+
+static int z_ugni_setup_conn(struct z_ugni_ep *uep, struct z_ugni_ep_desc *ep_desc)
+{
+	gni_return_t grc;
+	CONN_LOG("%p setting up GNI connection\n");
+	/* bind remote endpoint */
+	Z_GNI_API_LOCK(uep->ep.thread);
+	grc = GNI_EpBind(uep->gni_ep, ep_desc->pe_addr, ep_desc->inst_id);
+	Z_GNI_API_UNLOCK(uep->ep.thread);
+	if (grc != GNI_RC_SUCCESS) {
+		LOG_(uep, "GNI_EpBind() error: %d\n", grc);
+		goto out;
+	}
+	/* set remote event data as remote peer requested */
+	CONN_LOG("%p Setting event data, local: %x, remote: %x\n",
+			uep, uep->ep_idx->idx, ep_desc->remote_event);
+	Z_GNI_API_LOCK(uep->ep.thread);
+	grc = GNI_EpSetEventData(uep->gni_ep, uep->ep_idx->idx, ep_desc->remote_event);
+	Z_GNI_API_UNLOCK(uep->ep.thread);
+	if (grc != GNI_RC_SUCCESS) {
+		LOG_(uep, "GNI_EpSetEventData() error: %d\n", grc);
+		goto out;
+	}
+	/* smsg init */
+	memcpy(&uep->remote_smsg_attr, &ep_desc->smsg_attr, sizeof(ep_desc->smsg_attr));
+	Z_GNI_API_LOCK(uep->ep.thread);
+	grc = GNI_SmsgInit(uep->gni_ep, &uep->local_smsg_attr, &uep->remote_smsg_attr);
+	Z_GNI_API_UNLOCK(uep->ep.thread);
+	if (grc != GNI_RC_SUCCESS) {
+		LOG_(uep, "GNI_SmsgInit() error: %d\n", grc);
+		goto out;
+	}
+	CONN_LOG("%p GNI endpoint bound\n");
+	uep->ugni_ep_bound = 1;
+ out:
+	return gni_rc_to_errno(grc);
+}
+
+static void z_ugni_sock_recv(struct z_ugni_ep *uep)
+{
+	/* uep->ep.lock is held */
+	int n, mlen, rc;
+	zap_err_t zerr;
+	struct z_ugni_sock_msg_conn_req *conn_req;
+	struct z_ugni_sock_msg_conn_accept *conn_accept;
+
+	/* read full header first */
+	while (uep->sock_off < sizeof(struct zap_ugni_msg_hdr)) {
+		/* need to get the entire header to know the full msg len */
+		n = sizeof(struct zap_ugni_msg_hdr) - uep->sock_off;
+		n = read(uep->sock, uep->sock_buff.buff + uep->sock_off, n);
+		if (n < 0) {
+			if (errno == EAGAIN) /* this is OK */
+				return;
+			/* Otherwise, read error */
+			goto err;
+		}
+		uep->sock_off += n;
+	}
+	mlen = ntohl(uep->sock_buff.hdr.msg_len);
+	/* read entire message */
+	while (uep->sock_off < mlen) {
+		n = read(uep->sock, uep->sock_buff.buff + uep->sock_off,
+				    mlen - uep->sock_off);
+		if (n < 0) {
+			if (errno == EAGAIN) /* this is OK */
+				return;
+			/* Otherwise, read error */
+			goto err;
+		}
+		uep->sock_off += n;
+	}
+	/* network-to-host */
+	uep->sock_buff.hdr.msg_len = ntohl(uep->sock_buff.hdr.msg_len);
+	uep->sock_buff.hdr.msg_type = ntohs(uep->sock_buff.hdr.msg_type);
+	switch (uep->sock_buff.hdr.msg_type) {
+	case ZAP_UGNI_MSG_CONNECT:
+		/* validate version and signature */
+		conn_req = &uep->sock_buff.conn_req;
+		if (!ZAP_VERSION_EQUAL(conn_req->ver)) {
+			LOG_(uep, "zap_ugni: Receive conn request "
+				  "from an unsupported version "
+				  "%hhu.%hhu.%hhu.%hhu\n",
+				  conn_req->ver.major, conn_req->ver.minor,
+				  conn_req->ver.patch, conn_req->ver.flags);
+			goto err;
+		}
+		if (memcmp(conn_req->sig, ZAP_UGNI_SIG, sizeof(ZAP_UGNI_SIG))) {
+			LOG_(uep, "Expecting sig '%s', but got '%.*s'.\n",
+				  ZAP_UGNI_SIG, sizeof(conn_req->sig),
+				  conn_req->sig);
+			goto err;
+		}
+		conn_req->ep_desc.inst_id = ntohl(conn_req->ep_desc.inst_id);
+		conn_req->ep_desc.pe_addr = ntohl(conn_req->ep_desc.pe_addr);
+		conn_req->ep_desc.remote_event = ntohl(conn_req->ep_desc.remote_event);
+		if (uep->ep.state != ZAP_EP_ACCEPTING) {
+			LOG_(uep, "Get z_ugni_sock_msg_conn_req message while "
+				  "endpoint in %s state\n",
+				  __zap_ep_state_str(uep->ep.state));
+			goto err;
+		}
+		CONN_LOG("%p sock-recv conn_msg\n", uep);
+		rc = z_ugni_setup_conn(uep, &conn_req->ep_desc);
+		if (rc)
+			goto err;
+		rc = z_ugni_sock_send_conn_accept(uep);
+		if (rc)
+			goto err;
+		/* GNI SMSG established, socket not needed anymore */
+		z_ugni_disable_sock(uep);
+		break;
+	case ZAP_UGNI_MSG_ACCEPTED:
+		conn_accept = &uep->sock_buff.conn_accept;
+		conn_accept->ep_desc.inst_id = ntohl(conn_accept->ep_desc.inst_id);
+		conn_accept->ep_desc.pe_addr = ntohl(conn_accept->ep_desc.pe_addr);
+		conn_accept->ep_desc.remote_event = ntohl(conn_accept->ep_desc.remote_event);
+		if (uep->ep.state != ZAP_EP_CONNECTING) {
+			LOG_(uep, "Get z_ugni_sock_msg_conn_accept message "
+				  "while endpoint in %s state\n",
+				  __zap_ep_state_str(uep->ep.state));
+			goto err;
+		}
+		CONN_LOG("%p sock-recv conn_accept\n", uep);
+		rc = z_ugni_setup_conn(uep, &conn_accept->ep_desc);
+		if (rc)
+			goto err;
+		/* GNI SMSG established, socket not needed anymore */
+		z_ugni_disable_sock(uep);
+		zerr = z_ugni_send_connect(uep);
+		if (zerr) {
+			LOG_(uep, "z_ugni_send_connect() failed: %d\n", zerr);
+			goto err;
+		}
+		break;
+	default:
+		/* rogue message */
+		LOG_(uep, "Get unexpected message type: %d\n", uep->sock_buff.hdr.msg_type);
+		goto err;
+	}
+	return;
+ err:
+	z_ugni_disable_sock(uep);
+	switch (uep->ep.state) {
+	case ZAP_EP_CONNECTING:
+		uep->ep.state = ZAP_EP_ERROR;
+		pthread_mutex_unlock(&uep->ep.lock);
+		z_ugni_deliver_conn_error(uep);
+		pthread_mutex_lock(&uep->ep.lock);
+		break;
+	case ZAP_EP_ACCEPTING:
+		/* application does not know about this endpoint yet */
+		uep->ep.state = ZAP_EP_ERROR;
+		zap_put_ep(&uep->ep); /* b/c zap_new() in conn_req */
+		break;
+	default:
+		assert(0 == "Unexpected endpoint state");
+	}
+}
+
+static void z_ugni_sock_hup(struct z_ugni_ep *uep)
+{
+	z_ugni_disable_sock(uep);
+	if (uep->ugni_ep_bound) /* if gni_ep is bounded, ignore sock HUP */
+		return;
+	switch (uep->ep.state) {
+	case ZAP_EP_CONNECTING:
+		uep->ep.state = ZAP_EP_ERROR;
+		pthread_mutex_unlock(&uep->ep.lock);
+		z_ugni_deliver_conn_error(uep);
+		pthread_mutex_lock(&uep->ep.lock);
+		break;
+	case ZAP_EP_ACCEPTING:
+		/* application does not know about this endpoint yet */
+		uep->ep.state = ZAP_EP_ERROR;
+		zap_put_ep(&uep->ep); /* b/c zap_new() in conn_req */
+		break;
+	default:
+		assert(0 == "Unexpected endpoint state");
+	}
+}
+
+/* cm event over sock */
+static void z_ugni_handle_sock_event(struct z_ugni_ep *uep, int events)
+{
+	struct z_ugni_io_thread *thr = (void*)uep->ep.thread;
+	struct epoll_event ev;
+	zap_get_ep(&uep->ep);
+	pthread_mutex_lock(&uep->ep.lock);
+	if (uep->ep.state == ZAP_EP_LISTENING) {
+		/* This is a listening endpoint */
+		if (events != EPOLLIN) {
+			LOG("Listening endpoint expecting EPOLLIN(%d), "
+			    "but got: %d\n", EPOLLIN, events);
+			goto out;
+		}
+		z_ugni_sock_conn_request(uep);
+		goto out;
+	}
+	if (events & EPOLLHUP) {
+		z_ugni_sock_hup(uep);
+		goto out;
+	}
+	if (events & EPOLLOUT) {
+		/* just become sock-connected */
+		assert(uep->sock_connected == 0);
+		uep->sock_connected = 1;
+		CONN_LOG("uep %p becoming sock-connected\n", uep);
+		ev.events = EPOLLIN;
+		ev.data.ptr = &uep->sock_epoll_ctxt;
+		epoll_ctl(thr->efd, EPOLL_CTL_MOD, uep->sock, &ev);
+		if (uep->ep.state == ZAP_EP_CONNECTING) {
+			/* send connect message */
+			z_ugni_sock_send_conn_req(uep);
+		}
+	}
+	if ((events & EPOLLIN) && uep->sock >= 0) {
+		/* NOTE: sock may be disabled by z_ugni_sock_XXX(uep) above */
+		z_ugni_sock_recv(uep);
+	}
+ out:
+	pthread_mutex_unlock(&uep->ep.lock);
+	zap_put_ep(&uep->ep);
+}
+
+static void z_ugni_zq_post(struct z_ugni_io_thread *thr, struct z_ugni_ev *uev)
+{
+	static const char c = 1;
+	struct rbn *rbn;
+	uint64_t ts_min = -1;
+
+	assert(uev->in_zq == 0);
+	if (uev->in_zq) {
+		LLOG("WARNING: Trying to insert zq entry that is already in zq\n");
+		return;
+	}
+
+	pthread_mutex_lock(&thr->zap_io_thread.mutex);
+	rbn = rbt_min(&thr->zq);
+	if (rbn) {
+		ts_min = ((struct z_ugni_ev*)rbn)->ts_msec;
+	}
+	rbt_ins(&thr->zq, &uev->rbn);
+	uev->in_zq = 1;
+	if (uev->ts_msec < ts_min) /* notify the thread if wait time changed */
+		write(thr->zq_fd[1], &c, 1);
+	pthread_mutex_unlock(&thr->zap_io_thread.mutex);
+}
+
+/*
+ * type is ZAP_EVENT_CONNECTED, ZAP_EVENT_DISCONNECTED or
+ * ZAP_EVENT_CONNECT_ERROR.
+ */
+static void z_ugni_zq_try_post(struct z_ugni_ep *uep, uint64_t ts_msec, int type, int status)
+{
+	/* acquire the uep->uev */
+	if (__atomic_test_and_set(&uep->uev.acq, __ATOMIC_ACQUIRE)) {
+		/* Failed to acquire the event. This means that the `uev` has
+		 * already been used to post in zq. So, we can safely ignore
+		 * this. This can happen, for example, by application thread
+		 * calling `zap_close()` that races with on-going connect error
+		 * handling from zap ugni thread.
+		 */
+		return;
+	}
+	zap_get_ep(&uep->ep); /* will be put when uev is processed */
+	uep->uev.ts_msec = ts_msec;
+	rbn_init(&uep->uev.rbn, &uep->uev.ts_msec);
+	uep->uev.zev.ep = &uep->ep;
+	uep->uev.zev.type = type;
+	uep->uev.zev.status = status;
+	z_ugni_zq_post((void*)uep->ep.thread, &uep->uev);
+}
+
+static void z_ugni_zq_rm(struct z_ugni_io_thread *thr, struct z_ugni_ev *uev)
+{
+	struct z_ugni_ep *uep = container_of(uev, struct z_ugni_ep, uev);
+	static const char c = 1;
+	struct rbn *rbn;
+	uint64_t ts_min0 = -1, ts_min1 = -1;
+	assert(uev->in_zq == 1);
+	if (!uev->in_zq) {
+		LLOG("WARNING: Trying to remove zq entry that is not in zq\n");
+		return;
+	}
+	pthread_mutex_lock(&thr->zap_io_thread.mutex);
+	rbn = rbt_min(&thr->zq);
+	if (rbn) {
+		ts_min0 = ((struct z_ugni_ev*)rbn)->ts_msec;
+	}
+	rbt_del(&thr->zq, &uev->rbn);
+	uev->acq = 0;
+	uev->in_zq = 0;
+	rbn = rbt_min(&thr->zq);
+	if (rbn) {
+		ts_min1 = ((struct z_ugni_ev*)rbn)->ts_msec;
+	}
+	if (ts_min0 != ts_min1) /* notify the thread if wait time changed */
+		write(thr->zq_fd[1], &c, 1);
+	pthread_mutex_unlock(&thr->zap_io_thread.mutex);
+	zap_put_ep(&uep->ep); /* taken in __post_zq() */
+}
+
+/* return timeout in msec */
+static int z_ugni_handle_zq_events(struct z_ugni_io_thread *thr, int events)
+{
+	char c;
+	struct z_ugni_ep *uep;
+	struct z_ugni_ev *uev;
+	struct timespec ts;
+	uint64_t ts_msec;
+	int timeout = -1;
+	while (read(thr->zq_fd[0], &c, 1) == 1) {
+		/* clear the notification channel */ ;
+	}
+	pthread_mutex_lock(&thr->zap_io_thread.mutex);
+	while ((uev = (void*)rbt_min(&thr->zq))) {
+		clock_gettime(CLOCK_REALTIME, &ts);
+		ts_msec = ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+		if (ts_msec < uev->ts_msec) {
+			timeout = uev->ts_msec - ts_msec;
+			break;
+		}
+		assert(uev->in_zq == 1);
+		rbt_del(&thr->zq, &uev->rbn);
+		uev->in_zq = 0;
+		uev->acq = 0;
+		pthread_mutex_unlock(&thr->zap_io_thread.mutex);
+
+		uep = (void*)uev->zev.ep;
+		switch (uev->zev.type) {
+		case ZAP_EVENT_CONNECT_ERROR:
+		case ZAP_EVENT_DISCONNECTED:
+			zap_io_thread_ep_release(&uep->ep);
+			pthread_mutex_lock(&uep->ep.lock);
+			z_ugni_flush(uep);
+			pthread_mutex_unlock(&uep->ep.lock);
+			CONN_LOG("%p delivering last event: %s\n",
+				 uep, zap_event_str(uev->zev.type));
+			zap_event_deliver(&uev->zev);
+			zap_put_ep(&uep->ep); /* taken in z_ugni_connect()/z_ugni_accept() */
+			break;
+		default:
+			LLOG("Unexpected event in zq: %s(%d)\n",
+				zap_event_str(uev->zev.type),
+				uev->zev.type);
+			assert(0 == "Unexpected event in zq");
+		}
+
+		zap_put_ep(&uep->ep); /* taken in __post_zq() */
+		pthread_mutex_lock(&thr->zap_io_thread.mutex);
+	}
+	pthread_mutex_unlock(&thr->zap_io_thread.mutex);
+	return timeout;
+}
+
+static void *z_ugni_io_thread_proc(void *arg)
+{
+	struct z_ugni_io_thread *thr = arg;
+	static const int N_EV = 512;
+	int i, n;
+	int timeout;
+	struct z_ugni_epoll_ctxt *ctxt;
+	struct z_ugni_ep *uep;
+	struct epoll_event ev[N_EV];
+
+	pthread_cleanup_push(z_ugni_io_thread_cleanup, thr);
+
+ loop:
+	timeout = z_ugni_handle_zq_events(thr, ev[i].events);
+	zap_thrstat_wait_start(thr->zap_io_thread.stat);
+	n = epoll_wait(thr->efd, ev, N_EV, timeout);
+	zap_thrstat_wait_end(thr->zap_io_thread.stat);
+	for (i = 0; i < n; i++) {
+		ctxt = ev[i].data.ptr;
+		switch (ctxt->type) {
+		case Z_UGNI_CQ_EVENT:
+			z_ugni_handle_cq_event(thr, ev[i].events);
+			break;
+		case Z_UGNI_SOCK_EVENT:
+			uep = container_of(ctxt, struct z_ugni_ep, sock_epoll_ctxt);
+			z_ugni_handle_sock_event(uep, ev[i].events);
+			break;
+		case Z_UGNI_ZQ_EVENT:
+			z_ugni_handle_zq_events(thr, ev[i].events);
+			break;
+		default:
+			LOG("Unexpected type: %d\n", ctxt->type);
+			assert(0 == "Bad type!");
+			break;
+		}
+	}
+
+	goto loop;
+
+	pthread_cleanup_pop(1);
+
+	return NULL;
+}
+
+static int zqe_cmp(void *tree_key, const void *key)
+{
+	return (int*)tree_key - (int*)key;
+}
+
+zap_io_thread_t z_ugni_io_thread_create(zap_t z)
+{
+	int rc;
+	struct z_ugni_io_thread *thr;
+	struct epoll_event ev;
+
+	CONN_LOG("IO thread create\n");
+
+	thr = malloc(sizeof(*thr));
+	if (!thr)
+		goto err_0;
+	STAILQ_INIT(&thr->stalled_wrq);
+	rbt_init(&thr->zq, zqe_cmp);
+	CONN_LOG("zap thread initializing ...\n");
+	rc = zap_io_thread_init(&thr->zap_io_thread, z, "zap_ugni_io",
+			ZAP_ENV_INT(ZAP_THRSTAT_WINDOW));
+	CONN_LOG("zap thread initialized\n");
+	if (rc)
+		goto err_1;
+	CONN_LOG("ep_idx initializing ...\n");
+	z_ugni_ep_idx_init(thr);
+	CONN_LOG("setting up mbox ...\n");
+	rc = z_ugni_io_thread_mbox_setup(thr);
+	CONN_LOG("mbox setup done.\n");
+	if (rc)
+		goto err_2;
+	thr->efd = epoll_create1(O_CLOEXEC);
+	if (thr->efd < 0)
+		goto err_3;
+	/*
+	 * NOTE on GNI_CQ_BLOCKING
+	 * In order to use Completion Channel, GNI_CQ_BLOCKING is required.
+	 * `GNI_CqGetEvent()` is still a non-blocking call.
+	 */
+
+	/* For local/source completions (sends/posts) */
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	CONN_LOG("send CqCreate ...\n");
+	rc = GNI_CqCreate(_dom.nic, ZAP_UGNI_SCQ_DEPTH, 0, GNI_CQ_BLOCKING, NULL, NULL, &thr->scq);
+	CONN_LOG("send CqCreate ... done.\n");
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	if (rc != GNI_RC_SUCCESS) {
+		LLOG("GNI_CqCreate() failed: %s(%d)\n", gni_ret_str(rc), rc);
+		goto err_4;
+	}
+	/* For remote/destination completion (recv) */
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	CONN_LOG("recv CqCreate ...\n");
+	rc = GNI_CqCreate(_dom.nic, ZAP_UGNI_RCQ_DEPTH, 0, GNI_CQ_BLOCKING, NULL, NULL, &thr->rcq);
+	CONN_LOG("recv CqCreate ... done\n");
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	if (rc != GNI_RC_SUCCESS) {
+		LLOG("GNI_CqCreate() failed: %s(%d)\n", gni_ret_str(rc), rc);
+		goto err_5;
+	}
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	CONN_LOG("Registering mbox ...\n");
+	rc = GNI_MemRegister(_dom.nic, (uint64_t)thr->mbox,
+			     ZAP_UGNI_THREAD_EP_MAX * thr->mbox_sz, thr->rcq,
+			     GNI_MEM_READWRITE | GNI_MEM_RELAXED_PI_ORDERING,
+			     -1, &thr->mbox_mh);
+	CONN_LOG("Registering mbox ... done\n");
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	if (rc != GNI_RC_SUCCESS) {
+		LLOG("GNI_MemRegister() failed: %s(%d)\n", gni_ret_str(rc), rc);
+		goto err_6;
+	}
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	CONN_LOG("CompChanCreate ...\n");
+	rc = GNI_CompChanCreate(_dom.nic, &thr->cch);
+	CONN_LOG("CompChanCreate ... done\n");
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	if (rc) {
+		LLOG("GNI_CompChanCreate() failed: %s(%d)\n", gni_ret_str(rc), rc);
+		goto err_7;
+	}
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	CONN_LOG("Get CompChanFd ...\n");
+	rc = GNI_CompChanFd(thr->cch, &thr->cch_fd);
+	CONN_LOG("Get CompChanFd ... done\n");
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	if (rc) {
+		LLOG("GNI_CompChanFd() failed: %s(%d)\n", gni_ret_str(rc), rc);
+		goto err_8;
+	}
+	rc = __set_nonblock(thr->cch_fd);
+	if (rc)
+		goto err_8;
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	CONN_LOG("send-CQ CqAttachCompChan ...\n");
+	rc = GNI_CqAttachCompChan(thr->scq, thr->cch);
+	CONN_LOG("send-CQ CqAttachCompChan ... done\n");
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	if (rc) {
+		LLOG("GNI_CqAttachCompChan() failed: %s(%d)\n", gni_ret_str(rc), rc);
+		goto err_8;
+	}
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	CONN_LOG("recv-CQ CqAttachCompChan ...\n");
+	rc = GNI_CqAttachCompChan(thr->rcq, thr->cch);
+	CONN_LOG("recv-CQ CqAttachCompChan ... done\n");
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	if (rc) {
+		LLOG("GNI_CqAttachCompChan() failed: %s(%d)\n", gni_ret_str(rc), rc);
+		goto err_8;
+	}
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	CONN_LOG("Arming send-CQ ...\n");
+	rc = GNI_CqArmCompChan(&thr->scq, 1);
+	CONN_LOG("Arming send-CQ ... done\n");
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	if (rc) {
+		LLOG("GNI_CqArmCompChan() failed: %s(%d)\n", gni_ret_str(rc), rc);
+		goto err_8;
+	}
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	CONN_LOG("Arming recv-CQ ...\n");
+	rc = GNI_CqArmCompChan(&thr->rcq, 1);
+	CONN_LOG("Arming recv-CQ ... done\n");
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+	if (rc) {
+		LLOG("GNI_CqArmCompChan() failed: %s(%d)\n", gni_ret_str(rc), rc);
+		goto err_8;
+	}
+	CONN_LOG("Creating zq notification pipe ...\n");
+	rc = pipe2(thr->zq_fd, O_NONBLOCK|O_CLOEXEC);
+	CONN_LOG("Creating zq notification pipe ... done\n");
+	if (rc < 0) {
+		LLOG("pipe2() failed, errno: %d\n", errno);
+		goto err_8;
+	}
+
+	/* cq-epoll */
+	ev.events = EPOLLIN;
+	thr->cq_epoll_ctxt.type = Z_UGNI_CQ_EVENT;
+	ev.data.ptr = &thr->cq_epoll_ctxt;
+	CONN_LOG("Adding CompChanFd to epoll\n");
+	rc = epoll_ctl(thr->efd, EPOLL_CTL_ADD, thr->cch_fd, &ev);
+	if (rc)
+		goto err_9;
+
+	/* zq-epoll */
+	ev.events = EPOLLIN;
+	thr->zq_epoll_ctxt.type = Z_UGNI_ZQ_EVENT;
+	ev.data.ptr = &thr->zq_epoll_ctxt;
+	CONN_LOG("Adding zq fd to epoll\n");
+	rc = epoll_ctl(thr->efd, EPOLL_CTL_ADD, thr->zq_fd[0], &ev);
+	if (rc)
+		goto err_9;
+
+	CONN_LOG("Creating pthread\n");
+	rc = pthread_create(&thr->zap_io_thread.thread, NULL,
+			    z_ugni_io_thread_proc, thr);
+	if (rc)
+		goto err_9;
+	pthread_mutex_unlock(&ugni_lock);
+	pthread_setname_np(thr->zap_io_thread.thread, "zap_ugni_io");
+	CONN_LOG("returning.\n");
+	return &thr->zap_io_thread;
+
+ err_9:
+	close(thr->zq_fd[0]);
+	close(thr->zq_fd[1]);
+ err_8:
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	GNI_CompChanDestroy(thr->cch);
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+ err_7:
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	GNI_MemDeregister(_dom.nic, &thr->mbox_mh);
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+ err_6:
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	GNI_CqDestroy(thr->rcq);
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+ err_5:
+	Z_GNI_API_LOCK(&thr->zap_io_thread);
+	GNI_CqDestroy(thr->scq);
+	Z_GNI_API_UNLOCK(&thr->zap_io_thread);
+ err_4:
+	close(thr->efd);
+ err_3:
+	free(thr->mbox);
+ err_2:
+	zap_io_thread_release(&thr->zap_io_thread);
+ err_1:
+	free(thr);
+ err_0:
+	return NULL;
+}
+
+zap_err_t z_ugni_io_thread_cancel(zap_io_thread_t t)
+{
+	struct z_ugni_io_thread *thr = (void*)t;
+	int rc;
+	rc = pthread_cancel(t->thread);
+	switch (rc) {
+	case ESRCH: /* cleaning up structure w/o running thread b/c of fork */
+		thr->cch = 0;
+		thr->rcq = 0;
+		thr->scq = 0;
+		thr->mbox_mh.qword1 = 0;
+		thr->mbox_mh.qword2 = 0;
+		thr->efd = -1; /* b/c of O_CLOEXEC */
+		thr->zq_fd[0] = -1; /* b/c of O_CLOEXEC */
+		thr->zq_fd[1] = -1; /* b/c of O_CLOEXEC */
+		z_ugni_io_thread_cleanup(thr);
+	case 0:
+		return ZAP_ERR_OK;
+	default:
+		return ZAP_ERR_LOCAL_OPERATION;
+	}
+}
+
+zap_err_t z_ugni_io_thread_ep_assign(zap_io_thread_t t, zap_ep_t ep)
+{
+	/* assign ep_idx and mbox */
+	struct z_ugni_ep *uep = (void*)ep;
+	struct z_ugni_io_thread *thr = (void*)t;
+	zap_err_t zerr;
+	gni_return_t grc;
+	int rc;
+
+	CONN_LOG("assigning endpoint %p to thread %p\n", uep, t->thread);
+
+	pthread_mutex_lock(&t->mutex);
+
+	/* obtain idx */
+	rc = z_ugni_ep_idx_assign(uep);
+	if (rc) {
+		zerr = zap_errno2zerr(rc);
+		goto out;
+	}
+
+	/* setup local_smsg_attr */
+	uep->local_smsg_attr.msg_type = GNI_SMSG_TYPE_MBOX_AUTO_RETRANSMIT;
+	uep->local_smsg_attr.msg_buffer = thr->mbox;
+	uep->local_smsg_attr.buff_size = thr->mbox_sz;
+	uep->local_smsg_attr.mem_hndl = thr->mbox_mh;
+	uep->local_smsg_attr.mbox_maxcredit = ZAP_UGNI_EP_RQ_DEPTH;
+	uep->local_smsg_attr.msg_maxsize = ZAP_UGNI_MSG_SZ_MAX;
+	uep->local_smsg_attr.mbox_offset = thr->mbox_sz * uep->ep_idx->idx;
+
+	CONN_LOG("%p mbox_offset: %d\n", uep, uep->local_smsg_attr.mbox_offset);
+	CONN_LOG("%p mbox_idx: %d\n", uep,  uep->ep_idx->idx);
+
+	/* allocate GNI ednpoint. We need to do it here instead of zap_new()
+	 * because we don't know which cq to attached to yet. */
+	grc = GNI_EpCreate(_dom.nic, thr->scq, &uep->gni_ep);
+	if (grc) {
+		LOG("GNI_EpCreate() failed: %s\n", gni_ret_str(grc));
+		zerr = ZAP_ERR_RESOURCE;
+		goto out;
+	}
+	CONN_LOG("%p created gni_ep %p\n", uep, uep->gni_ep);
+	zerr = ZAP_ERR_OK;
+ out:
+	pthread_mutex_unlock(&t->mutex);
+	return zerr;
+}
+
+zap_err_t z_ugni_io_thread_ep_release(zap_io_thread_t t, zap_ep_t ep)
+{
+	/* release ep_idx and mbox */
+	pthread_mutex_lock(&t->mutex);
+	z_ugni_ep_idx_release((void*)ep);
+	pthread_mutex_unlock(&t->mutex);
+	z_ugni_ep_release((void*)ep);
+	return ZAP_ERR_OK;
 }
 
 zap_err_t zap_transport_get(zap_t *pz, zap_log_fn_t log_fn,
 			    zap_mem_info_fn_t mem_info_fn)
 {
 	zap_t z;
-	size_t sendrecv_sz, rendezvous_sz;
 	if (log_fn)
 		zap_ugni_log = log_fn;
 	if (!init_complete && init_once())
@@ -2945,12 +3877,7 @@ zap_err_t zap_transport_get(zap_t *pz, zap_log_fn_t log_fn,
 	if (!z)
 		goto err;
 
-	sendrecv_sz = sizeof(struct zap_ugni_msg_regular);
-	rendezvous_sz = sizeof(struct zap_ugni_msg_rendezvous);
-
-	/* max_msg is unused (since RDMA) ... */
-	z->max_msg = UGNI_SOCKBUF_SZ -
-			(sendrecv_sz<rendezvous_sz?rendezvous_sz:sendrecv_sz);
+	z->max_msg = ZAP_UGNI_MSG_SZ_MAX - sizeof(struct zap_ugni_msg);
 	z->new = z_ugni_new;
 	z->destroy = z_ugni_destroy;
 	z->connect = z_ugni_connect;
@@ -2965,6 +3892,10 @@ zap_err_t zap_transport_get(zap_t *pz, zap_log_fn_t log_fn,
 	z->unmap = z_ugni_unmap;
 	z->share = z_ugni_share;
 	z->get_name = z_get_name;
+	z->io_thread_create = z_ugni_io_thread_create;
+	z->io_thread_cancel = z_ugni_io_thread_cancel;
+	z->io_thread_ep_assign = z_ugni_io_thread_ep_assign;
+	z->io_thread_ep_release = z_ugni_io_thread_ep_release;
 
 	/* is it needed? */
 	z->mem_info_fn = mem_info_fn;
@@ -2976,3 +3907,17 @@ zap_err_t zap_transport_get(zap_t *pz, zap_log_fn_t log_fn,
 	return ZAP_ERR_RESOURCE;
 }
 
+void z_ugni_list_dump()
+{
+	struct z_ugni_ep *uep;
+	int n = 0;
+	pthread_mutex_lock(&z_ugni_list_mutex);
+	LOG("==== z_ugni_list_dump ====\n");
+	LIST_FOREACH(uep, &z_ugni_list, link) {
+		LOG("    uep: %p, state: %s(%d)\n", uep, __zap_ep_state_str(uep->ep.state), uep->ep.state);
+		n++;
+	}
+	LOG("    total: %d endpoints\n", n);
+	LOG("-------------------------\n");
+	pthread_mutex_unlock(&z_ugni_list_mutex);
+}

--- a/lib/src/zap/ugni/zap_ugni.h
+++ b/lib/src/zap/ugni/zap_ugni.h
@@ -66,18 +66,11 @@
 
 #define UGNI_SOCKBUF_SZ 1024 * 1024
 
-/**
- * \brief CQ size.
- */
-#define ZAP_UGNI_CQ_DEPTH	2048
-
 /*
  * The length of the string
  * lcl=<local ip address:port> <--> rmt=<remote ip address:port>
  */
 #define ZAP_UGNI_EP_NAME_SZ 64
-
-#define ZAP_UGNI_INIT_RECV_BUFF_SZ 4096
 
 struct zap_ugni_map {
 	struct zap_map map;
@@ -89,17 +82,27 @@ struct z_ugni_key {
 	struct zap_ugni_map *map; /**< reference to zap_map */
 };
 
+struct z_ugni_epoll_ctxt {
+	enum {
+		Z_UGNI_SOCK_EVENT, /* event from socket */
+		Z_UGNI_CQ_EVENT, /* event from cq channel */
+		Z_UGNI_ZQ_EVENT, /* event from zq (zap queue) channel */
+	} type;
+};
+
 /**
  * ZAP_UGNI message types.
  */
 typedef enum zap_ugni_msg_type {
 	ZAP_UGNI_MSG_NONE,        /**< Dummy first type */
 	ZAP_UGNI_MSG_CONNECT,     /**< Connect data */
-	ZAP_UGNI_MSG_REGULAR,     /**< Regular send-receive */
+	ZAP_UGNI_MSG_REGULAR,     /**< Application send-receive */
 	ZAP_UGNI_MSG_RENDEZVOUS,  /**< Share zap_map */
 	ZAP_UGNI_MSG_ACCEPTED,    /**< Connection accepted */
 	ZAP_UGNI_MSG_REJECTED,    /**< Connection rejected */
 	ZAP_UGNI_MSG_ACK_ACCEPTED,/**< Acknowledge accepted msg */
+	ZAP_UGNI_MSG_TERM,        /**< Connection termination request */
+	ZAP_UGNI_MSG_ACK_TERM,    /**< Acknowledge connection termination */
 	ZAP_UGNI_MSG_TYPE_LAST    /**< Dummy last type (for type count) */
 } zap_ugni_msg_type_t;
 
@@ -112,6 +115,8 @@ static const char *__zap_ugni_msg_type_str[] = {
 	[ZAP_UGNI_MSG_CONNECT]     =  "ZAP_UGNI_MSG_CONNECT",
 	[ZAP_UGNI_MSG_REJECTED]    =  "ZAP_UGNI_MSG_REJECTED",
 	[ZAP_UGNI_MSG_ACK_ACCEPTED]=  "ZAP_UGNI_MSG_ACK_ACCEPTED",
+	[ZAP_UGNI_MSG_TERM]        =  "ZAP_UGNI_MSG_TERM",
+	[ZAP_UGNI_MSG_ACK_TERM]    =  "ZAP_UGNI_MSG_ACK_TERM",
 	[ZAP_UGNI_MSG_TYPE_LAST]   =  "ZAP_UGNI_MSG_TYPE_LAST"
 };
 
@@ -193,45 +198,93 @@ struct zap_ugni_msg_rendezvous {
 	struct zap_ugni_msg_hdr hdr;
 	gni_mem_handle_t gni_mh;
 	zap_access_t acc;
-	uint64_t addr; /**< Address in the map */
-	uint32_t data_len; /**< Length */
+	uint64_t map_addr; /**< Address in the map */
+	uint32_t map_len; /**< Length */
 	char msg[OVIS_FLEX]; /**< Context */
 };
 
 /**
- * Message for zap connection accepted.
+ * Remote endpoint descriptor
  */
-struct zap_ugni_msg_accepted {
-	struct zap_ugni_msg_hdr hdr;
-	uint32_t inst_id; /**< inst_id of the accepter (passive side). */
-	uint32_t pe_addr; /**< peer address of the accepter (passive side). */
-	uint32_t data_len;
-	char data[OVIS_FLEX];
+struct z_ugni_ep_desc {
+	uint32_t inst_id; /**< peer inst_id */
+	uint32_t pe_addr; /**< peer address */
+	uint32_t remote_event; /**< `remote_event` for `GNI_EpSetEventData()` */
+	struct gni_smsg_attr smsg_attr; /**< recv buffer info */
 };
 
-static char ZAP_UGNI_SIG[8] = "UGNI";
+static char ZAP_UGNI_SIG[8] = "UGNI_2";
 
 /**
  * Message for zap connection.
+ *
+ * NOTE: Even though the `ver`, `sig`, and `ep_desc` are redundant to
+ *       those of `z_ugni_sock_msg_conn_req` that was sent at the beginning of
+ *       the connect operation, we keep these field around so that when we
+ *       discard the socket in the near future, we can use the connect message
+ *       right away.
  */
 struct zap_ugni_msg_connect {
 	struct zap_ugni_msg_hdr hdr;
 	char pad[12];  /**< padding so that ugni ver,xprt are aligned with sock ver,xprt */
+	struct zap_version ver; /* zap version */
+	char sig[8];     /**< transport type signature. */
+	struct z_ugni_ep_desc ep_desc; /**< Endpoint descriptor. */
+	uint32_t data_len; /**< Size of connection data */
+	char data[OVIS_FLEX];      /**< Connection data */
+};
+
+/**
+ * Message for zap connection accepted.
+ *
+ * NOTE: `ep_desc` is to be used in the near-future when we discard sockets.
+ */
+struct zap_ugni_msg_accepted {
+	struct zap_ugni_msg_hdr hdr;
+	struct z_ugni_ep_desc ep_desc; /**< Endpoint descriptor. */
+	uint32_t data_len;
+	char data[OVIS_FLEX];
+};
+
+typedef struct zap_ugni_msg {
+	union {
+		struct zap_ugni_msg_hdr hdr;
+		struct zap_ugni_msg_regular regular;
+		struct zap_ugni_msg_connect connect;
+		struct zap_ugni_msg_accepted accepted;
+		struct zap_ugni_msg_rendezvous rendezvous;
+	};
+} *zap_ugni_msg_t;
+
+/**
+ * Connection request socket message for setting up uGNI endpoints.
+ *
+ * We still need to be zap_sock aware to refuse the incorrect connection request
+ * from zap_sock.
+ */
+struct z_ugni_sock_msg_conn_req {
+	struct zap_ugni_msg_hdr hdr;
+	char pad[12];  /**< padding so that ugni ver,xprt are aligned with sock ver,xprt */
 	struct zap_version ver;
 	char sig[8];     /**< transport type signature. */
-	uint32_t inst_id; /**< inst_id of the requester (active side). */
-	uint32_t pe_addr; /**< peer address of the requester (active side). */
-	uint32_t data_len; /**< Connection data*/
-	char data[OVIS_FLEX];      /**< Size of connection data */
+	struct z_ugni_ep_desc ep_desc;
+};
+
+/**
+ * Conection accept socket message for setting up uGNI endpoints.
+ */
+struct z_ugni_sock_msg_conn_accept {
+	struct zap_ugni_msg_hdr hdr;
+	struct z_ugni_ep_desc ep_desc;
 };
 
 #pragma pack()
 
 struct zap_ugni_send_wr {
 	STAILQ_ENTRY(zap_ugni_send_wr) link;
-	off_t off; /* offset of to be written */
-	size_t alen; /* remaining length after data + off */
-	char data[OVIS_FLEX];
+	uint32_t msg_id; /* ep_idx(16-bit)|smsg_seq(16-bit) */
+	size_t msg_len;
+	struct zap_ugni_msg msg[OVIS_FLEX];
 };
 
 struct zap_ugni_recv_buff {
@@ -240,45 +293,10 @@ struct zap_ugni_recv_buff {
 	char data[OVIS_FLEX];
 };
 
-struct zap_ugni_post_desc;
-LIST_HEAD(zap_ugni_post_desc_list, zap_ugni_post_desc);
-struct z_ugni_ep {
-	struct zap_ep ep;
-
-	int sock;
-	int node_id;
-	int ep_id; /* The index in the endpoint array */
-	struct ovis_event_s io_ev;
-	struct ovis_event_s deferred_ev;
-	char *conn_data;
-	size_t conn_data_len;
-	uint8_t rejecting;
-	uint8_t sock_connected;
-	uint8_t app_accepted;
-	uint8_t ugni_ep_bound;
-	gni_ep_handle_t gni_ep;
-	gni_cq_handle_t gni_cq;
-
-	struct zap_ugni_post_desc_list post_desc_list;
-	struct zap_event conn_ev;
-
-	/*
-	 * The counter of retries to unbind the GNI endpoint
-	 */
-	int unbind_count;
-
-	STAILQ_HEAD(, zap_ugni_send_wr) sq; /* send queue */
-	struct zap_ugni_recv_buff *rbuff; /* recv buffer */
-
-	LIST_ENTRY(z_ugni_ep) link;
-	LIST_ENTRY(z_ugni_ep) deferred_link;
-
-#if defined(ZAP_DEBUG) || defined(DEBUG)
-
-#define UEP_EPOLL_RECORD_SZ 12
-	uint32_t epoll_record[UEP_EPOLL_RECORD_SZ];
-	uint32_t epoll_record_curr;
-#endif /* ZAP_DEBUG || DEBUG */
+struct z_ugni_ep_idx {
+	uint16_t idx; /* index to self */
+	uint16_t next_idx; /* next idx in the free list */
+	struct z_ugni_ep *uep;
 };
 
 struct zap_ugni_post_desc {
@@ -293,9 +311,171 @@ struct zap_ugni_post_desc {
 	LIST_ENTRY(zap_ugni_post_desc) stalled_link;
 };
 
-static inline struct z_ugni_ep *z_sock_from_ep(zap_ep_t *ep)
-{
-	return (struct z_ugni_ep *)ep;
-}
+struct z_ugni_wr {
+	STAILQ_ENTRY(z_ugni_wr) entry;
+	enum {
+		Z_UGNI_WR_RDMA,
+		Z_UGNI_WR_SMSG,
+	} type;
+	enum {
+		Z_UGNI_WR_INIT,
+		Z_UGNI_WR_PENDING,
+		Z_UGNI_WR_SUBMITTED,
+		Z_UGNI_WR_STALLED, /* submitted, but not completed before ep destroy */
+	} state;
+	union {
+		struct zap_ugni_post_desc post_desc[0];
+		struct zap_ugni_send_wr send_wr[0];
+	};
+};
+
+STAILQ_HEAD(z_ugni_wrq, z_ugni_wr);
+
+/* zap event entry primarily for deferred event */
+struct z_ugni_ev {
+	struct rbn rbn;
+	int in_zq; /* for debugging */
+	char acq; /* acquire flag */
+	uint64_t ts_msec; /* msec since the Epoch for timed event */
+	struct zap_event zev;
+};
+
+struct zap_ugni_post_desc;
+LIST_HEAD(zap_ugni_post_desc_list, zap_ugni_post_desc);
+struct z_ugni_ep {
+	struct zap_ep ep;
+
+	int sock;
+	int node_id;
+	int ep_id; /* The index in the endpoint array */
+	char *conn_data;
+	size_t conn_data_len;
+	uint8_t sock_connected:1;
+	uint8_t zap_connected:1; /* has become zap connected */
+	uint8_t app_owned:1;
+	uint8_t app_accepted:1;
+	uint8_t ugni_ep_bound:1; /* can use SMSG */
+	uint8_t ugni_term_sent:1; /* TERM msg has been sent */
+	uint8_t ugni_term_recv:1; /* TERM msg has been received */
+	uint8_t ugni_ack_term_sent:1; /* ACK_TERM msg has been sent */
+	uint8_t ugni_ack_term_recv:1; /* ACK_TERM msg has been received */
+	gni_ep_handle_t gni_ep;
+	gni_cq_handle_t gni_cq;
+
+	struct z_ugni_ev uev;
+	struct zap_event conn_ev;
+
+	/*
+	 * The counter of retries to unbind the GNI endpoint
+	 */
+	int unbind_count;
+
+	LIST_ENTRY(z_ugni_ep) link;
+	LIST_ENTRY(z_ugni_ep) deferred_link;
+
+#if defined(ZAP_DEBUG) || defined(DEBUG)
+
+#define UEP_EPOLL_RECORD_SZ 12
+	uint32_t epoll_record[UEP_EPOLL_RECORD_SZ];
+	uint32_t epoll_record_curr;
+#endif /* ZAP_DEBUG || DEBUG */
+
+	uint64_t next_msg_id;
+	uint16_t next_msg_seq;
+
+	gni_smsg_attr_t local_smsg_attr;
+	gni_smsg_attr_t remote_smsg_attr;
+
+	struct z_ugni_epoll_ctxt sock_epoll_ctxt;
+	union {
+		char buff[0];
+		struct zap_ugni_msg_hdr hdr;
+		struct z_ugni_sock_msg_conn_req conn_req;
+		struct z_ugni_sock_msg_conn_accept conn_accept;
+	} sock_buff;
+	int sock_off; /* offset into sock_buff */
+
+	struct z_ugni_ep_idx *ep_idx;
+	struct z_ugni_wrq pending_wrq;
+	struct z_ugni_wrq submitted_wrq;
+	int post_credit; /* post credit */
+
+	struct zap_ugni_msg *rmsg; /* current recv msg */
+};
+
+/* NOTE: This is the maximum entire message length submitted to GNI_SmsgSend().
+ * The `max_msg` length reported to the application is ZAP_UGNI_MSG_MAX -
+ * `max_hdr_len`. */
+#define ZAP_UGNI_MSG_SZ_MAX 2048
+
+#define ZAP_UGNI_THREAD_EP_MAX 8192 /* max endpoints per thread */
+#define ZAP_UGNI_EP_SQ_DEPTH 4
+#define ZAP_UGNI_EP_RQ_DEPTH 4
+#define ZAP_UGNI_SCQ_DEPTH (ZAP_UGNI_EP_SQ_DEPTH * ZAP_UGNI_THREAD_EP_MAX)
+#define ZAP_UGNI_RCQ_DEPTH (ZAP_UGNI_EP_RQ_DEPTH * ZAP_UGNI_THREAD_EP_MAX)
+#define ZAP_UGNI_EP_MBOX_SZ (ZAP_UGNI_EP_RQ_DEPTH * ZAP_UGNI_MSG_SZ_MAX)
+#define ZAP_UGNI_THR_MBOX_SZ (ZAP_UGNI_EP_MBOX_SZ * ZAP_UGNI_THREAD_EP_MAX)
+
+struct z_ugni_io_thread {
+	struct zap_io_thread zap_io_thread;
+	int efd; /* epoll file descriptor */
+	gni_cq_handle_t scq; /* Send completion queue: PostRdma, SmsgSend */
+	gni_cq_handle_t rcq; /* Recv completion queue: SmsgGetNext (recv) */
+	/* Remark on 2 CQs:
+	 *
+	 *   The FMA Short Messaging Overview page on Cray website stated the
+	 *   following:
+	 *
+	 *   > An application should use a dedicated CQ for remote events and
+	 *   > cannot rely on GNI_CQ_GET_TYPE to determine the type of the
+	 *   > incoming remote event. A receiving peer should use
+	 *   > GNI_CQ_GET_REM_INST_ID(event) to obtain the sender's instance ID.
+	 *   > See gni_cq_entry.
+	 *
+	 *   Ref:
+	 *   https://pubs.cray.com/bundle/XC_Series_GNI_and_DMAPP_API_User_Guide_CLE70UP02_S-2446/page/FMA_Short_Messaging_Overview.html
+	 *
+	 *   The smsg example (`smsg_send_pmi_example.c` in
+	 *   /opt/cray/ugni/default/examples/) also shows that the send
+	 *   completions are delivered on the endpoint's cq, and the recv
+	 *   completions are delivered on the mbox memory registration's cq. It
+	 *   looks like there is no way to differentiate the send completion
+	 *   from the recv completion if they were to register to the same cq.
+	 *
+	 *   GNI_CQ_GET_TYPE() only reports POST, SMSG, DMAPP, or MSGQ which
+	 *   does not tell whether the cqe is for a send or recv.
+	 *
+	 *   gni_cq_entry_t is uint64_t. For SMSG SEND completion on the SENDER
+	 *   the first 32-bit is the `msg_id` supplied to `GNI_SmsgSend()`. For
+	 *   the SMSG RECV completion, the same first 32-bit is the `inst_id` of
+	 *   the sender.
+	 *
+	 *   Since `GNI_GetComleted()` is only for GNI_Post(RDMA/FMA)
+	 *   completions, it looks like the `GNI_SmsgSend()` completion event
+	 *   has to rely on `inst_id/msg_id` from the cq entry.
+	 *
+	 *   REMARK: Not sure if GNI_CQ_GET_SOURCE() would help us differentiate
+	 *           the SEND/RECV. There is little documentation about it.
+	 */
+	gni_comp_chan_handle_t cch; /* Completion Channel */
+	int cch_fd; /* cq channel file descriptor */
+
+	struct z_ugni_epoll_ctxt cq_epoll_ctxt;
+
+	/* endpoint index resources, used for mapping GNI SMSG event to uep */
+	struct z_ugni_ep_idx ep_idx[ZAP_UGNI_THREAD_EP_MAX];
+	struct z_ugni_ep_idx *ep_idx_head, *ep_idx_tail;
+
+	/* mailboxes for endpoints in this thread */
+	uint32_t mbox_sz; /* size per mbox */
+	gni_mem_handle_t mbox_mh; /* memory handle for mbox */
+	char *mbox; /* mailboxes memory */
+
+	struct z_ugni_wrq stalled_wrq;
+
+	struct rbt zq; /* zap event queue, protected by zap_io_thread.mutex */
+	int zq_fd[2]; /* zap event queue fd (for epoll notification) */
+	struct z_ugni_epoll_ctxt zq_epoll_ctxt;
+};
 
 #endif

--- a/lib/src/zap/zap.c
+++ b/lib/src/zap/zap.c
@@ -81,6 +81,10 @@ int __zap_assert = 1;
 int __zap_assert = 0;
 #endif
 
+/* the busy threshold by thread utilization (0.0 - 1.0) */
+#define ZAP_IO_BUSY 0.8 /* default value */
+static double zap_io_busy = ZAP_IO_BUSY;
+
 static void default_log(const char *fmt, ...)
 {
 	va_list ap;
@@ -99,13 +103,6 @@ static void default_log(const char *fmt, ...)
 LIST_HEAD(zap_list, zap) zap_list;
 
 pthread_mutex_t zap_list_lock;
-
-static int zap_event_workers = ZAP_EVENT_WORKERS;
-static int zap_event_qdepth = ZAP_EVENT_QDEPTH;
-
-struct zap_event_queue *zev_queue;
-
-struct ovis_heap *zev_queue_heap;
 
 #ifndef PLUGINDIR
 #define PLUGINDIR "/usr/local/lib/ovis-lib"
@@ -253,9 +250,6 @@ zap_mem_info_t default_zap_mem_info(void)
 	return NULL;
 }
 
-static
-void zap_interpose_event(zap_ep_t ep, void *ctxt);
-
 zap_t zap_get(const char *name, zap_log_fn_t log_fn, zap_mem_info_fn_t mem_info_fn)
 {
 	char _libdir[MAX_ZAP_LIBPATH];
@@ -323,7 +317,8 @@ zap_t zap_get(const char *name, zap_log_fn_t log_fn, zap_mem_info_fn_t mem_info_
 	memcpy(z->name, name, strlen(name)+1);
 	z->log_fn = log_fn;
 	z->mem_info_fn = mem_info_fn;
-	z->event_interpose = zap_interpose_event;
+	pthread_mutex_init(&z->_io_mutex, NULL);
+	LIST_INIT(&z->_io_threads);
 
 	pthread_mutex_lock(&zap_list_lock);
 	LIST_INSERT_HEAD(&zap_list, z, zap_link);
@@ -371,87 +366,6 @@ void blocking_zap_cb(zap_ep_t zep, zap_event_t ev)
 	}
 }
 
-struct zap_interpose_ctxt {
-	struct zap_event ev;
-	unsigned char data[OVIS_FLEX];
-};
-
-/*
- * interposing a real callback, putting callback task into the queue.
- * Only read/write/recv completions are posted to the queue.
- */
-static
-void zap_interpose_cb(zap_ep_t ep, zap_event_t ev)
-{
-	struct zap_interpose_ctxt *ictxt;
-	uint32_t data_len = 0;
-
-	switch (ev->type) {
-	/* these events need data copy */
-	case ZAP_EVENT_RENDEZVOUS:
-	case ZAP_EVENT_REJECTED:
-	case ZAP_EVENT_CONNECTED:
-	case ZAP_EVENT_RECV_COMPLETE:
-	case ZAP_EVENT_CONNECT_REQUEST:
-		data_len = ev->data_len;
-		break;
-	/* these do not need data copy */
-	case ZAP_EVENT_CONNECT_ERROR:
-	case ZAP_EVENT_DISCONNECTED:
-	case ZAP_EVENT_READ_COMPLETE:
-	case ZAP_EVENT_WRITE_COMPLETE:
-		ev->data = NULL;
-		ev->data_len = 0;
-		/* do nothing */
-		break;
-	default:
-		assert(0);
-		break;
-	}
-
-	ictxt = calloc(1, sizeof(*ictxt) + data_len + 2);
-	if (!ictxt) {
-		DLOG(ep, "zap_interpose_cb(): ENOMEM\n");
-		return;
-	}
-	DLOG(ep, "%s: Vep %p: ictxt %p: ev type %s\n", __func__, ep,
-				ictxt, zap_event_str(ev->type));
-#ifdef TMP_DEBUG
-	ep->z->log_fn("%s: Vep %p: ictxt %p: ev type %s. q->depth = %d\n",
-				__func__, ep,
-				ictxt, zap_event_str(ev->type),
-				ep->event_queue->depth);
-#endif /* TMP_DEBUG */
-	ictxt->ev = *ev;
-	ictxt->ev.data = ictxt->data;
-	if (data_len)
-		memcpy(ictxt->data, ev->data, data_len);
-	zap_get_ep(ep);
-	if (zap_event_add(ep->event_queue, ep, ictxt)) {
-		ep->z->log_fn("%s[%d]: event could not be added.",
-			      __func__, __LINE__);
-		zap_put_ep(ep);
-	}
-}
-
-static
-void zap_interpose_event(zap_ep_t ep, void *ctxt)
-{
-	/* delivering real io event callback */
-	struct zap_interpose_ctxt *ictxt = ctxt;
-	DLOG(ep, "%s: ep %p: ictxt %p\n", __func__, ep, ictxt);
-#if defined(ZAP_DEBUG) || defined(DEBUG)
-	if (ep->state == ZAP_EP_CLOSE)
-		default_log("Delivering event after close.\n");
-#endif /* ZAP_DEBUG || DEBUG */
-	ep->app_cb(ep, &ictxt->ev);
-	free(ictxt);
-	zap_put_ep(ep);
-}
-
-static
-struct zap_event_queue *__get_least_busy_zap_event_queue();
-
 zap_ep_t zap_new(zap_t z, zap_cb_fn_t cb)
 {
 	zap_ep_t zep = NULL;
@@ -461,13 +375,11 @@ zap_ep_t zap_new(zap_t z, zap_cb_fn_t cb)
 	if (!zep)
 		return NULL;
 	zep->z = z;
-	zep->app_cb = cb;
-	zep->cb = zap_interpose_cb;
+	zep->cb = cb;
 	zep->ref_count = 1;
 	zep->state = ZAP_EP_INIT;
 	pthread_mutex_init(&zep->lock, NULL);
 	sem_init(&zep->block_sem, 0, 0);
-	zep->event_queue = __get_least_busy_zap_event_queue();
 	return zep;
 }
 
@@ -479,9 +391,8 @@ void zap_set_priority(zap_ep_t ep, int prio)
 zap_err_t zap_accept(zap_ep_t ep, zap_cb_fn_t cb, char *data, size_t data_len)
 {
 	zap_err_t zerr;
-	ep->app_cb = cb;
-	ep->cb = zap_interpose_cb;
-	zerr = ep->z->accept(ep, zap_interpose_cb, data, data_len);
+	ep->cb = cb;
+	zerr = ep->z->accept(ep, cb, data, data_len);
 	return zerr;
 }
 
@@ -591,7 +502,6 @@ void zap_put_ep(zap_ep_t ep)
 		return;
 	assert(ep->ref_count);
 	if (0 == __sync_sub_and_fetch(&ep->ref_count, 1)) {
-		zap_event_queue_ep_put(ep->event_queue);
 		ep->z->destroy(ep);
 	}
 }
@@ -690,77 +600,6 @@ int z_map_access_validate(zap_map_t map, char *p, size_t sz, zap_access_t acc)
 	return 0;
 }
 
-void *zap_event_thread_proc(void *arg)
-{
-	struct zap_event_queue *q = arg;
-	struct zap_event_entry *ent, *pent;
-loop:
-	pthread_mutex_lock(&q->mutex);
-	while (NULL == (pent = TAILQ_FIRST(&q->prio_q))
-	       &&
-	       NULL == (ent = TAILQ_FIRST(&q->queue))) {
-		zap_thrstat_wait_start(q->stats);
-		pthread_cond_wait(&q->cond_nonempty, &q->mutex);
-		zap_thrstat_wait_end(q->stats);
-	}
-	if (pent) {
-		TAILQ_REMOVE(&q->prio_q, pent, entry);
-		ent = pent;
-	} else {
-		TAILQ_REMOVE(&q->queue, ent, entry);
-	}
-	q->depth++;
-	pthread_cond_broadcast(&q->cond_vacant);
-	pthread_mutex_unlock(&q->mutex);
-	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
-	ent->ep->z->event_interpose(ent->ep, ent->ctxt);
-	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
-	free(ent);
-	goto loop;
-	return NULL;
-}
-
-int zap_event_add(struct zap_event_queue *q, zap_ep_t ep, void *ctxt)
-{
-	struct zap_event_entry *ent = malloc(sizeof(*ent));
-	if (!ent)
-		return errno;
-	ent->ep = ep;
-	ent->ctxt = ctxt;
-	pthread_mutex_lock(&q->mutex);
-	while (q->depth == 0) {
-		pthread_cond_wait(&q->cond_vacant, &q->mutex);
-	}
-	q->depth--;
-	if (ep->prio)
-		TAILQ_INSERT_TAIL(&q->prio_q, ent, entry);
-	else
-		TAILQ_INSERT_TAIL(&q->queue, ent, entry);
-
-	pthread_cond_broadcast(&q->cond_nonempty);
-	pthread_mutex_unlock(&q->mutex);
-	return 0;
-}
-
-void zap_event_queue_init(struct zap_event_queue *q, int qdepth,
-		const char *name, int stat_window)
-{
-	q->depth = qdepth;
-	q->ep_count = 0;
-	q->stats = zap_thrstat_new(name, stat_window);
-	assert(q->stats);
-	pthread_mutex_init(&q->mutex, NULL);
-	pthread_cond_init(&q->cond_nonempty, NULL);
-	pthread_cond_init(&q->cond_vacant, NULL);
-	TAILQ_INIT(&q->queue);
-	TAILQ_INIT(&q->prio_q);
-}
-
-void zap_event_queue_free(struct zap_event_queue *q)
-{
-	free(q);
-}
-
 int zap_env_int(char *name, int default_value)
 {
 	char *x = getenv(name);
@@ -774,43 +613,177 @@ int zap_env_int(char *name, int default_value)
 
 }
 
-static
-struct zap_event_queue *__get_least_busy_zap_event_queue()
+double zap_env_dbl(char *name, double default_value)
 {
-	int i;
-	struct zap_event_queue *q;
-	q = &zev_queue[0];
-	for (i = 1; i < zap_event_workers; i++) {
-		if (zev_queue[i].ep_count < q->ep_count) {
-			q = &zev_queue[i];
-		}
-	}
-	zap_event_queue_ep_get(q);
-	return q;
+	char *x = getenv(name);
+	if (!x)
+		return default_value;
+	return strtod(x, NULL);
+
 }
 
-int zap_term(int timeout_sec)
+static zap_err_t __io_thread_cancel(zap_io_thread_t t);
+int zap_term(zap_t z, int timeout_sec)
 {
-	int i, tmp;
+	int tmp, i, n;
 	int rc = 0;
 	struct timespec ts;
-	for (i = 0; i < zap_event_workers; i++) {
-		pthread_cancel(zev_queue[i].thread);
+	zap_io_thread_t t;
+	pthread_t *thr;
+
+	pthread_mutex_lock(&z->_io_mutex);
+	n = 0;
+	LIST_FOREACH(t, &z->_io_threads, _entry) {
+		n++;
 	}
-	if (timeout_sec > 0) {
-		ts.tv_sec = time(NULL) + timeout_sec;
-		ts.tv_nsec = 0;
+	thr = malloc(sizeof(*thr) * n);
+	if (!thr) {
+		rc = errno;
+		goto out;
 	}
-	for (i = 0; i < zap_event_workers; i++) {
+	i = 0;
+	while ((t = LIST_FIRST(&z->_io_threads))) {
+		thr[i++] = t->thread;
+		__io_thread_cancel(t); /* t is removed and invalidated */
+	}
+	/* join */
+	for (i = 0; i < n; i++) {
 		if (timeout_sec > 0) {
-			tmp = pthread_timedjoin_np(zev_queue[i].thread, NULL, &ts);
+			tmp = pthread_timedjoin_np(thr[i], NULL, &ts);
 			if (tmp)
 				rc = tmp;
 		} else {
-			pthread_join(zev_queue[i].thread, NULL);
+			pthread_join(thr[i], NULL);
 		}
 	}
+	free(thr);
+ out:
+	pthread_mutex_unlock(&z->_io_mutex);
 	return rc;
+}
+
+int zap_io_thread_init(zap_io_thread_t t, zap_t z, const char *name, int stat_window)
+{
+	t->stat = zap_thrstat_new(name, stat_window);
+	if (!t->stat)
+		return errno;
+	t->zap = z;
+	pthread_mutex_init(&t->mutex, NULL);
+	LIST_INIT(&t->_ep_list);
+	t->_n_ep = 0;
+	return 0;
+}
+
+int zap_io_thread_release(zap_io_thread_t t)
+{
+	if (t->stat)
+		zap_thrstat_free(t->stat);
+	pthread_mutex_destroy(&t->mutex);
+	return 0;
+}
+
+zap_err_t zap_event_deliver(zap_event_t ev)
+{
+	ev->ep->cb(ev->ep, ev);
+	return ZAP_ERR_OK;
+}
+
+static inline uint64_t timespec2usec(struct timespec *ts)
+{
+	return ts->tv_sec*1000000 + ts->tv_nsec/1000;
+}
+
+static zap_io_thread_t __io_thread_create(zap_t z)
+{
+	/* z->_io_mutex is held by the caller */
+
+	zap_io_thread_t t;
+	t = z->io_thread_create(z);
+	if (!t)
+		return NULL;
+	LIST_INSERT_HEAD(&z->_io_threads, t, _entry);
+	return t;
+}
+
+static zap_err_t __io_thread_cancel(zap_io_thread_t t)
+{
+	/* z->_io_mutex is held by the caller */
+	LIST_REMOVE(t, _entry);
+	return t->zap->io_thread_cancel(t);
+}
+
+static double zap_utilization(zap_thrstat_t in, struct timespec *now);
+
+static zap_io_thread_t __zap_least_busy_thread(zap_t z)
+{
+	zap_io_thread_t t = NULL, _t;
+	struct timespec now;
+	double u, min_u = 1.0; /* utilization <= 1.0 */
+
+	clock_gettime(CLOCK_REALTIME, &now);
+	pthread_mutex_lock(&z->_io_mutex);
+	LIST_FOREACH(_t, &z->_io_threads, _entry)
+	{
+		u = zap_utilization(_t->stat, &now);
+		if (u < min_u) {
+			t = _t;
+			min_u = u;
+		}
+	}
+	if (!t) {
+		t = __io_thread_create(z);
+	} else if (min_u > zap_io_busy) {
+		/* the least busy thread is too busy, create a new thread */
+		_t = __io_thread_create(z);
+		if (_t)
+			t = _t;
+		/* else, use the least busy one */
+	}
+	pthread_mutex_unlock(&z->_io_mutex);
+	return t;
+}
+
+zap_err_t zap_io_thread_ep_assign(zap_ep_t ep)
+{
+	zap_err_t zerr = ZAP_ERR_OK;
+	zap_t z = ep->z;
+	zap_io_thread_t t;
+
+	t = __zap_least_busy_thread(z);
+	if (!t) {
+		zerr = errno; /* expect zap_err_t in errno */
+		goto out;
+	}
+	pthread_mutex_lock(&t->mutex);
+	LIST_INSERT_HEAD(&t->_ep_list, ep, _entry);
+	t->_n_ep++;
+	pthread_mutex_unlock(&t->mutex);
+	ep->thread = t;
+	zerr = z->io_thread_ep_assign(t, ep);
+	if (zerr) {
+		ep->thread = NULL;
+		pthread_mutex_lock(&t->mutex);
+		LIST_REMOVE(ep, _entry);
+		t->_n_ep--;
+		pthread_mutex_unlock(&t->mutex);
+		goto out;
+	}
+ out:
+	return zerr;
+}
+
+zap_err_t zap_io_thread_ep_release(zap_ep_t ep)
+{
+	zap_err_t zerr;
+	zap_io_thread_t t = ep->thread;
+
+	pthread_mutex_lock(&t->mutex);
+	LIST_REMOVE(ep, _entry);
+	t->_n_ep--;
+	pthread_mutex_unlock(&t->mutex);
+	zerr = ep->z->io_thread_ep_release(ep->thread, ep);
+	ep->thread = NULL;
+	return zerr;
 }
 
 void zap_thrstat_reset(zap_thrstat_t stats)
@@ -826,6 +799,20 @@ void zap_thrstat_reset(zap_thrstat_t stats)
 static pthread_mutex_t thrstat_list_lock = PTHREAD_MUTEX_INITIALIZER;
 static LIST_HEAD(thrstat_list, zap_thrstat) thrstat_list;
 int thrstat_count = 0;
+
+void zap_thrstat_dump()
+{
+	zap_thrstat_t t;
+	struct timespec now;
+	double u;
+	clock_gettime(CLOCK_REALTIME, &now);
+	pthread_mutex_lock(&thrstat_list_lock);
+	LIST_FOREACH(t, &thrstat_list, entry) {
+		u = zap_utilization(t, &now);
+		printf("thrstat '%s', u: %lf\n", t->name, u);
+	}
+	pthread_mutex_unlock(&thrstat_list_lock);
+}
 
 void zap_thrstat_reset_all()
 {
@@ -1010,30 +997,28 @@ void zap_thrstat_free_result(struct zap_thrstat_result *res)
 
 static void init_atfork(void)
 {
-	int i;
-	int rc;
-	int stats_w;
+	zap_t z;
+	zap_io_thread_t t;
 
 	pthread_mutex_init(&zap_list_lock, 0);
 
-	stats_w = ZAP_ENV_INT(ZAP_THRSTAT_WINDOW);
-	zap_event_workers = ZAP_ENV_INT(ZAP_EVENT_WORKERS);
-	zap_event_qdepth = ZAP_ENV_INT(ZAP_EVENT_QDEPTH);
-
-	zev_queue = malloc(zap_event_workers * sizeof(*zev_queue));
-	assert(zev_queue);
-
-	for (i = 0; i < zap_event_workers; i++) {
-		char thread_name[16];
-		(void)snprintf(thread_name, 16, "zap:wkr:%hd", (short)i);
-		zap_event_queue_init(&zev_queue[i], zap_event_qdepth,
-					thread_name, stats_w);
-		rc = pthread_create(&zev_queue[i].thread, NULL,
-					zap_event_thread_proc, &zev_queue[i]);
-		assert(rc == 0);
-		pthread_setname_np(zev_queue[i].thread, thread_name);
-
+	zap_io_busy = ZAP_ENV_DBL(ZAP_IO_BUSY);
+	if (zap_io_busy < 0.0 || zap_io_busy > 1.0) {
+		/* bad value, set to default */
+		fprintf(stderr, "*** ERROR *** bad ZAP_IO_BUSY value: %lf, "
+				"the value must be in (0.0-1.0) range\n",
+				zap_io_busy);
+		zap_io_busy = ZAP_IO_BUSY;
 	}
+	pthread_mutex_lock(&zap_list_lock);
+	LIST_FOREACH(z, &zap_list, zap_link) {
+		pthread_mutex_lock(&z->_io_mutex);
+		while ((t = LIST_FIRST(&z->_io_threads))) {
+			__io_thread_cancel(t);
+		}
+		pthread_mutex_unlock(&z->_io_mutex);
+	}
+	pthread_mutex_unlock(&zap_list_lock);
 }
 
 #ifdef NDEBUG

--- a/lib/src/zap/zap.h
+++ b/lib/src/zap/zap.h
@@ -236,6 +236,12 @@ typedef struct zap_event {
 	size_t data_len;
 	/*! Application provided context */
 	void *context;
+
+	/** Event timestamp */
+	struct timespec ts;
+
+	/** Endpoint associated with the event */
+	zap_ep_t ep;
 } *zap_event_t;
 
 /**
@@ -676,15 +682,15 @@ const char* zap_event_str(enum zap_event_type e);
  * \retval 0         The threads terminated successfully.
  * \retval ETIMEDOUT A timeout occurred before the threads terminated.
  */
-int zap_term(int timeout_sec);
+int zap_term(zap_t z, int timeout_sec);
 
 /**
  * \brief The zap_thrstat_t handle maintains thread utilization data
- * 
+ *
  * This handle is created with the zap_thrstat_new() function and
  * freed with the zap_thrstat_free() function. The measurement
  * state can be reset with the zap_thrstat_reset() function.
- * 
+ *
  * Internally, zap_thrstat_t maintains a measurement window defined
  * by the window_size parameter to the zap_thrstat_new() function.
  * The window is an array of wait and processing time
@@ -715,7 +721,7 @@ zap_thrstat_t zap_thrstat_new(const char *name, int window_size);
 void zap_thrstat_free(zap_thrstat_t stats);
 /**
  * \brief Reset the thread utlization state data
- * 
+ *
  * Reset the measurement data held in the zap_thrstat_t instance.
  * Immediately after calling this function the internal sample_count
  * and window data are zero. It is not necessary to call this function
@@ -730,15 +736,15 @@ void zap_thrstat_reset_all();
 
 /**
  * \brief Begin an I/O wait measurement interval
- * 
+ *
  * The zap_thrstat_wait_start() and zap_thrstat_wait_end() annotate the
  * logic in the code that is waiting for I/O events. The time between
  * calls to zap_thrstat_wait_start() and zap_thrstat_wait_end() is the I/O
  * thread wait interval. The time between the call to zap_thrstat_wait_end()
  * and zap_thrstat_wait_start() is the processing interval.
- * 
+ *
  * Example usage:
- * 
+ *
  * void *io_thread_proc(void *)
  * {
  *    ...
@@ -778,13 +784,13 @@ struct zap_thrstat_result_entry {
 };
 
 struct zap_thrstat_result {
-	int count;	
+	int count;
 	struct zap_thrstat_result_entry entries[0];
 };
 
 /**
  * \brief Return thread utilization information
- * 
+ *
  * Returns a zap_thrstat_result structure or NULL on memory
  * allocation failure. This result must be freed with the
  * zap_thrstat_free_result() function.
@@ -800,7 +806,7 @@ void zap_thrstat_free_result(struct zap_thrstat_result *result);
 
 /**
  * \brief Return the name of the Zap stats handle
- * 
+ *
  * \returns The name provided to the zap_thrstat_new() function
  */
 const char *zap_thrstat_get_name(zap_thrstat_t stats);

--- a/lib/src/zap/zap_priv.h
+++ b/lib/src/zap/zap_priv.h
@@ -155,6 +155,8 @@ const char *zap_ep_state_str[] = {
 
 const char *__zap_ep_state_str(zap_ep_state_t state);
 
+typedef struct zap_io_thread *zap_io_thread_t;
+
 struct zap_ep {
 	zap_t z;
 	uint32_t ref_count;
@@ -170,10 +172,11 @@ struct zap_ep {
 	/** Event callback routine. */
 	zap_cb_fn_t cb;
 
-	zap_cb_fn_t app_cb;
+	/** The thread that the endpoint is assigned to. */
+	zap_io_thread_t thread;
 
-	/** Event queue */
-	struct zap_event_queue *event_queue;
+	/** (private to libzap) for thread->ep_list */
+	LIST_ENTRY(zap_ep) _entry;
 };
 
 struct zap {
@@ -235,9 +238,6 @@ struct zap {
 	zap_err_t (*get_name)(zap_ep_t ep, struct sockaddr *local_sa,
 			      struct sockaddr *remote_sa, socklen_t *sa_len);
 
-	/** Event interposer */
-	void (*event_interpose)(zap_ep_t ep, void *ctxt);
-
 	/** Transport message logging callback */
 	zap_log_fn_t log_fn;
 
@@ -246,6 +246,83 @@ struct zap {
 
 	/** Pointer to the transport's private data */
 	void *private;
+
+	/**
+	 * Create and start an IO thread.
+	 *
+	 * This API is called when libzap determines that a new IO thread for
+	 * the transport is required. The transport shall:
+	 *   1) allocate a zap_io_thread structure (or an extension of it),
+	 *   2) call `zap_io_thread_init()` to initialize the structure,
+	 *   3) perform additional transport-specific IO thread initialization,
+	 *   4) create and start a POSIX thread, and
+	 *   5) returns the `zap_io_thread` handle.
+	 *
+	 * The purpose of an IO thread is to process the low-level events from
+	 * associated endpoints, create zap events and deliver them to the
+	 * application. In addition, to collect thread statistics, libzap
+	 * requires the transport IO thread to call `zap_thrstat_wait_start()`
+	 * before it sleeps, and to call `zap_thrstat_wait_end()` when it wakes
+	 * up. The IO thread shall follow the following procedure:
+	 *   1) call `zap_thrstat_wait_start()`
+	 *   2) wait for an event or events from the associated endpoints,
+	 *   3) wake up on events then call `zap_thrstat_wait_end()`,
+	 *   4) process the events, converting them to zap events with
+	 *      timestamps from \c clock_gettime(),
+	 *   5) deliver zap events via \c zap_event_deliver(), and
+	 *   6) repeat from 1.
+	 *
+	 *
+	 * \retval thr  On success, the thread handle.
+	 * \retval NULL On failure. \c errno is also set to describe the error.
+	 */
+	zap_io_thread_t (*io_thread_create)(zap_t z);
+
+	/**
+	 * Terminate the IO thread.
+	 *
+	 * This API is called when libzap determines that the thread is no
+	 * longer needed. The transport shall terminate the thread and release
+	 * its resources, including the thread handle memory allocated in the
+	 * thread creation.
+	 *
+	 * \retval ZAP_ERR_OK On success.
+	 * \retval zerr A zap error code on failure.
+	 */
+	zap_err_t (*io_thread_cancel)(zap_io_thread_t t);
+
+	/**
+	 * Assign an endpoint to an IO thread.
+	 *
+	 * libzap calls this function to assign the endpoint \c ep to the thread
+	 * \c t. A thread may have multiple endpoints assigned to it.
+	 *
+	 * \retval ZAP_ERR_OK On success.
+	 * \retval zerr A zap error code on failure.
+	 */
+	zap_err_t (*io_thread_ep_assign)(zap_io_thread_t t, zap_ep_t ep);
+
+	/**
+	 * Release an endpoint from an IO thread.
+	 *
+	 * libzap calls this function to release the endpoint \c ep from the
+	 * thread \c t.
+	 *
+	 * \retval ZAP_ERR_OK On success.
+	 * \retval zerr A zap error code on failure.
+	 */
+	zap_err_t (*io_thread_ep_release)(zap_io_thread_t t, zap_ep_t ep);
+
+	/**
+	 * A collection of io threads of the tranport managed by libzap.
+	 *
+	 * The transport shall not access nor modify this data.
+	 */
+	LIST_HEAD(, zap_io_thread) _io_threads;
+
+	/** Mutex for _io_threads. */
+	pthread_mutex_t _io_mutex;
+
 };
 
 static inline zap_err_t
@@ -310,18 +387,63 @@ typedef zap_err_t (*zap_get_fn_t)(zap_t *pz, zap_log_fn_t log_fn,
  */
 int z_map_access_validate(zap_map_t map, char *p, size_t sz, zap_access_t acc);
 
-/* this is the default value for the number of zap_io_threads */
-#define ZAP_EVENT_WORKERS 4
+#define ZAP_ENV_INT(X) zap_env_int(#X, X)
 
-#define ZAP_EVENT_QDEPTH 4096
+/**
+ * Deliver an event to the application.
+ *
+ * The transport shall call this function in order to deliver an event to the
+ * application.
+ */
+zap_err_t zap_event_deliver(zap_event_t ev);
+
+/**
+ * Initialize the zap_io_thread structure.
+ *
+ * \param t The pointer to the \c zap_io_thread structure.
+ * \param z The associated zap handle.
+ * \param name The name of the thread.
+ * \param stat_window The window size of the thread statistics.
+ *
+ * \retval 0 If OK.
+ * \retval errno If error.
+ */
+int zap_io_thread_init(zap_io_thread_t t, zap_t z,
+		       const char *name, int stat_window);
+
+/**
+ * Release resources allocated in \c zap_io_thread_init().
+ */
+int zap_io_thread_release(zap_io_thread_t t);
 
 int zap_env_int(char *name, int default_value);
 #define ZAP_ENV_INT(X) zap_env_int(#X, X)
 
+double zap_env_dbl(char *name, double default_value);
+#define ZAP_ENV_DBL(X) zap_env_dbl(#X, X)
+
 /**
- * Add IO completion to the completion queue.
+ * Assign \c ep to a zap io thread.
+ *
+ * The transport shall call this function to assign the endpoint to an io
+ * thread. libzap will select the least busy thread, or create a
+ * new thread, and assign the endpoint \c ep to the thread.
+ * \c zap.io_thread_ep_assign() will be called subsequently.
+ *
+ * \retval ZAP_ERR_OK
+ * \retval ZAP_ERR_RESOURCE
+ * \retval ZAP_ERR_BUSY
  */
-int zap_event_add(struct zap_event_queue *q, zap_ep_t ep, void *ctxt);
+zap_err_t zap_io_thread_ep_assign(zap_ep_t ep);
+
+/**
+ * Release \c ep from the zap io thread.
+ *
+ * The transport shall call this function to release an endpoint from the
+ * associated io thread. \c zap.io_thread_ep_release() will also be called as a
+ * subsequence.
+ */
+zap_err_t zap_io_thread_ep_release(zap_ep_t ep);
 
 /*
  * The zap_thrstat structure maintains state for
@@ -342,5 +464,39 @@ struct zap_thrstat {
 	LIST_ENTRY(zap_thrstat) entry;
 };
 #define ZAP_THRSTAT_WINDOW 4096	/*< default window size */
+
+/**
+ * A structure describing a zap IO thread.
+ *
+ * The transport implementation may extend this structure to store
+ * transport-specific data for its IO threads.
+ *
+ * The fields beginning with "_" are considered private to libzap. The transport
+ * shall not modify such fields.
+ */
+struct zap_io_thread {
+	/** The thread handle.
+	 *
+	 *  When the transport creats a zap IO thread, it shall use this field
+	 *  to create the thread.
+	 */
+	pthread_t thread;
+
+	/** The transport handle. */
+	zap_t zap;
+
+	/** Primarily used to protect the _ep_list */
+	pthread_mutex_t mutex;
+
+	/** Thread statistics */
+	struct zap_thrstat *stat;
+
+	/** (private to libzap) for zap->_io_threads */
+	LIST_ENTRY(zap_io_thread) _entry;
+	/** (private to libzap) endpoint list */
+	LIST_HEAD(, zap_ep) _ep_list;
+	/** (private to libzap) number of associated endpoints */
+	int _n_ep;
+};
 
 #endif


### PR DESCRIPTION
    NOTE: Please see `lib/src/zap/ZAP_THREAD_NOTE.md` for an overview of
          the zap thread mechanism.
    
    [x] busy-ness calculation (using Tom's  thrstat)
    [x] sock
        [x] zap_test
        [x] ldmsd: samp->agg1->agg2 (w/sos)
        [x] all tests in ldms-test (sock)
    [x] rdma
        [x] samp - agg1 - agg2 - store test
        [x] flap samp (sniff)
        [x] flap agg1 (sniff)
            [x] flap agg2 (sniff)
        [x] fd check
            [x] ldms_ls - ldmsd test
    [x] ugni
       [x] ldmsd - ldms_ls
           - with debug print, the endpoint references are correct, the
             endpoints (both active and passive) are destroyed at the end.
       [x] samp - agg1 - agg2 - ldms_ls, with flapping agg1
       [x] samp (many sets) - agg1 - ldms_ls
       [x] scale test: many samp -> agg11+agg12 -> agg2
       [*] NOTE1: Need to protect GNI calls with the global `ugni_lock`.
           Not protecting them at all gave us SIGSEGV and SIGABRT down in
           the libugni. Protecting only the CQ of each thread using
           thread's own mutex also did not work. We got GNI_DlaDrain()
           hanged when we have multiple io threads.
       [*] NOTE2: `GNI_MemRegister()` call with recv CQ to register SMSG
           mbox memory took 0.6-0.7 seconds to complete. It is the source
           of the connection slowness seen by `ldms_ls`. Fortunately, this
           happens only once for each io thread initialization.
    [x] fabric over tcp: 64 samps -> 2 agg1 -> 1 agg2 - ldms_ls
    [x] fabric over verbs: 64 samps -> 2 agg1 -> 1 agg2 - ldms_ls
