### PR TITLE
Set the effective uid/gid to the peer's uid/gid

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -1971,21 +1971,22 @@ static int ldms_xprt_recv_reply(struct ldms_xprt *x, struct ldms_reply *reply)
 
 static int recv_cb(struct ldms_xprt *x, void *r)
 {
+	int rc, euid_set = 0;
 	struct ldms_request_hdr *h = r;
 	int cmd = ntohl(h->cmd);
+	uid_t euid = geteuid();
+	if ((int)x->ruid > 0 && euid == 0) {
+		euid_set = 1;
+		seteuid(x->ruid);
+	}
 	if (cmd > LDMS_CMD_REPLY)
 		return ldms_xprt_recv_reply(x, r);
 
-	return ldms_xprt_recv_request(x, r);
+	rc = ldms_xprt_recv_request(x, r);
+	if (euid_set)
+		seteuid(euid);
+	return rc;
 }
-
-#if defined(__MACH__)
-#define _SO_EXT ".dylib"
-#undef LDMS_XPRT_LIBPATH_DEFAULT
-#define LDMS_XPRT_LIBPATH_DEFAULT "/home/tom/macos/lib"
-#else
-#define _SO_EXT ".so"
-#endif
 
 zap_mem_info_t ldms_zap_mem_info()
 {


### PR DESCRIPTION
This security enhancement ensures that a connected peer cannot cause the
ldmsd to undertake any action with elevated privilege.
