### PR TITLE
Only check space on pull request

### DIFF
--- a/.github/workflows/space-check.yaml
+++ b/.github/workflows/space-check.yaml
@@ -1,8 +1,6 @@
 name: Space Check
 
 on:
-  push:
-    branches: [ OVIS-4 ]
   pull_request:
     branches: [ OVIS-4 ]
 


### PR DESCRIPTION
The space-checking github action should be executed against pull
requests only.