### PR TITLE
Implement tx2mon sampler plugin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -352,6 +352,20 @@ AS_IF([test "x$enable_papi" != xno],[
 AM_CONDITIONAL([HAVE_LIBPAPI], [test "x$HAVE_LIBPAPI" = xyes])
 AM_CONDITIONAL([HAVE_LIBPFM], [test "x$HAVE_LIBPFM" = xyes])
 
+# enable tx2mon by default only when sensible.
+AC_ARG_ENABLE([tx2mon],
+	[AS_HELP_STRING([--enable-tx2mon], [require components that depend upon tx2mon header) @<:@default=check@:>@])],
+	[],
+	[enable_tx2mon="check"])
+AS_IF([test "x$enable_tx2mon" != xno],[
+	AC_CHECK_HEADER([tx2mon/mc_oper_region.h], [HAVE_TX2MON=yes; enable_tx2mon=yes], [HAVE_TX2MON=no], [#include <stdint.h>])
+	AS_IF([test "x$enable_tx2mon" != xcheck],[
+		AS_IF([test "x$HAVE_TX2MON" = xno], [AC_MSG_ERROR([tx2mon headers not found. Install tx2mon package and (at runtime) kernel module on ThunderX2 platforms.])])
+	])
+])
+AM_CONDITIONAL([HAVE_TX2MON], [test "x$HAVE_TX2MON" = xyes])
+AM_CONDITIONAL([ENABLE_TX2MON], [test "$enable_tx2mon" = "yes"])
+
 if test -z "$ENABLE_KOKKOS_TRUE"; then
 	dnl kokkos needs sos (not the storesos).
 	CHECK_SOS=1
@@ -791,6 +805,7 @@ ldms/src/sampler/spank/Makefile
 ldms/src/sampler/papi/Makefile
 ldms/src/sampler/appinfo_lib/Makefile
 ldms/src/sampler/kgnilnd/Makefile
+ldms/src/sampler/tx2mon/Makefile
 ldms/src/sampler/meminfo/Makefile
 ldms/src/sampler/procinterrupts/Makefile
 ldms/src/sampler/variable/Makefile

--- a/ldms/scripts/examples/tx2mon
+++ b/ldms/scripts/examples/tx2mon
@@ -1,0 +1,28 @@
+export plugname=tx2mon
+portbase=61086
+VGARGS="--leak-check=full --track-origins=yes"
+DAEMONS $(seq 1 6)
+vgoff
+LDMSD -p prolog.sampler 1
+LDMSD 2 3 4 5
+LDMSD -p prolog.sampler 6
+vgoff
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1 -v
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2 -v
+MESSAGE ldms_ls on host 3:
+LDMS_LS 3 -v
+MESSAGE ldms_ls on host 4:
+LDMS_LS 4 -v
+MESSAGE ldms_ls on host 5:
+LDMS_LS 5 -v
+MESSAGE ldms_ls on host 6:
+LDMS_LS 6 -l
+LDMS_LS 6 -v
+SLEEP 5
+KILL_LDMSD `seq 6`
+file_created $STOREDIR/node/$testname
+file_created $STOREDIR/node/${testname}_01
+file_created $STOREDIR/node/${testname}_10_*
+file_created $STOREDIR/node/${testname}_11_*

--- a/ldms/scripts/examples/tx2mon.2
+++ b/ldms/scripts/examples/tx2mon.2
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} auto-schema=1
+start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/tx2mon.3
+++ b/ldms/scripts/examples/tx2mon.3
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} instance=localhost${i}/${testname} component_id=${i} auto-schema=1 array=1
+start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/tx2mon.4
+++ b/ldms/scripts/examples/tx2mon.4
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} instance=localhost${i}/${testname} component_id=${i} auto-schema=1 extra=1
+start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/tx2mon.5
+++ b/ldms/scripts/examples/tx2mon.5
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} instance=localhost${i}/${testname} component_id=${i} auto-schema=1 array=1 extra=1
+start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/tx2mon.6
+++ b/ldms/scripts/examples/tx2mon.6
@@ -1,0 +1,47 @@
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_start name=localhost1
+
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=10000000
+prdcr_start name=localhost2
+
+prdcr_add name=localhost3 host=${HOST} type=active xprt=${XPRT} port=${port3} interval=10000000
+prdcr_start name=localhost3
+
+prdcr_add name=localhost4 host=${HOST} type=active xprt=${XPRT} port=${port4} interval=10000000
+prdcr_start name=localhost4
+
+prdcr_add name=localhost5 host=${HOST} type=active xprt=${XPRT} port=${port5} interval=10000000
+prdcr_start name=localhost5
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+# schemas are testname, tx2mon_10_$ncore, tx2mon_01, tx2mon_11_$ncore
+strgp_add name=store_${testname} plugin=store_csv schema=${testname} container=node
+strgp_prdcr_add name=store_${testname} regex=.*
+strgp_start name=store_${testname}
+
+strgp_add name=store_${testname}_11_32 plugin=store_csv schema=${testname}_11_32 container=node
+strgp_prdcr_add name=store_${testname}_11_32 regex=.*
+strgp_start name=store_${testname}_11_32
+
+strgp_add name=store_${testname}_10_32 plugin=store_csv schema=${testname}_10_32 container=node
+strgp_prdcr_add name=store_${testname}_10_32 regex=.*
+strgp_start name=store_${testname}_10_32
+
+strgp_add name=store_${testname}_11_28 plugin=store_csv schema=${testname}_11_28 container=node
+strgp_prdcr_add name=store_${testname}_11_28 regex=.*
+strgp_start name=store_${testname}_11_28
+
+strgp_add name=store_${testname}_10_28 plugin=store_csv schema=${testname}_10_28 container=node
+strgp_prdcr_add name=store_${testname}_10_28 regex=.*
+strgp_start name=store_${testname}_10_28
+
+strgp_add name=store_${testname}_01 plugin=store_csv schema=${testname}_01 container=node
+strgp_prdcr_add name=store_${testname}_01 regex=.*
+strgp_start name=store_${testname}_01
+

--- a/ldms/src/sampler/Makefile.am
+++ b/ldms/src/sampler/Makefile.am
@@ -126,6 +126,10 @@ liblnet_stats_la_LIBADD = $(COMMON_LIBADD)
 pkglib_LTLIBRARIES += liblnet_stats.la
 endif
 
+if ENABLE_TX2MON
+SUBDIRS += tx2mon
+endif
+
 if ENABLE_MEMINFO
 SUBDIRS += meminfo
 endif

--- a/ldms/src/sampler/tx2mon/Makefile.am
+++ b/ldms/src/sampler/tx2mon/Makefile.am
@@ -1,0 +1,31 @@
+#  Copyright [2020] Hewlett Packard Enterprise Development LP
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to:
+#
+#   Free Software Foundation, Inc.
+#   51 Franklin Street, Fifth Floor
+#   Boston, MA 02110-1301, USA.
+
+AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
+
+AM_LDFLAGS = @OVIS_LIB_ABS@
+
+COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
+
+if ENABLE_TX2MON
+libtx2mon_la_SOURCES = tx2mon_cli.c tx2mon.c tx2mon.h
+libtx2mon_la_LIBADD = $(COMMON_LIBADD)
+pkglib_LTLIBRARIES = libtx2mon.la
+dist_man7_MANS = Plugin_tx2mon.man
+endif
+

--- a/ldms/src/sampler/tx2mon/Plugin_tx2mon.man
+++ b/ldms/src/sampler/tx2mon/Plugin_tx2mon.man
@@ -1,0 +1,145 @@
+.\" Manpage for Plugin_tx2mon
+.\" Contact ovis-help@sandia.gov to correct errors or typos.
+.TH man 7 "25 Dec 2020" "v4.3" "LDMS Plugin tx2mon man page"
+
+.SH NAME
+Plugin_tx2mon - man page for the LDMS tx2mon plugin
+
+.SH SYNOPSIS
+Within ldmsd configuration
+.br
+config name=tx2mon [ <attr> = <value> ]
+
+.SH DESCRIPTION
+The tx2mon plugin provides cpu and system-on-chip information from /sys/bus/platform/devices/tx2mon/[socinfo, node<i>_raw] and reports it in the same units as the tx2mon command-line utility.
+
+.SH CONFIGURATION ATTRIBUTE SYNTAX
+
+The standard options from sampler_base apply. The specific options for tx2mon are listed here
+.TP
+.BR config
+name=tx2mon <standard options> [array=<bool>] [extra=<bool>] [auto-schema=<bool>]
+.br
+.RS
+.TP
+schema=<schema>
+.br
+Optional schema name. It is required by most storage backends that the same sampler on different nodes with different metric subsets needs to have a unique schema name. Use auto-schema=1 instead of or in addition to schema to automatically meet the backend requirement.
+.TP
+auto-schema=<bool>
+.br
+If true, change the schema name to tx2mon_$X, where $X will be
+a unique value derived from the data selection options. If both schema and auto-schema=1 are given, the
+schema name given is used as the base instead of "tx2mon".
+.TP
+array=<bool>
+.br
+For per-core data, report all array value elements if true. Report only maximum and minimum values if false. The default is false.
+.TP
+extra=<bool>
+.br
+For per-core data, report additional information of the internal block frequencies and the set system metrics. These additional values are static. If false, additional information will not be reported. The default is false.
+.RE
+
+
+.SH METRICS
+.PP
+The sampler_base standard metrics are included.
+The following data is reported in a set instance per socket.
+
+.nf
+node                 Number of socket i from
+                     /sys/bus/platform/devices/tx2mon/node<i>_raw
+.fi
+
+.PP
+The metrics listed here are named as their respective fields in tx2mon/mc_oper_region.h. Where applicable, metrics are converted to the units listed here from the raw values.
+.nf
+counter        Snapshot counter of the cpu.
+
+.PP
+Include the following metrics when array=true:
+.nf
+freq_cpu[]     Frequency reading of each core.
+tmon_cpu[]     Temperature reading of each core. (deg. C).
+.fi
+.PP
+Include the following metrics when array=false:
+.nf
+freq_cpu_min   Minimum value found in freq_cpu.
+freq_cpu_max   Maximum value found in freq_cpu.
+tmon_cpu_min   Minimum value found in tmon_cpu. (deg. C)
+tmon_cpu_max   Maximum value found in tmon_cpu. (deg. C)
+.fi
+.PP
+Include the following metrics unconditionally:
+.nf
+tmon_soc_avg   Average temperature on the SoC. (deg. C)
+pwr_core       Power consumed by all cores on the SoC. (Watt).
+pwr_sram       Power consumed by all internal SRAM on the SoC. (Watt).
+pwr_mem        Power consumed by the LLC ring on the SoC. (Watt)
+pwr_soc        Power consumed by SoC blocks that are misc. (Watt)
+v_core         Voltage consumed by all cores on the SoC. (V)
+v_sram         Voltage consumed by all internal SRAM on the SoC. (V)
+v_mem          Voltage consumed by the LLC ring on the SoC. (V)
+v_soc          Voltage consumed by SoC blocks that are misc. (V).
+active_evt     Provides a bit list of active events that are causing throttling.
+Temperature    Active event with a bit flag where 1 is true.
+Power          Active event with a bit flag where 1 is true.
+External       Active event with a bit flag where 1 is true.
+Unk3           Active event with a bit flag where 1 is true.
+Unk4           Active event with a bit flag where 1 is true.
+Unk5           Active event with a bit flag where 1 is true.
+temp_evt_cnt   Total number of temperature events.
+pwr_evt_cnt       Total number of power events.
+ext_evt_cnt       Total number of exteral events.
+temp_throttle_ms  Time duration of all temperature events in ms.
+pwr_throttle_ms   Time duration of all power events in ms.
+ext_throttle_ms   Time duration of all external events in ms.
+.fi
+
+.PP
+Include the following metrics with extra=true:
+.nf
+temp_abs_max       Absolute maximum limit of temperature beyond
+                   which the SoC will throttle voltage and frequency.
+temp_soft_thresh   Soft limit of temperature beyond which the SoC will
+                   throttle voltage and frequency down.
+temp_hard_thresh   Hard limit of temperature beyond which the SoC will
+                   throttle voltage and frequency down.
+freq_mem_net       Frequency reading of the SoC and ring connection.
+freq_max           Maximum limit of SoC frequency. Depends on the SKU.
+freq_min           Minimum limit of SoC frequency. Depends on the SKU.
+freq_socs          Internal block frequency of SOC South clock. (Mhz)
+freq_socn          Internal block frequency of SOC North clock. (Mhz)
+.fi
+
+.SH EXAMPLES
+.PP
+Within ldmsd_controller or a configuration file:
+.nf
+load name=tx2mon
+config name=tx2mon producer=vm1_1 component_id=1 instance=vm1_1/tx2mon
+start name=tx2mon interval=1000000
+.fi
+
+.SH NOTES
+By default, root privilege is required to read the data files produced by tx2mon_kmod.
+The kernel module tx2mon_kmod must be loaded, e.g. by
+"modprobe /lib/modules/$(uname -r)/extra/tx2mon_kmod.ko".
+
+The current generated schema names are: tx2mon, tx2mon_01, tx2mon_11_$n_core, and tx2mon_10_$n_core, where the suffix is derived as _(array)(extra)[_ncore]. "tx2mon" is used when tx2mon_00 would occur. If present, $n_core is the size of the array metrics.
+
+There is additional power consumed by cross-socket interconnect, PCIe, DDR and
+other IOs that is not currently reported by this tool.
+
+tx2mon reports on the sensors monitored by the on-chip management controller.
+Some of the on-chip components (such as the IO blocks) do not have sensors
+and therefore the voltage and power measurements of these blocks are not
+provided by tx2mon.
+
+
+.SH SEE ALSO
+ldmsd(8), ldms_sampler_base
+.nf
+.fi

--- a/ldms/src/sampler/tx2mon/README.md
+++ b/ldms/src/sampler/tx2mon/README.md
@@ -1,0 +1,68 @@
+# Marvell TX2 plug-in.
+
+## Introduction
+The tx2mon sampler plug-in reports the same information as the
+tx2mon command line tool:
+```
+Node: 0  Snapshot: 40146152
+Freq (Min/Max): 1000/2000 MHz     Temp Thresh (Soft/Max):  92.39/110.25 C
+
+|Core  Temp   Freq |Core  Temp   Freq |Core  Temp   Freq |Core  Temp   Freq |
++------------------+------------------+------------------+------------------+
+|  0:  58.89  2001 |  1:  57.78  2001 |  2:  57.78  2004 |  3:  59.45  2003 |
+|  4:  58.34  2002 |  5:  57.78  2005 |  6:  56.10  2006 |  7:  57.78  2001 |
+|  8:  60.01  2007 |  9:  56.10  2003 | 10:  59.45  2006 | 11:  57.22  2000 |
+| 12:  58.89  2002 | 13:  56.66  2004 | 14:  60.01  2000 | 15:  58.89  2007 |
+| 16:  56.10  2006 | 17:  58.34  2001 | 18:  58.89  2006 | 19:  57.78  2006 |
+| 20:  58.34  2001 | 21:  58.89  2003 | 22:  58.34  2000 | 23:  57.22  2003 |
+| 24:  56.10  2003 | 25:  60.01  2005 | 26:  57.78  2000 | 27:  56.66  2006 |
+
+SOC Center Temp:  60.57 C
+Voltage    Core:   0.74 V, SRAM:  0.90 V,  Mem:  0.93 V, SOC:  0.85 V
+Power      Core:  18.97 W, SRAM:  0.45 W,  Mem: 13.41 W, SOC: 15.21 W
+Frequency    Memnet: 2304 MHz
+
+
+Throttling Active Events: None
+Throttle Events     Temp:      0,    Power:    108,    External:      0
+Throttle Durations  Temp:      0 ms, Power:  56220 ms, External:      0 ms
+
+Node: 1  Snapshot: 40026090
+Freq (Min/Max): 1000/2000 MHz     Temp Thresh (Soft/Max):  92.39/110.25 C
+
+|Core  Temp   Freq |Core  Temp   Freq |Core  Temp   Freq |Core  Temp   Freq |
++------------------+------------------+------------------+------------------+
+|  0:  50.52  2006 |  1:  51.64  2006 |  2:  49.41  2003 |  3:  49.41  2001 |
+|  4:  52.75  2001 |  5:  52.20  2006 |  6:  50.52  2002 |  7:  51.08  2001 |
+|  8:  52.20  2000 |  9:  52.20  2005 | 10:  51.64  2000 | 11:  49.41  2002 |
+| 12:  51.64  2005 | 13:  49.96  2004 | 14:  53.31  2001 | 15:  49.41  2000 |
+| 16:  52.20  2004 | 17:  53.31  2005 | 18:  51.64  2002 | 19:  54.43  2000 |
+| 20:  51.64  2005 | 21:  51.64  2001 | 22:  50.52  2003 | 23:  49.96  2003 |
+| 24:  50.52  2001 | 25:  49.96  2000 | 26:  52.75  2005 | 27:  49.41  2006 |
+
+SOC Center Temp:  51.64 C
+Voltage    Core:   0.74 V, SRAM:  0.90 V,  Mem:  0.93 V, SOC:  0.85 V
+Power      Core:  19.69 W, SRAM:  0.54 W,  Mem: 14.30 W, SOC: 14.54 W
+Frequency    Memnet: 2304 MHz
+
+
+Throttling Active Events: None
+Throttle Events     Temp:      0,    Power:     91,    External:      0
+Throttle Durations  Temp:      0 ms, Power:  60362 ms, External:      0 ms
+```
+The tx2mon code is available [here](https://github.com/jchandra-cavm/tx2mon),
+it contains two components:
+* kernel module
+
+  This makes the data structures from the M3 manangement processor on each TX2 die available in sysfs.
+  The tx2mon\_kmod kernel module must be present for the sampler to operate.
+
+* user application
+
+  This mmaps the sysfs files, and displays their contents in real time.
+
+This sampler requires the kernel module to be loaded.
+## Building
+In order to build the tx2mon sampler, the Marvell tx2mon header needs to be resident on the build system.
+By default, the plugin is enabled if the header is present and disabled if it is not found automatically.
+

--- a/ldms/src/sampler/tx2mon/tx2mon.c
+++ b/ldms/src/sampler/tx2mon/tx2mon.c
@@ -1,0 +1,908 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2021 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ * Copyright (c) 2021 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *	Redistributions of source code must retain the above copyright
+ *	notice, this list of conditions and the following disclaimer.
+ *
+ *	Redistributions in binary form must reproduce the above
+ *	copyright notice, this list of conditions and the following
+ *	disclaimer in the documentation and/or other materials provided
+ *	with the distribution.
+ *
+ *	Neither the name of Sandia nor the names of any contributors may
+ *	be used to endorse or promote products derived from this software
+ *	without specific prior written permission.
+ *
+ *	Neither the name of Open Grid Computing nor the names of any
+ *	contributors may be used to endorse or promote products derived
+ *	from this software without specific prior written permission.
+ *
+ *	Modified source versions must be plainly marked as such, and
+ *	must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file tx2mon.c
+ */
+
+/*
+ * tx2mon.c -	LDMS sampler for basic Marvell TX2 chip telemetry.
+ *
+ *		Sampler to provide LDMS data available via the tx2mon
+ *		CLI utility (https://github.com/jchandra-cavm/tx2mon).
+ *		This data exists in structure that is mapped all
+ *		the way into sysfs from the memory of the M3 management
+ *		processor present on each TX2 die.
+ *		This sampler requires the tx2mon kernel module to be loaded.
+ *		This module creates sysfs entries that can be opened and
+ *		mmapped, then overlaid with a matching structure definition.
+ *		Management processor updates the underlying structure at >= 10Hz.
+ *		The structure contains a great deal of useful telemetry, including:
+ *		 - clock speeds
+ *		 - per-core temperatures
+ *		 - power data
+ *		 - throttling statistics
+ */
+
+/*
+ *  Copyright [2020] Hewlett Packard Enterprise Development LP
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to:
+ *
+ *   Free Software Foundation, Inc.
+ *   51 Franklin Street, Fifth Floor
+ *   Boston, MA 02110-1301, USA.
+ */
+
+#define _GNU_SOURCE
+#include <inttypes.h>
+#include "assert.h"
+#include <unistd.h>
+#include <sys/errno.h>
+#include <sys/syscall.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <time.h>
+#include "ldms.h"
+#include "ldmsd.h"
+#include "sampler_base.h"
+#include "tx2mon.h"
+#include "stdbool.h"
+#include <stdint.h>
+#include <string.h>
+
+#define SAMP "tx2mon"
+
+static ldmsd_msg_log_f msglog;
+static ldms_set_t set[MAX_CPUS_PER_SOC];
+static ldms_set_t sc;
+
+static base_data_t base;
+static ldms_schema_t schema;
+static ldmsd_msg_log_f msglog;
+static struct tx2mon_sampler tx2mon_s = {0};
+
+static struct tx2mon_sampler *tx2mon = &tx2mon_s;
+
+#define MCP_STR_WRAP(NAME) #NAME
+#define MCP_LISTWRAP(NAME) MCP_ ## NAME
+#define META_MCP_STR_WRAP(NAME) #NAME
+#define META_MCP_LISTWRAP(NAME) MCP_ ## NAME
+
+static int pidarray = 0;
+static int pidextra = 0;
+static char *pids = "self";
+
+/*
+ * - Define metric list found in /usr/include/tx2mon/mc_oper_region.h.
+ * - Create list with the following arguments: name, metric name, type, position in the metric list.
+ * - Add schema meta data with ldms_schema_meta_array_add() and ldms_schema_meta_add().
+ * - Add schema metric data with ldms_schema_metric_array_add() and ldms_schema_metric_add().
+ * - Set the total length of the arrays to the number of cores found in /sys/bus/platform/devices/tx2mon/socinfo.
+ * - If "array = true/1/t", add all arrays listed in MCP_LIST and their contents  - set array size to the number
+ *	of n_cores found in /socinfo.
+ * - If "array = false/0/f", add metrics "min" and "max" for each array listed in MCP_LIST.
+ * */
+#define MCP_LIST(WRAP) \
+	WRAP("counter", counter, LDMS_V_U32, pos_counter) \
+	WRAP("freq_cpu", freq_cpu[0], LDMS_V_U32_ARRAY, pos_freq_cpu) \
+	WRAP("tmon_cpu", tmon_cpu[0], LDMS_V_F32_ARRAY, pos_tmon_cpu) \
+	WRAP("tmon_soc_avg", tmon_soc_avg, LDMS_V_F32, pos_tmon_soc_avg) \
+	WRAP("pwr_core", pwr_core, LDMS_V_F32, pos_pwr_core) \
+	WRAP("pwr_sram", pwr_sram, LDMS_V_F32, pos_pwr_sram) \
+	WRAP("pwr_mem", pwr_mem, LDMS_V_F32, pos_pwr_mem) \
+	WRAP("pwr_soc", pwr_soc, LDMS_V_F32, pos_pwr_soc) \
+	WRAP("v_core", v_core, LDMS_V_F32, pos_v_core) \
+	WRAP("v_sram", v_sram, LDMS_V_F32, pos_v_sram) \
+	WRAP("v_mem", v_mem, LDMS_V_F32, pos_v_mem ) \
+	WRAP("v_soc", v_soc, LDMS_V_F32, pos_v_soc) \
+	WRAP("active_evt", active_evt, LDMS_V_CHAR_ARRAY, pos_active_evt) \
+	WRAP("temp_evt_cnt", temp_evt_cnt, LDMS_V_U32, pos_temp_evt_cnt) \
+	WRAP("pwr_evt_cnt", pwr_evt_cnt, LDMS_V_U32, pos_pwr_evt_cnt) \
+	WRAP("ext_evt_cnt", ext_evt_cnt, LDMS_V_U32, pos_ext_evt_cnt) \
+	WRAP("temp_throttle_ms", temp_throttle_ms, LDMS_V_U32, pos_temp_throttle_ms) \
+	WRAP("pwr_throttle_ms", pwr_throttle_ms, LDMS_V_U32, pos_pwr_throttle_ms) \
+	WRAP("ext_throttle_ms", ext_throttle_ms , LDMS_V_U32, pos_ext_throttle_ms)
+
+/* Define constants in the metric list */
+#define META_MCP_LIST(WRAP) \
+	WRAP("temp_abs_max", temp_abs_max, LDMS_V_F32, pos_temp_abs_max) \
+	WRAP("temp_soft_thresh", temp_soft_thresh, LDMS_V_F32, pos_temp_soft_thresh) \
+	WRAP("temp_hard_thresh", temp_hard_thresh, LDMS_V_F32, pos_temp_hard_thresh) \
+	WRAP("freq_mem_net", freq_mem_net, LDMS_V_U32, pos_freq_mem_net) \
+	WRAP("freq_max", freq_max, LDMS_V_U32, pos_freq_max) \
+	WRAP("freq_min", freq_min, LDMS_V_U32, pos_freq_min)\
+	WRAP("freq_socs", freq_socs, LDMS_V_U32, pos_freq_socs)\
+	WRAP("freq_socn", freq_socn, LDMS_V_U32, pos_freq_socn)\
+
+#define DECLPOS(n, m, t, p) static int p = -1;
+
+MCP_LIST(DECLPOS);
+META_MCP_LIST(DECLPOS);
+
+#define META(n, m, t, p) \
+	rc = meta_filter(n, t);\
+	p = rc;\
+
+#define METRIC(n, m, t, p) \
+	rc = metric_filter(n, t);\
+	p = rc;\
+/*
+ * meta_filter() checks the stored value in "pidextra" variable and add/removes the following metrics respectively.
+ * If "extra" is set to true in the configuration file, the extra metrics will be included.
+ * If "extra" is set to false then the extra metrics will not be included.
+ * Default is false.
+ */
+static int meta_filter(char *n, uint32_t t)
+{
+	int rc = 0;
+	int pos = -1;
+	if (pidextra)
+		rc = ldms_schema_meta_add(schema, n, t);
+	else if (!pidextra)
+		return rc;
+
+	if (rc > -1)
+		pos = rc;
+	else {
+		rc = ENOMEM;
+		return rc;
+	}
+	return pos;
+}
+
+
+/* This function checks the value contained in pidarray and adds the corresponding metrics
+ * as follows using a switch statement:
+ * Include metric arrays if "array" is set to true in the configuration file.
+ * Inlcude only max and min metric values if "array" is set to false.
+ * Default is false.
+ */
+static int metric_filter(char *n, uint32_t t)
+{
+	int rc = 0;
+	int pos = -1;
+	switch (t) {
+	case LDMS_V_U32_ARRAY:
+		if (pidarray) {
+			rc = ldms_schema_metric_array_add(schema, n, t, tx2mon->n_core);
+		} else {
+			rc = ldms_schema_metric_add(schema, "freq_cpu_min", LDMS_V_U32);
+			rc = ldms_schema_metric_add(schema, "freq_cpu_max", LDMS_V_U32);
+		}
+		if (rc > -1)
+			pos = rc;
+		else
+			goto err;
+		break;
+	case LDMS_V_F32_ARRAY:
+		if (pidarray) {
+			rc = ldms_schema_metric_array_add(schema, n, t, tx2mon->n_core);
+		} else {
+			rc = ldms_schema_metric_add(schema, "tmon_cpu_min", LDMS_V_F32);
+			rc = ldms_schema_metric_add(schema, "tmon_cpu_max", LDMS_V_F32);
+		}
+		if (rc > -1)
+			pos = rc;
+		else
+			goto err;
+		break;
+	case LDMS_V_CHAR_ARRAY:
+		rc = ldms_schema_metric_array_add(schema, n, t, 50);
+		if (rc> -1)
+			pos = rc;
+		else
+			goto err;
+		if (!strcmp(n, "active_evt")) {
+			rc = ldms_schema_metric_add(schema, "Temperature", LDMS_V_U32);
+			rc = ldms_schema_metric_add(schema, "Power", LDMS_V_U32);
+			rc = ldms_schema_metric_add(schema, "External", LDMS_V_U32);
+			rc = ldms_schema_metric_add(schema, "Unk3", LDMS_V_U32);
+			rc = ldms_schema_metric_add(schema, "Unk4", LDMS_V_U32);
+			rc = ldms_schema_metric_add(schema, "Unk5", LDMS_V_U32);
+			if (rc > -1)
+				return pos;
+			else
+				goto err;
+		}
+		break;
+	default:
+		rc = ldms_schema_metric_add(schema, n, t);
+		if (rc > -1)
+			pos = rc;
+		else
+			goto err;
+		break;
+	}
+
+	return pos;
+
+err:
+	rc = ENOMEM;
+	return rc;
+
+}
+
+static bool get_bool(const char *val, char *name)
+{
+	if (!val)
+		return false;
+
+	switch (val[0]) {
+	case '1':
+	case 't':
+	case 'T':
+	case 'y':
+	case 'Y':
+		return true;
+	case '0':
+	case 'f':
+	case 'F':
+	case 'n':
+	case 'N':
+		return false;
+	default:
+		msglog(LDMSD_LERROR, "%s: bad bool value %s for %s\n",
+		       val, name);
+		return false;
+	}
+}
+/***************************************************************************/
+/*brief parse on soc info and fill provides struct.
+ * \return 0 on success, errno from fopen, ENODATA from
+ * failed fgets, ENOKEY or ENAMETOOLONG from failed parse.
+ */
+static int parse_socinfo(void);
+
+/* Read and query cpu data for each node and map to data structure. Can also be used for debugging
+ * by displaying the data to the ldmsd log file*/
+static int parse_mc_oper_region();
+
+/* Define metric list and call tx2mon_array_conv */
+static int tx2mon_set_metrics(int i);
+
+/* Convert metric values to temp, voltage and power units. Output results in float and uint32_t types */
+static int tx2mon_array_conv(void *s, int p, int idx, int i, uint32_t t);
+
+
+/***************************************************************************/
+
+/*
+ * Create the schema and metric set.
+ *
+ *  - Read & parse TX2MON_SOCINFO_PATH to learn about the system config, and
+ *    test that the kernel module is loaded etc. This file is plain ascii.
+ *  - Open & mmap TX2MON_NODE?_PATH files. These are binary data structures
+ *    defined in mc_oper_region.h.
+ *  - Establish the capabilities reported, based on the version number of
+ *    the data structure.
+ *  - Set up metrics, update data and sample.
+ *
+ *    Return 0 iff all good, else report useful error message, clean up,
+ *    and return appropriate errno.
+ */
+static int create_metric_set(base_data_t base)
+{
+	int rc, i;
+	int mcprc = -1;
+	size_t instance_len = strlen(base->instance_name) + 12;
+	static struct mc_oper_region *s;
+	char buf[instance_len];
+	char cpu_instance_index[12];
+
+	mcprc = parse_mc_oper_region();
+	if (mcprc != 0) {
+		msglog(LDMSD_LERROR, SAMP ": unable to read the node file for the sample (%s)\n",
+		       pids, strerror(mcprc));
+		return mcprc;
+	}
+
+	schema = base_schema_new(base);
+	if (!schema) {
+		rc = ENOMEM;
+		goto err;
+	}
+	MCP_LIST(METRIC);
+	META_MCP_LIST(META);
+	for (i = 0; i < 2; i++) {
+		s = &tx2mon->cpu[i].mcp;
+		snprintf(cpu_instance_index, instance_len, ".%d", i);
+
+		strncpy(buf, base->instance_name, instance_len);
+		strncat(buf, cpu_instance_index, 12);
+
+		set[i] = ldms_set_new(buf, schema);
+
+		if (!set[i]) {
+			rc = errno;
+			msglog(LDMSD_LERROR, SAMP ": ldms_set_new failed %d for %s\n",
+			       errno, base->instance_name);
+			goto err;
+		}
+
+#define META_MCSAMPLE(n, m, t, p)\
+		rc = tx2mon_array_conv(&s->m, p, tx2mon->n_core, i, t);\
+		if (rc){ \
+		rc = EINVAL; \
+		msglog(LDMSD_LERROR, SAMP ": sample " n " not correctly defined.\n"); \
+		return rc;}\
+
+		META_MCP_LIST(META_MCSAMPLE);
+
+		ldms_set_producer_name_set(set[i], base->producer_name);
+		ldms_metric_set_u64(set[i], BASE_COMPONENT_ID, base->component_id);
+		ldms_metric_set_u64(set[i], BASE_JOB_ID, 0);
+		ldms_metric_set_u64(set[i], BASE_APP_ID, 0);
+		base_auth_set(&base->auth, set[i]);
+
+		rc = ldms_set_publish(set[i]);
+		if (rc) {
+			ldms_set_delete(base->set);
+			base->set = NULL;
+			errno = rc;
+			base->log(LDMSD_LERROR,"base_set_new: ldms_set_publish failed for %s\n",
+			          base->instance_name);
+			return EINVAL;
+		}
+		ldmsd_set_register(set[i], base->pi_name);
+
+		base->set = set[i];
+		base_sample_begin(base);
+
+		rc = tx2mon_set_metrics(i);
+		if (rc) {
+			msglog(LDMSD_LERROR, SAMP ": failed to create metric set.\n");
+			rc = EINVAL;
+			return rc;
+		}
+		base_sample_end(base);
+		base->set = NULL;
+
+	}
+
+
+	return 0;
+err:
+	if(schema)
+		ldms_schema_delete(schema);
+	return rc;
+}
+
+/* compute unique schema name based on options.
+ * no options: base = tx2mon
+ * schema=xxx: use xxx as the base of the unique name
+ * pidarray or pidextra: add schema suffix based on set content.
+ * @return name which the caller must arrange to free eventually.
+ */
+static char * compute_schema_name(int pidarray, int pidextra, struct attr_value_list *avl, int arraysize)
+{
+	char *schema_name = av_value(avl, "schema");
+	if (!schema_name) {
+		schema_name = SAMP;
+	}
+	if (pidarray || pidextra) {
+		size_t blen = strlen(schema_name) + 14;
+		char *buf = malloc(blen);
+		char asize[10];
+		if (pidarray) {
+			snprintf(asize, sizeof(asize), "_%hd", (short) arraysize);
+		} else {
+			asize[0] = '\0';
+		}
+		if (buf) {
+			snprintf(buf, blen, "%s_%c%c%s", schema_name,
+			         (pidarray ?  '1' : '0'),
+			         (pidextra ?  '1' : '0'),
+			         asize);
+		}
+		return buf;
+	} else {
+		return strdup(schema_name);
+	}
+}
+
+/*
+ * Plug-in data structure and access method.
+ */
+
+static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct attr_value_list *avl)
+{
+	int rc = -1;
+	char *array, *extra;
+	char *sbuf = NULL;
+	int i;
+
+	int ret = parse_socinfo();
+	if (ret != 0) {
+		msglog(LDMSD_LERROR, SAMP ": Failed. Check that you loaded tx2mon_kmod module. \n");
+		return EINVAL;
+	}
+
+	for (i = 0; i < tx2mon->n_cpu; i++) {
+		if (set[i]) {
+			msglog(LDMSD_LERROR, SAMP ": Set already created.\n");
+			return EINVAL;
+		}
+	}
+
+	array = av_value(avl, "array");
+	extra = av_value(avl, "extra");
+
+	if (array && get_bool(array, "array"))
+		pidarray = 1;
+	if (extra && get_bool(extra, "extra"))
+		pidextra = 1;
+
+	sbuf = compute_schema_name(pidarray, pidextra, avl, tx2mon->n_core);
+	if (!sbuf) {
+		msglog(LDMSD_LERROR, SAMP ": out of memory computing schema name.\n");
+		goto err;
+	}
+
+	base = base_config(avl, SAMP, sbuf, msglog);
+	if (!base) {
+		goto err;
+	}
+	char *as = av_value(avl, "auto-schema");
+	bool dosuffix = (as && get_bool(as, "auto-schema") );
+	if (dosuffix && strcmp(base->schema_name, sbuf) != 0) {
+		free(base->schema_name);
+		base->schema_name = sbuf;
+		sbuf = NULL;
+	}
+
+	rc = create_metric_set(base);
+	if (rc) {
+		msglog(LDMSD_LERROR, SAMP ": failed to create metric set.\n");
+		goto err;
+	}
+
+	msglog(LDMSD_LDEBUG, SAMP ": config done. \n");
+
+	free(sbuf);
+	return 0;
+
+err:
+	rc = EINVAL;
+	base_del(base);
+	free(sbuf);
+	msglog(LDMSD_LDEBUG, SAMP ": config fail.\n");
+	return rc;
+
+}
+
+static const char *usage(struct ldmsd_plugin *self)
+{
+	return
+"config name=" SAMP " [port-number=<num>]\n"
+"	[producer=<name>] [instance=<name>] [component_id=<uint64_t>] [schema=<name_base>]\n"
+"       [array=<bool>] [extra=bool] [auto-schema=bool]\n"
+"	[uid=<user-id>] [gid=<group-id>] [perm=<mode_t permission bits>]\n"
+"    producer	  A unique name for the host providing the timing data (default $HOSTNAME)\n"
+"    instance	  A unique name for the timing metric set (default $HOSTNAME/" SAMP ")\n"
+"    component_id A unique number for the component being monitoring, Defaults to zero.\n"
+"    schema	  The base name of the port metrics schema, Defaults to " SAMP ".\n"
+"    auto-schema  Use schema as base of schema name generated to be unique.\n"
+"    array	  Includes only the minimum and maximum metric values of each array in the metric set. \n"
+"		  If true, all array values are included. Default is FALSE.\n"
+"    extra	  Includes additional frequency metrics of the internal block. \n"
+"		  If false, these metrics will be ommitted. Default is FALSE.\n"
+"    uid	  The user-id of the set's owner\n"
+"    gid	  The group id of the set's owner\n"
+"    perm	  The set's access permissions\n"
+	        ;
+}
+
+static void term(struct ldmsd_plugin *self)
+{
+	int i;
+	if (base)
+		base_del(base);
+	for (i = 0; i < tx2mon->n_cpu; i++) {
+		if (set[i])
+			ldms_set_delete(set[i]);
+		set[i] = NULL;
+	}
+}
+
+static int sample(struct ldmsd_sampler *self)
+{
+	int rc = 0;
+	int i;
+	int mcprc = -1;
+	for (i = 0; i < tx2mon->n_cpu; i++) {
+		if (!set[i]) {
+			msglog(LDMSD_LERROR, SAMP ": plugin not initialized\n");
+			return EINVAL;
+		}
+	}
+	mcprc = parse_mc_oper_region();
+
+	for (i = 0; i < tx2mon->n_cpu; i ++) {
+		base_sample_begin(base);
+		if (!mcprc) {
+			rc = tx2mon_set_metrics(i);
+			if (rc) {
+				msglog(LDMSD_LERROR, SAMP ": failed to create metric set.\n");
+				rc = EINVAL;
+				return rc;
+			}
+
+		}
+
+		base_sample_end(base);
+	}
+	return rc;
+}
+
+static ldms_set_t get_set(struct ldmsd_sampler *self)
+{
+	return sc;
+}
+
+static struct ldmsd_sampler tx2mon_plugin = {
+	.base = {
+		.name = SAMP,
+		.type = LDMSD_PLUGIN_SAMPLER,
+		.term = term,
+		.config = config,
+		.usage = usage,
+	},
+	.get_set = get_set,
+	.sample = sample,
+};
+
+struct ldmsd_plugin *get_plugin(ldmsd_msg_log_f pf)
+{
+	msglog = pf;
+	int i;
+	for (i = 0; i < MAX_CPUS_PER_SOC; i++)
+		set[i] = NULL;
+	return &tx2mon_plugin.base;
+}
+
+/***************************************************************************/
+
+/*
+ * tx2mon_get_throttling_events() checks the value of the "active_evt" metric.
+ * If the metric is zero, the character array will be set to
+ * "None".
+ * If "active_evt" is not 0, the function will iterate through the causes
+ * and perform a left shift to determine what the cause is.
+ * If there is more than one cause, the strings will be concatinated and
+ * returned as a single char array.
+ * EXAMPLE: If active_evt = 5 (binary:101) and, starting from the far
+ * right and iterating by 1 to the left, the initial (zero) and second
+ * bits are set to 1 (active). Since "Temperature and External" are
+ * indexes 0 and 2 then the returned array will be "Temperature External"
+ */
+
+static int  tx2mon_get_throttling_events(uint32_t *active, int i, int p, char *throt_buf, int bufsz)
+{
+	const char *causes[] = { "Temperature", "Power", "External", "Unk3", "Unk4", "Unk5"};
+	const int ncauses = sizeof(causes)/sizeof(causes[0]);
+	int sz, incr;
+	int rc = 0;
+	int events = 0;
+	const char *sep = ",";
+	int pos = p;
+	char total_causes[sizeof(causes)+2];
+	strcpy(total_causes, "");
+
+	if (!*active) {
+		ldms_metric_array_set_str(set[i], p, "None");
+		return rc;
+	}
+
+	if (!tx2mon->cpu[i].throttling_available) {
+		for (pos = p; p <= ncauses; pos++) {
+			ldms_metric_set_u32(set[i], p, 0);
+		}
+		msglog(LDMSD_LDEBUG, SAMP ": Throttling events not supported. \n");
+		return rc;
+	}
+
+
+	for (incr = 0, events = 0; incr < ncauses && bufsz > 0; incr++) {
+		pos++;
+		if ((*active & (1 << incr)) == 0)
+			continue;
+		sz = snprintf(throt_buf, bufsz, "%s%s", events ? sep : "", causes[incr]);
+		bufsz -= sz;
+		throt_buf += sz;
+		++events;
+		strcat(total_causes, causes[incr]);
+		ldms_metric_array_set_str(set[i], p, total_causes);
+		ldms_metric_set_u32(set[i], pos, 1);
+		strcat(total_causes, ",");
+	}
+
+	return rc;
+}
+
+/* Converts unsigned 32 and 16 integers to temperature units and returns a float. to_c is the
+temperature calulation defined in mc_oper_region.h*/
+static float my_to_c_u32(uint32_t t)
+{
+	return to_c(t);
+
+}
+static float my_to_c_u16(uint16_t t)
+{
+	return to_c(t);
+}
+
+/*
+ * - Define all metrics in the structure list "MCP_LIST". This definition will be used to sample the metric set.
+ * - Call tx2mon_array_conv.
+ * - tx2mon_array_conv converts each metric and array to the necessary types (float, uint16 and uint32) and sets
+ *	the metrics with ldms_metric_set_<type>() and ldms_metric_array_set_<type>().
+ * - If "array = true/1/t/T", both arrays in "MCP_LIST" (freq_cpu and tmon_cpu) will be included.
+ * - Values found in the array are converted to temp, voltage and power with my_to_c_u16() and my_to_c_u32().
+ * - Fail with rc = EINVAL if a metric type does not exist
+ * */
+
+static int tx2mon_set_metrics (int i)
+{
+
+	struct mc_oper_region *s;
+	int rc = 0;
+	s = &tx2mon->cpu[i].mcp;
+
+#define MCSAMPLE(n, m, t, p) \
+	rc = tx2mon_array_conv(&s->m, p, tx2mon->n_core, i, t);\
+	if (rc){ \
+		rc = EINVAL; \
+		msglog(LDMSD_LERROR, SAMP ": sample " n " not correctly defined.\n"); \
+		return rc; }\
+
+
+	MCP_LIST(MCSAMPLE);
+	return rc;
+
+}
+
+static int tx2mon_array_conv(void *s, int p, int idx, int i, uint32_t t)
+{
+	int rc = 0;
+	int c = 0;
+	char throt_buf[64];
+	int temp_p = 0;
+	if (t == LDMS_V_F32_ARRAY) {
+		uint16_t *s16 = (uint16_t*)s;
+		if (!pidarray) {
+			uint16_t *min_max16 = (uint16_t*)s;
+			min_max16[0] = s16[0];
+			min_max16[1] = s16[0];
+			for (c = 0; c < idx; c++) {
+				if (my_to_c_u16(s16[c]) < my_to_c_u16(min_max16[0]))
+					min_max16[0] = s16[c];
+				if (my_to_c_u16(s16[c]) > my_to_c_u16(min_max16[1]))
+					min_max16[1] =s16[c];
+
+			}
+			for (temp_p = -1; temp_p < 1; temp_p++) {
+				ldms_metric_set_float(set[i], p+temp_p, my_to_c_u16(min_max16[temp_p+1]));
+			}
+
+		} else {
+			for (c = 0; c < idx; c++)
+				ldms_metric_array_set_float(set[i], p, c, my_to_c_u16(s16[c]));
+		}
+	}
+
+	if (t == LDMS_V_U32_ARRAY) {
+		uint32_t *s32 = (uint32_t*)s;
+		if (!pidarray) {
+			uint32_t *min_max32 = (uint32_t*)s;
+			min_max32[0] = s32[0];
+			min_max32[1] = s32[0];
+			for (c = 0; c < idx; c++) {
+				if (s32[c] < min_max32[0])
+					min_max32[0] = s32[c];
+				if (s32[c] > min_max32[1])
+					min_max32[1] =s32[c];
+			}
+			for (temp_p = -1; temp_p < 1; temp_p++) {
+				ldms_metric_set_u32(set[i], p+temp_p, min_max32[temp_p+1]);
+			}
+		} else {
+			for (c = 0; c < idx; c++)
+				ldms_metric_array_set_u32(set[i], p, c, s32[c]);
+		}
+	}
+
+	if (t == LDMS_V_F32) {
+		uint32_t *f32 = (uint32_t*)s;
+		ldms_metric_set_float(set[i], p, my_to_c_u32(*f32));
+		if (!pidarray) {
+			if (p >= 9 && p <= 16)
+				ldms_metric_set_float(set[i], p, (*f32/1000.0));
+		} else {
+			if (p >= 7 && p <= 14)
+				ldms_metric_set_float(set[i], p, (*f32/1000.0));
+		}
+	}
+
+	if (t == LDMS_V_U32) {
+		uint32_t *u32 = (uint32_t*)s;
+		ldms_metric_set_u32(set[i], p, *u32);
+	}
+
+	if (t == LDMS_V_CHAR_ARRAY) {
+		uint32_t *str = (uint32_t*)s;
+		rc = tx2mon_get_throttling_events(str, i, p, throt_buf, sizeof(throt_buf));
+	}
+
+	return rc;
+}
+
+/* populate tx2mon struct before any use of it. */
+static int parse_socinfo(void)
+{
+	FILE *socinfo;
+	char *path;
+
+	path = realpath(TX2MON_SOCINFO_PATH, NULL);
+	if (path == NULL) {
+		msglog(LDMSD_LERROR, SAMP ": cannot resolve path for '%s'.\n",
+		       TX2MON_SOCINFO_PATH);
+		return EBADF;
+	}
+
+	socinfo = fopen(path, "r");
+	if (!socinfo) {
+		msglog(LDMSD_LERROR, SAMP ": cannot open '%s', %s.\n",
+		       path, strerror(errno));
+		free(path);
+		return errno;
+	}
+
+	/*
+	Parse socinfo file, it contains three integers with a single
+	space between, any problem => fail.
+	*/
+	if (fscanf(socinfo, "%d %d %d", &tx2mon->n_cpu,
+	           &tx2mon->n_core, &tx2mon->n_thread) != 3) {
+		msglog(LDMSD_LERROR, SAMP ": cannot parse '%s'.\n", path);
+		fclose(socinfo);
+		free(path);
+		return EBADF;
+	}
+
+	fclose(socinfo);
+	free(path);
+
+	msglog(LDMSD_LINFO, SAMP ": n_cpu: %d, n_core: %d, n_thread: %d.\n",
+	       tx2mon->n_cpu, tx2mon->n_core, tx2mon->n_thread);
+
+	if (TX2MON_MAX_CPU < tx2mon->n_cpu) {
+		msglog(LDMSD_LWARNING, SAMP ": sampler built for max %d CPUs, system reporting %d CPUs, limiting reporting to %d.\n",
+		       TX2MON_MAX_CPU, tx2mon->n_cpu, TX2MON_MAX_CPU);
+		tx2mon->n_cpu = TX2MON_MAX_CPU;
+	}
+
+	if (MAX_CPUS_PER_SOC < tx2mon->n_core) {
+		msglog(LDMSD_LWARNING, SAMP ": sampler built for max %d cores, system reporting %d cores, limiting reporting to %d.\n",
+		       MAX_CPUS_PER_SOC, tx2mon->n_core, MAX_CPUS_PER_SOC);
+		tx2mon->n_core = MAX_CPUS_PER_SOC;
+	}
+
+	return 0;
+
+}
+
+
+/* - Loop through number of cpu structs defined in /sys/bus/platform/devices/tx2mon/socinfo
+ *	and set in parse_socinfo().
+ * - Check the node file path for each cpu struct exist.
+ * - Read cpu information in /sys/bus/platform/devices/tx2mon/node<i>_raw
+ * - Close file path.
+ *
+ * - Define "debug" in tx2mon header file to output all structs and their metric values
+ *   in table format (similar to tx2mon program).
+ */
+
+static int parse_mc_oper_region()
+{
+	int ret, ret1;
+	int i;
+	char filename[sizeof(TX2MON_NODE_PATH) + 2];
+	ret = ret1 = 1;
+	assert(tx2mon != NULL);
+	for(i = 0; i < tx2mon->n_cpu; i++) {
+
+		//Get node path name(s)
+		snprintf(filename, sizeof(filename), TX2MON_NODE_PATH, i);
+		//set number of nodes for each cpu found
+		tx2mon->cpu[i].node = i;
+		tx2mon->cpu[i].fd = open(filename, O_RDONLY);
+		if (tx2mon->cpu[i].fd < 0) {
+			msglog(LDMSD_LERROR, SAMP ": Error reading node%i entry.\n", i);
+			msglog(LDMSD_LERROR, SAMP ": Is tx2mon_kmod in the kernel?\n", i);
+			return errno;
+		}
+		ret = tx2mon_read_node(&tx2mon->cpu[i]);
+
+		if (ret < 0) {
+			printf("Unexpected read error!\n");
+			return EINVAL;
+		}
+
+#ifdef debug
+		if (ret > 0) {
+			tx2mon->samples++;
+			term_init_save();
+			dump_cpu_info(&tx2mon->cpu[i]);
+		}
+#endif
+
+		close(tx2mon->cpu[i].fd);
+
+	}
+	return 0;
+}
+

--- a/ldms/src/sampler/tx2mon/tx2mon.h
+++ b/ldms/src/sampler/tx2mon/tx2mon.h
@@ -1,0 +1,84 @@
+#ifndef tx2mon_h
+#define tx2mon_h
+/*
+ * tx2mon.h -	LDMS sampler for basic Marvell TX2 chip telemetry.
+ */
+
+/*
+ *  Copyright [2020] Hewlett Packard Enterprise Development LP
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to:
+ *
+ *   Free Software Foundation, Inc.
+ *   51 Franklin Street, Fifth Floor
+ *   Boston, MA 02110-1301, USA.
+ */
+
+/*
+ * Header file from github.com/jchandra-cavm/tx2mon.git, which
+ * is required to be installed elsewhere on the build system,
+ * and pointed to during the configure phase.
+ *
+ * configure --enable-tx2mon
+ *
+ * If there is no tx2mon/mc_oper_region.h in /usr/include,
+ * provide CFLAGS=$(tx2mon_include_path) pointing to the header location.
+ */
+#include <stdint.h>
+#include <tx2mon/mc_oper_region.h>
+
+#include <limits.h>
+#include <stdio.h>
+
+/*
+ * Location of the sysfs entries created by the kernel module.
+ *
+ * NOTE: TX2MON_NODE_PATH is a snprintf() string to create actual path.
+ */
+#define	TX2MON_SYSFS_PATH	"/sys/bus/platform/devices/tx2mon/"
+#define	TX2MON_SOCINFO_PATH	TX2MON_SYSFS_PATH "socinfo"
+#define TX2MON_NODE_PATH      TX2MON_SYSFS_PATH "node%d_raw"
+/*
+ * Max number of CPUs (TX2 chips) supported.
+ */
+#define	TX2MON_MAX_CPU	(2)
+
+/*
+ * Per-CPU record keeping
+ */
+struct cpu_info {
+	int	fd;		/* fd of raw file opened */
+	int	metric_offset;	/* starting offset into schema for this CPU */
+	unsigned int throttling_available;
+	int	node;
+	struct	mc_oper_region mcp;	/* mmapped data structure (from fd) */
+};
+
+/*
+ * Per-sampler record keeping
+ */
+struct tx2mon_sampler {
+	int	n_cpu;		/* number of CPUs (e.g. TX2 chips) present */
+	int	n_core;		/* cores *per CPU* */
+	int	n_thread;	/* threads *per core* (unused currently) */
+	FILE	*fileout;
+	int 	samples;
+	struct cpu_info cpu[TX2MON_MAX_CPU];
+} ;
+
+/* Read the information located in th the node file directory.
+ * @return 1 if ok, 2 if read is short, 0 if data is unready,
+ * -1 if error (see errno). */
+int tx2mon_read_node(struct cpu_info *d);
+
+#endif

--- a/ldms/src/sampler/tx2mon/tx2mon_cli.c
+++ b/ldms/src/sampler/tx2mon/tx2mon_cli.c
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2018 Marvell International Ltd.
+ */
+/* Extracted from tx2mon.c in
+ * https://github.com/jchandra-cavm/tx2mon/
+ */
+#include "tx2mon.h"
+#include "assert.h"
+#include "stdlib.h"
+#include <sys/types.h>
+#include <unistd.h>
+
+int tx2mon_read_node(struct cpu_info *d)
+{
+	assert(d!=NULL);
+	int rv;
+	struct mc_oper_region *op = &d->mcp;
+	rv = lseek(d->fd, 0, SEEK_SET);
+	if (rv == (off_t) -1)
+		return rv;
+	rv = read(d->fd, op, sizeof(*op));
+	if (rv < sizeof(*op))
+		return 2;
+	if (CMD_STATUS_READY(op->cmd_status) == 0)
+		return 0;
+	if (CMD_VERSION(op->cmd_status) > 0)
+		d->throttling_available = 1;
+	else
+		d->throttling_available = 0;
+	return 1;
+}
+


### PR DESCRIPTION
Adding a sampler called tx2mon. This sampler is designed to run on Stria because this machine contains the kernel module "tx2mon_kmod" that produces the decoded sysfs files that are used to map to operating region metrics. 

As with the tx2mon utility, the tx2mon sampler reports cpu and system-on-chip information from the node files located in the /sys/bus/platform/devices/tx2mon/[socinfo, node<i>_raw], decodes and provides the metric values of the SoC management controller (MC) operating region, current temperature from sensors and the frequencies and power measurements that is logged by the MC to host memory. 

The tx2mon sampler reports the same units and variables as the tx2mon command-line utility. 
The sampler contains two options where:
1.) User can enable/disable set system metrics and additional information of the internal block frequencies. (extra=true/false)
2.) User can view the frequency and temperature readings of each core or only the maximum and minimum frequency and temperature of all cores. (array=true/false)

Test and auto-schema naming option scripts have been created for ldms-static-test.sh. 