### PR TITLE
zap close to wait for empty sq

### DIFF
--- a/lib/src/zap/fabric/zap_fabric.h
+++ b/lib/src/zap/fabric/zap_fabric.h
@@ -250,6 +250,7 @@ struct z_fi_ep {
 #endif /* ZAP_DEBUG */
 
 	LIST_ENTRY(z_fi_ep) ep_link;
+	pthread_cond_t io_q_cond;
 };
 
 #endif

--- a/lib/src/zap/rdma/zap_rdma.h
+++ b/lib/src/zap/rdma/zap_rdma.h
@@ -210,6 +210,7 @@ struct z_rdma_ep {
 	} dev_type;
 	int cm_channel_enabled;
 	int cq_channel_enabled;
+	pthread_cond_t io_q_cond;
 };
 
 #endif

--- a/lib/src/zap/sock/zap_sock.h
+++ b/lib/src/zap/sock/zap_sock.h
@@ -287,6 +287,7 @@ struct z_sock_ep {
 	TAILQ_HEAD(z_sock_io_q, z_sock_io) io_q;
 	TAILQ_HEAD(, z_sock_send_wr_s) sq; /* send queue */
 	LIST_ENTRY(z_sock_ep) link;
+	pthread_cond_t sq_cond;
 };
 
 static inline struct z_sock_ep *z_sock_from_ep(zap_ep_t *ep)

--- a/lib/src/zap/ugni/zap_ugni.h
+++ b/lib/src/zap/ugni/zap_ugni.h
@@ -279,6 +279,7 @@ struct z_ugni_ep {
 	uint32_t epoll_record[UEP_EPOLL_RECORD_SZ];
 	uint32_t epoll_record_curr;
 #endif /* ZAP_DEBUG || DEBUG */
+	pthread_cond_t sq_cond;
 };
 
 struct zap_ugni_post_desc {


### PR DESCRIPTION
Modify zap close to wait for empty send queue. This is to ensure
that the send operations requested by the application got submitted
to the underlying socket before the socket get destroyed by close().

This patch has been tested with test cases in `ldms-test` repository.