### PR TITLE
Address build warnings (errors) when '-O2' is given

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -3278,7 +3278,7 @@ int ldms_register_notify_cb(ldms_t x, ldms_set_t s, int flags,
 void ldms_xprt_set_delete(ldms_set_t s, ldms_set_delete_cb_t cb_fn, void *cb_arg)
 {
 	struct ldms_request *req;
-	struct ldms_rbuf_desc *rbd, *next_rbd;
+	struct ldms_rbuf_desc *rbd, *next_rbd = NULL;
 	ldms_t xprt;
 	struct ldms_context *ctxt;
 	struct ldms_set *set = s->set;

--- a/ldms/src/ldmsd/ldmsctl.c
+++ b/ldms/src/ldmsd/ldmsctl.c
@@ -175,18 +175,23 @@ static void ldmsctl_buffer_free(ldmsctl_buffer_t buf)
 	free(buf);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Walloc-size-larger-than="
 static void ldmsctl_buffer_mem_append(ldmsctl_buffer_t buf, void *src, size_t n)
 {
 	if (buf->len - buf->off < n) {
-		buf->buf = realloc(buf->buf, buf->len + n);
-		if (!buf->buf) {
+		char *tmp = realloc(buf->buf, buf->len + n);
+		if (!tmp) {
 			fprintf(stderr, "Out of memory\n");
 			exit(ENOMEM);
 		}
+		buf->buf = tmp;
 		buf->len += n;
 	}
 	memcpy(&(buf->buf[buf->off]), src, n);
 }
+#pragma GCC diagnostic pop
 
 static void ldmsctl_recv_buf_new(void *data, size_t data_len)
 {
@@ -2252,7 +2257,7 @@ static int __handle_cmd(struct ldmsctl_ctrl *ctrl, char *cmd_str)
 	size_t msglen = 0;
 	rc = 0;
 	ldmsctl_buffer_t recv_buf;
-	int flags;
+	int flags = 0;
 
 	while (1) {
 		sem_wait(&ctrl->ldms_xprt.recv_sem);

--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -604,7 +604,7 @@ void kpublish(int map_fd, int set_no, int set_size, char *set_name)
 		return;
 	}
 	sh = meta_addr;
-	sprintf(sh->producer_name, "%s", myhostname);
+	snprintf(sh->producer_name, sizeof(sh->producer_name), "%.63s", myhostname);
 }
 
 pthread_t k_thread;

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -5585,6 +5585,8 @@ static char *__xprt_stats_as_json(size_t *json_sz)
 	struct ldms_xprt_rate_data rate_data;
 	int reset = 0;
 
+	(void)clock_gettime(CLOCK_REALTIME, &start);
+
 	ldms_xprt_rate_data(&rate_data, reset);
 
 	buff = malloc(sz);

--- a/ldms/src/sampler/dstat/dstat.c
+++ b/ldms/src/sampler/dstat/dstat.c
@@ -166,14 +166,15 @@ static char * compute_pidopts_schema(struct attr_value_list *kwl, struct attr_va
 		return strdup(schema_name);
 	}
 	schema_name = "dstat";
-	bsz = strlen(schema_name) + 16;
+	bsz = strlen(schema_name) + 18; /* len(schema_name) + len("_<HEX>") + 1 */
 	buf = malloc(bsz);
-	char hbuf[bsz];
-	memset(hbuf, 0, bsz);
+	if (!buf)
+		return NULL;
 	if (dosuffix) {
-		snprintf(hbuf, bsz, "_%x", pidopts);
+		snprintf(buf, bsz, "%s_%x", schema_name, pidopts);
+	} else {
+		snprintf(buf, bsz, "%s", schema_name);
 	}
-	snprintf(buf, bsz, "%s%s", schema_name, hbuf);
 	return buf;
 }
 

--- a/ldms/src/sampler/hello_stream/hello_sampler.c
+++ b/ldms/src/sampler/hello_stream/hello_sampler.c
@@ -102,7 +102,7 @@ static int hello_recv_cb(ldmsd_stream_client_t c, void *ctxt,
 			 json_entity_t entity)
 {
 	int rc = 0;
-	const char *type;
+	const char *type = "UNKNOWN";
 	switch (stream_type) {
 	case LDMSD_STREAM_JSON:
 		type = "JSON";

--- a/ldms/src/sampler/hweventpapi.c
+++ b/ldms/src/sampler/hweventpapi.c
@@ -468,8 +468,8 @@ static int string2attr_list_local(char *str, struct attr_value_list **__av_list,
 	struct attr_value_list **__kw_list)
 {
 	char *cmd_s;
-	struct attr_value_list *av_list;
-	struct attr_value_list *kw_list;
+	struct attr_value_list *av_list = NULL;
+	struct attr_value_list *kw_list = NULL;
 	int tokens, rc;
 
 	/*

--- a/ldms/src/sampler/procnetdev.c
+++ b/ldms/src/sampler/procnetdev.c
@@ -132,6 +132,9 @@ static int create_metric_set(base_data_t base)
 	   populated with 0 values for non existent ifaces. The metrics will appear
 	   in the order of the ifaces as specified */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wformat-truncation"
 	for (i = 0; i < niface; i++){
 		for (j = 0; j < NVARS; j++){
 			snprintf(metric_name, 128, "%s#%s", varname[j], iface[i]);
@@ -144,6 +147,7 @@ static int create_metric_set(base_data_t base)
 				mindex[i] = rc;
 		}
 	}
+#pragma GCC diagnostic pop
 
 	set = base_set_new(base);
 	if (!set) {

--- a/ldms/src/sampler/rapl.c
+++ b/ldms/src/sampler/rapl.c
@@ -98,7 +98,7 @@ static int find_rapl_component()
 static int create_metric_set(base_data_t base)
 {
 	ldms_schema_t schema;
-	int rc, rapl_event_count, rapl_cid;
+	int rc, rapl_event_count = 0, rapl_cid;
 	int event_code = PAPI_NULL;
 	int papi_event_set = PAPI_NULL;
 	char event_names[MAX_RAPL_EVENTS][PAPI_MAX_STR_LEN];

--- a/lib/src/ovis_util/util.c
+++ b/lib/src/ovis_util/util.c
@@ -115,9 +115,9 @@ char *str_repl_cmd(const char *_str)
 {
 	FILE *p = NULL;
 	char *str = strdup(_str);
+	char *buff = NULL;
 	if (!str)
 		goto err;
-	char *buff = NULL;
 	char *xbuff;
 	const char *eos = str + strlen(str);
 	size_t slen = 0; /* strlen of buff */

--- a/lib/src/zap/sock/zap_sock.c
+++ b/lib/src/zap/sock/zap_sock.c
@@ -577,7 +577,7 @@ static void process_sep_msg_read_req(struct z_sock_ep *sep)
 	uint32_t data_len;
 	char *src;
 	struct sock_msg_read_resp rmsg;
-	memset(&(rmsg.status), 0, sizeof(int32_t));
+	memset(&(rmsg.status), 0, sizeof(rmsg.status));
 	rmsg.dst_ptr = 0;
 
 	msg = sep->buff.data;

--- a/lib/src/zap/test/zap_test_reconnect.c
+++ b/lib/src/zap/test/zap_test_reconnect.c
@@ -307,7 +307,7 @@ void *send_msg(void *arg)
 	char data[512];
 
 	while (1) {
-		zap_ep_t ep;
+		zap_ep_t ep = NULL;
 		pthread_mutex_lock(&flag_lock);
 		if (flag != CONNECTED) {
 			if (flag == CONNECTING) {

--- a/lib/src/zap/zap.c
+++ b/lib/src/zap/zap.c
@@ -1011,7 +1011,7 @@ static void init_atfork(void)
 
 	for (i = 0; i < zap_event_workers; i++) {
 		char thread_name[16];
-		(void)snprintf(thread_name, 16, "zap:worker:%d", i);
+		(void)snprintf(thread_name, 16, "zap:wkr:%hd", (short)i);
 		zap_event_queue_init(&zev_queue[i], zap_event_qdepth,
 					thread_name, stats_w);
 		rc = pthread_create(&zev_queue[i].thread, NULL,


### PR DESCRIPTION
This patch addresses warnings, which become errors, found when building
with `CFLAGS='-O2 -Wall -Werror'` on CLE 7.0.UP02 (SuSE 15.1) system.