### PR TITLE
Set errno if auth domain cannot be found

### DIFF
--- a/ldms/src/ldmsd/ldmsd_prdcr.c
+++ b/ldms/src/ldmsd/ldmsd_prdcr.c
@@ -764,8 +764,10 @@ ldmsd_prdcr_new_with_auth(const char *name, const char *xprt_name,
 	if (!auth)
 		auth = DEFAULT_AUTH;
 	auth_dom = ldmsd_auth_find(auth);
-	if (!auth_dom)
+	if (!auth_dom) {
+		errno = ENOENT;
 		goto out;
+	}
 	prdcr->conn_auth = strdup(auth_dom->plugin);
 	if (!prdcr->conn_auth)
 		goto out;


### PR DESCRIPTION
When creating a new producer, ldmsd_auth_find is called to associate
an authentication domain with the connection to the peer. If the domain
does not exist, the create fails, but errno is not set. This change now
sets errno to ENOENT in that case.