### PR TITLE
Resolve `-O2` warnings on `strncpy`

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2816,7 +2816,8 @@ static int __rbd_rbt_key_comp(void *tree_key, const void *key)
 void __ldms_xprt_init(struct ldms_xprt *x, const char *name,
 					ldms_log_fn_t log_fn)
 {
-	strncpy(x->name, name, LDMS_MAX_TRANSPORT_NAME_LEN);
+	x->name[LDMS_MAX_TRANSPORT_NAME_LEN - 1] = 0;
+	memccpy(x->name, name, 0, LDMS_MAX_TRANSPORT_NAME_LEN - 1);
 	x->ref_count = 1;
 	x->remote_dir_xid = x->local_dir_xid = 0;
 

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -5585,6 +5585,8 @@ static char *__xprt_stats_as_json(size_t *json_sz)
 	struct ldms_xprt_rate_data rate_data;
 	int reset = 0;
 
+	xprt_type[sizeof(xprt_type)-1] = 0; /* NULL-terminate at the end */
+
 	(void)clock_gettime(CLOCK_REALTIME, &start);
 
 	ldms_xprt_rate_data(&rate_data, reset);
@@ -5681,8 +5683,8 @@ static char *__xprt_stats_as_json(size_t *json_sz)
 					    (struct sockaddr *)&ss_local,
 					    (struct sockaddr *)&ss_remote,
 					    &socklen);
-			strncpy(xprt_type, ldms_xprt_type_name(op->op_min_xprt),
-				sizeof(xprt_type));
+			memccpy(xprt_type, ldms_xprt_type_name(op->op_min_xprt),
+				0, sizeof(xprt_type)-1);
 			inet_ntop(sin->sin_family, &sin->sin_addr, ip_str, sizeof(ip_str));
 		}
 		if (op->op_min_xprt)
@@ -5698,8 +5700,8 @@ static char *__xprt_stats_as_json(size_t *json_sz)
 					    (struct sockaddr *)&ss_local,
 					    (struct sockaddr *)&ss_remote,
 					    &socklen);
-			strncpy(xprt_type, ldms_xprt_type_name(op->op_max_xprt),
-				sizeof(xprt_type));
+			memccpy(xprt_type, ldms_xprt_type_name(op->op_max_xprt),
+				0, sizeof(xprt_type)-1);
 			inet_ntop(sin->sin_family, &sin->sin_addr, ip_str, sizeof(ip_str));
 		}
 		if (op->op_max_xprt)
@@ -5788,7 +5790,7 @@ static char * __thread_stats_as_json(size_t *json_sz)
 	res = zap_thrstat_get_result();
 	if (!res)
 		return NULL;
-		
+
 	buff = malloc(sz);
 	if (!buff)
 		goto __APPEND_ERR;
@@ -5869,7 +5871,7 @@ err:
  * {
  *   "prdcr_count" : <int>,
  *   "stopped" : <int>,
- *   "disconnected" : <int>, 
+ *   "disconnected" : <int>,
  *   "connecting" : <int>,
  * 	 "connected" : <int>,
  *   "stopping"	: <int>,
@@ -6006,7 +6008,7 @@ static char * __set_stats_as_json(size_t *json_sz)
 	(void)clock_gettime(CLOCK_REALTIME, &end);
 	uint64_t compute_time = ldms_timespec_diff_us(&start, &end);
 	__APPEND(" \"compute_time\": %ld\n", compute_time);
-	__APPEND("}"); 
+	__APPEND("}");
 
 	*json_sz = s - buff + 1;
 	return buff;

--- a/ldms/src/sampler/dstat/parse_stat.c
+++ b/ldms/src/sampler/dstat/parse_stat.c
@@ -127,7 +127,8 @@ int parse_proc_pid_stat(struct proc_pid_stat *s, const char *pid) {
 	commstart++;
 	if ((commend - commstart) >= COMM_SZ)
 		return ENAMETOOLONG;
-	strncpy(s->comm, commstart , COMM_SZ);
+	memccpy(s->comm, commstart , 0, COMM_SZ - 1);
+	s->comm[COMM_SZ-1] = 0;
 	rc = sscanf(dat, "%d", &s->pid);
 	if (rc != 1) {
 		return ENOKEY;
@@ -141,7 +142,7 @@ int parse_proc_pid_stat(struct proc_pid_stat *s, const char *pid) {
 		&s->state,
 		&s->ppid,
 		&s->pgrp,
-		&s->session, 
+		&s->session,
 		&s->tty_nr,
 		&s->tpgid,
 		&s->flags,
@@ -311,7 +312,7 @@ void dump_proc_pid_stat(struct proc_pid_stat *s)
 		s->state,
 		s->ppid,
 		s->pgrp,
-		s->session, 
+		s->session,
 		s->tty_nr,
 		s->tpgid,
 		s->flags,

--- a/ldms/src/store/papi/store_papi.c
+++ b/ldms/src/store/papi/store_papi.c
@@ -136,7 +136,13 @@ sos_handle_t create_handle(const char *path, sos_t sos)
 	sos_handle_t h = calloc(1, sizeof(*h));
 	if (!h)
 		return NULL;
-	strncpy(h->path, path, sizeof(h->path));
+	int len = strlen(path);
+	if (len >= sizeof(h->path)) {
+		errno = ENAMETOOLONG;
+		free(h);
+		return NULL;
+	}
+	memcpy(h->path, path, len+1);
 	h->ref_count = 1;
 	h->sos = sos;
 	rbt_init(&h->schema_tree, schema_cmp);
@@ -386,7 +392,7 @@ static sos_handle_t find_container(const char *path)
 static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct attr_value_list *avl)
 {
 	struct sos_instance *si;
-	int rc;
+	int rc, len;
 	char *value;
 	value = av_value(avl, "path");
 	if (!value) {
@@ -395,8 +401,15 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 		       __func__, __LINE__);
 		return EINVAL;
 	}
+	len = strlen(value);
+	if (len >= PATH_MAX) {
+		LOG_(LDMSD_LERROR,
+		       "%s[%d]: The 'path' is too long.\n",
+		       __func__, __LINE__);
+		return ENAMETOOLONG;
+	}
 	pthread_mutex_lock(&cfg_lock);
-	strncpy(root_path, value, PATH_MAX);
+	memcpy(root_path, value, len+1);
 
 	/*
 	 * Run through all open containers and close them. They will

--- a/ldms/src/store/slurm/store_slurm.c
+++ b/ldms/src/store/slurm/store_slurm.c
@@ -297,7 +297,13 @@ sos_handle_t create_handle(const char *path, sos_t sos)
 	sos_handle_t h = calloc(1, sizeof(*h));
 	if (!h)
 		return NULL;
-	strncpy(h->path, path, sizeof(h->path));
+	int len = strlen(path);
+	if (len >= sizeof(h->path)) {
+		errno = ENAMETOOLONG;
+		free(h);
+		return NULL;
+	}
+	memcpy(h->path, path, len+1);
 	h->ref_count = 1;
 	h->sos = sos;
 
@@ -408,7 +414,7 @@ static sos_handle_t find_container(const char *path)
 static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct attr_value_list *avl)
 {
 	struct sos_instance *si;
-	int rc;
+	int rc, len;
 	char *value;
 	value = av_value(avl, "verbosity");
 	if (!value) {
@@ -423,8 +429,15 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 		       __func__, __LINE__);
 		return EINVAL;
 	}
+	len = strlen(value);
+	if (len >= PATH_MAX) {
+		LOG_(LDMSD_LERROR,
+		       "%s[%d]: The 'path' is too long.\n",
+		       __func__, __LINE__);
+		return ENAMETOOLONG;
+	}
 	pthread_mutex_lock(&cfg_lock);
-	strncpy(root_path, value, PATH_MAX);
+	memcpy(root_path, value, len+1);
 
 	/*
 	 * Run through all open containers and close them. They will

--- a/lib/src/ovis_util/notification.c
+++ b/lib/src/ovis_util/notification.c
@@ -452,7 +452,7 @@ int ovis_notification_add(struct ovis_notification *onp, const char *msg)
 	}
 	e->buf_sz = len;
 	e->buf_done = 0;
-	strncpy(e->buf, msg, len-2);
+	memcpy(e->buf, msg, len-2);
 	e->buf[len-2] = '\n';
 	e->buf[len-1] = '\0';
 	e->time_in = get_sec();

--- a/lib/src/ovis_util/util.c
+++ b/lib/src/ovis_util/util.c
@@ -659,7 +659,7 @@ __attribute__ ((sentinel)) int ovis_join_buf(char *buf, size_t buflen, char *pat
 	if (!buf)
 		return EINVAL;
 	buf[0] = '\0';
-	
+
 
 	va_start(ap, pathsep);
 	n = va_arg(ap, const char *);
@@ -670,7 +670,7 @@ __attribute__ ((sentinel)) int ovis_join_buf(char *buf, size_t buflen, char *pat
 
 	chunk = strlen(n);
 	if ( (len + chunk) < buflen) {
-		strncat(buf + len, n, chunk);
+		memcpy(buf + len, n, chunk);
 		len += chunk;
 	} else {
 		rc = E2BIG;
@@ -678,7 +678,7 @@ __attribute__ ((sentinel)) int ovis_join_buf(char *buf, size_t buflen, char *pat
 
 	while ( 0 == rc && (n = va_arg(ap, const char *)) != NULL) {
 		if ((len + sepsize) < buflen) {
-			strncat(buf + len, sep, sepsize);
+			memcpy(buf + len, sep, sepsize);
 			len += sepsize;
 		} else {
 			rc = E2BIG;
@@ -686,7 +686,7 @@ __attribute__ ((sentinel)) int ovis_join_buf(char *buf, size_t buflen, char *pat
 		}
 		chunk = strlen(n);
 		if ((len + chunk) < buflen) {
-			strncat(buf + len, n, chunk);
+			memcpy(buf + len, n, chunk);
 			len += chunk;
 		} else {
 			rc = E2BIG;


### PR DESCRIPTION
On Cray Linux Environment (CLE) 7.0.UP02, gcc-9 seems to be the
preferred GNU C compiler. When '-O2' is supplied to the CFLAGS,
`-Werror=stringop-truncation` (which is not present in GCC 4.8.5 on
CentOS 7) is also enabled and gives the following warnings in many
places in our source tree (which results in error by `-Werror`):
```
    error: ‘strncpy’ specified bound <NUMBER> equals destination size
```

This patch addresses places where the warnings occur, and provides
length checking if necessary.