### PR TITLE
Create the metric_sets_default_authz configuration option and rpc

### DIFF
--- a/ldms/python/ldmsd/ldmsd_config.py
+++ b/ldms/python/ldmsd/ldmsd_config.py
@@ -145,6 +145,7 @@ LDMSD_CTRL_CMD_MAP = {'usage': {'req_attr': [], 'opt_attr': ['name']},
                       'prdcr_stats': {'req_attr':[], 'opt_attr': []},
                       'set_stats': {'req_attr':[], 'opt_attr': []},
                       'listen': {'req_attr':['xprt', 'port'], 'opt_attr': ['host', 'auth']},
+                      'metric_sets_default_authz': {'req_attr':[], 'opt_attr': ['uid', 'gid', 'perm']},
                       ##### Failover. #####
                       'failover_config': {
                                 'req_attr': [

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1466,6 +1466,20 @@ class LdmsdCmdParser(cmd.Cmd):
     def complete_listen(self, text, lien, begidx, endidx):
         return self.__complete_attr_list('listen', text)
 
+    def do_metric_sets_default_authz(self, arg):
+        """
+        Set the default authorization values for subsequently created metric sets
+
+        Parameters:
+            [uid=]  User ID number or user name string
+            [gid=]  Group ID number or group name string
+            [perm=] Octal number representing the permissions bits
+        """
+        self.handle('metric_sets_default_authz', arg)
+
+    def complete_metric_sets_default_authz(self, text, line, begidx, endidx):
+        return self.__complete_attr_list('metric_sets_default_authz', text)
+
     def do_auth_add(self, arg):
         """
         Add an authentication domain

--- a/ldms/python/ldmsd/ldmsd_request.py
+++ b/ldms/python/ldmsd/ldmsd_request.py
@@ -338,6 +338,7 @@ class LDMSD_Request(object):
     PRDCR_STATS = 0x600 + 14
     SET_STATS = 0x600 + 15
     LISTEN = 0x600 + 16
+    SET_DEFAULT_AUTHZ = 0x600 + 17
 
     FAILOVER_CONFIG        = 0x700
     FAILOVER_PEERCFG_START = 0x700  +  1
@@ -443,7 +444,9 @@ class LDMSD_Request(object):
 
             'listen'        :  {'id' : LISTEN },
             'auth_add'      :  {'id' : AUTH_ADD },
-        }
+
+            'metric_sets_default_authz' : {'id' : SET_DEFAULT_AUTHZ },
+    }
 
     TYPE_CONFIG_CMD = 1
     TYPE_CONFIG_RESP = 2

--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -1284,7 +1284,7 @@ void ldms_set_default_authz(uid_t *uid, gid_t *gid, mode_t *perm, int set_flags)
 	}
 	if (perm != NULL) {
 		if (set_flags & DEFAULT_AUTHZ_SET_PERM) {
-			__ldms_config.default_authz_perm = perm;
+			__ldms_config.default_authz_perm = *perm;
 		} else {
 			*perm = __ldms_config.default_authz_perm;
 		}

--- a/ldms/src/ldmsd/ldmsctl.c
+++ b/ldms/src/ldmsd/ldmsctl.c
@@ -425,6 +425,15 @@ static void help_loglevel()
 		"	level=	levels [DEBUG, INFO, ERROR, CRITICAL, QUIET]\n");
 }
 
+static void help_metric_sets_default_authz()
+{
+	printf( "\nSet the default authorization values for subsequently created metric sets\n\n"
+		"Parameters:\n"
+		"     [uid=]         User ID number or user name string\n"
+		"     [gid=]         Group ID number or group name string\n"
+		"     [perm=]        Octal number representing the permissions bits\n");
+}
+
 static void help_quit()
 {
 	printf( "\nquit\n"
@@ -2076,6 +2085,8 @@ static struct command command_tbl[] = {
 	{ "listen", LDMSD_LISTEN_REQ, NULL, help_listen, resp_generic },
 	{ "load", LDMSD_PLUGN_LOAD_REQ, NULL, help_load, resp_generic },
 	{ "loglevel", LDMSD_VERBOSE_REQ, NULL, help_loglevel, resp_generic },
+	{ "metric_sets_default_authz", LDMSD_SET_DEFAULT_AUTHZ_REQ, NULL,
+			help_metric_sets_default_authz, resp_generic },
 	{ "oneshot", LDMSD_ONESHOT_REQ, NULL, help_oneshot, resp_generic },
 	{ "plugn_sets", LDMSD_PLUGN_SETS_REQ, NULL, help_plugn_sets, resp_plugn_sets },
 	{ "prdcr_add", LDMSD_PRDCR_ADD_REQ, NULL, help_prdcr_add, resp_generic },

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -50,13 +50,17 @@
 #include <errno.h>
 #include <unistd.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <coll/rbt.h>
 #include <pthread.h>
+#include <pwd.h>
+#include <grp.h>
 #include <ovis_util/util.h>
 #include <ovis_json/ovis_json.h>
 #include <arpa/inet.h>
@@ -243,6 +247,8 @@ static int listen_handler(ldmsd_req_ctxt_t reqc);
 
 static int auth_add_handler(ldmsd_req_ctxt_t reqc);
 static int auth_del_handler(ldmsd_req_ctxt_t reqc);
+
+static int set_default_authz_handler(ldmsd_req_ctxt_t reqc);
 
 /* executable for all */
 #define XALL 0111
@@ -437,6 +443,10 @@ static struct request_handler_entry request_handler[] = {
 	},
 	[LDMSD_SET_STATS_REQ] = {
 		LDMSD_SET_STATS_REQ, set_stats_handler, XALL
+	},
+
+	[LDMSD_SET_DEFAULT_AUTHZ_REQ] = {
+		LDMSD_SET_DEFAULT_AUTHZ_REQ, set_default_authz_handler, XUG
 	},
 
 	/* FAILOVER user commands */
@@ -6589,5 +6599,110 @@ send_reply:
 	/* cleanup */
 	if (name)
 		free(name);
+	return 0;
+}
+
+static int set_default_authz_handler(ldmsd_req_ctxt_t reqc)
+{
+	char *value = NULL;
+	uid_t uid;
+	bool uid_is_supplied = false;
+	gid_t gid;
+	bool gid_is_supplied = false;
+	mode_t perm;
+	bool perm_is_supplied = false;
+
+	reqc->errcode = 0;
+
+	/* Each of LDMSD_ATTR_UID, LDMSD_ATTR_GID, and LDMSD_ATTR_PERM
+	   are optional */
+
+	value = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_UID);
+	if (value) {
+		/* Check if the value is a valid user name */
+		struct passwd *pwd = getpwnam(value);
+		if (pwd) {
+			uid = pwd->pw_uid;
+			uid_is_supplied = true;
+		} else {
+			/* Check if the value is a valid UID */
+			char *endptr;
+			errno = 0;
+			uid = strtol(value, &endptr, 0);
+			if (errno == 0 && endptr != value && *endptr == '\0') {
+				uid_is_supplied = true;
+			}
+		}
+		if (!uid_is_supplied) {
+			reqc->errcode = EINVAL;
+			(void) snprintf(reqc->line_buf, reqc->line_len,
+					"uid value \"%s\" is not a valid UID or user name",
+					value);
+		}
+		free(value);
+	}
+
+	value = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_GID);
+	if (value) {
+		/* Check if the value is a valid user name */
+		struct group *grp = getgrnam(value);
+		if (grp) {
+			gid = grp->gr_gid;
+			gid_is_supplied = true;
+		} else {
+			/* Check if the value is a valid GID */
+			char *endptr;
+			errno = 0;
+			gid = strtol(value, &endptr, 0);
+			if (errno == 0 && endptr != value && *endptr == '\0') {
+				gid_is_supplied = true;
+			}
+		}
+		if (!gid_is_supplied) {
+			reqc->errcode = EINVAL;
+			(void) snprintf(reqc->line_buf, reqc->line_len,
+					"gid value \"%s\" is not a valid GID or user name",
+					value);
+		}
+		free(value);
+	}
+
+	value = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_PERM);
+	if (value) {
+		char *endptr;
+		errno = 0;
+		perm = strtol(value, &endptr, 8);
+		if (errno || endptr == value || *endptr != '\0') {
+			reqc->errcode = EINVAL;
+			(void) snprintf(reqc->line_buf, reqc->line_len,
+					"String to permission bits conversion failed");
+		} else if (perm < 0 || perm > 0777) {
+			reqc->errcode = EINVAL;
+			(void) snprintf(reqc->line_buf, reqc->line_len,
+					"Permissions value is out of range");
+		} else {
+			perm_is_supplied = true;
+		}
+		free(value);
+	}
+
+	/* only set/get the values if no errors occurred in parsing the rpc */
+	if (reqc->errcode == 0) {
+		int set_flags = 0;
+		if (uid_is_supplied)
+			set_flags |= DEFAULT_AUTHZ_SET_UID;
+		if (gid_is_supplied)
+			set_flags |= DEFAULT_AUTHZ_SET_GID;
+		if (perm_is_supplied)
+			set_flags |= DEFAULT_AUTHZ_SET_PERM;
+		ldms_set_default_authz(&uid, &gid, &perm, set_flags);
+
+		(void) snprintf(reqc->line_buf, reqc->line_len,
+				"defaults: uid=%d, gid=%d, perm=%o",
+				(int)uid, (int)gid, (int)perm);
+	}
+
+	ldmsd_send_req_response(reqc, reqc->line_buf);
+
 	return 0;
 }

--- a/ldms/src/ldmsd/ldmsd_request.h
+++ b/ldms/src/ldmsd/ldmsd_request.h
@@ -120,9 +120,8 @@ enum ldmsd_request {
 	LDMSD_THREAD_STATS_REQ,
 	LDMSD_PRDCR_STATS_REQ,
 	LDMSD_SET_STATS_REQ,
-
-	/* command-line options */
 	LDMSD_LISTEN_REQ,
+	LDMSD_SET_DEFAULT_AUTHZ_REQ,
 
 	/* failover requests by user */
 	LDMSD_FAILOVER_CONFIG_REQ = 0x700, /* "failover_config" user command */

--- a/ldms/src/ldmsd/ldmsd_request_util.c
+++ b/ldms/src/ldmsd/ldmsd_request_util.c
@@ -83,6 +83,7 @@ const struct req_str_id req_str_id_table[] = {
 	{  "load",               LDMSD_PLUGN_LOAD_REQ  },
 	{  "loglevel",           LDMSD_VERBOSE_REQ  },
 	{  "logrotate",          LDMSD_LOGROTATE_REQ  },
+	{  "metric_sets_default_authz", LDMSD_SET_DEFAULT_AUTHZ_REQ  },
 	{  "oneshot",            LDMSD_ONESHOT_REQ  },
 	{  "plugn_sets",         LDMSD_PLUGN_SETS_REQ  },
 	{  "plugn_status",       LDMSD_PLUGN_STATUS_REQ  },


### PR DESCRIPTION
Create a new configuration directive "metric_sets_default_authz" and
the associated rpc with ID LDMSD_SET_DEFAULT_AUTHZ_REQ.

This directive/rpc allows the default uid, gid, and perms of
metrics sets to be configured. All subsequently created metric sets
will use these default values unless overridden.
