### PR TITLE
Fix rbd leak/infinite loop/crash in `ldms_set_delete()`

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -3314,11 +3314,9 @@ void ldms_xprt_set_delete(ldms_set_t s, ldms_set_delete_cb_t cb_fn, void *cb_arg
 	rbd = LIST_FIRST(&rbd_list);
 	while (rbd) {
 		xprt = ldms_xprt_get(rbd->xprt);
+		next_rbd = LIST_NEXT(rbd, set_link);
 		if (!xprt)
 			goto next_1;
-
-		next_rbd = LIST_NEXT(rbd, set_link);
-		LIST_REMOVE(rbd, set_link);
 
 		pthread_mutex_lock(&xprt->lock);
 
@@ -3353,6 +3351,7 @@ void ldms_xprt_set_delete(ldms_set_t s, ldms_set_delete_cb_t cb_fn, void *cb_arg
 		pthread_mutex_unlock(&xprt->lock);
 		ldms_xprt_put(xprt);
 	next_1:
+		LIST_REMOVE(rbd, set_link);
 		ref_put(&rbd->ref, "xprt_set_delete");
 		rbd = next_rbd;
 	}


### PR DESCRIPTION
`next_rbd` was not set before jumping to `next_1` label. If the first
`rbd` did not have `xprt`, then the loop stopped prematurely (as
`rbd = next_rbd` being NULL). If the first `rbd` had `xprt`, but one of
the other `rbd` did not have `xprt`, `rbd` value would stay the same
since `next_rbd` value won't change and `rbd = next_rbd`. This resulted
either in an inifinite loop (rbd won't be NULL) or a crash (too many
`ref_put()` on the `rbd`).