### PR TITLE
Stream performance improvements

### DIFF
--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -160,7 +160,7 @@ class LdmsdCmdParser(cmd.Cmd):
                 "auth": "none",
                 "auth_opt": {},
             }
-        r = re.compile("\s*(\w+)=(\w+)")
+        r = re.compile(r"\s*(\w+)=(\w+)")
         for attr, value in r.findall(args):
             if attr in kwargs:
                 kwargs[attr] = value
@@ -356,7 +356,7 @@ class LdmsdCmdParser(cmd.Cmd):
         [interval=] The connection retry interval in micro-seconds. If this is not
                   specified, the previously configured value will be used.
         """
-        self.handle('prdcr_start', arg);
+        self.handle('prdcr_start', arg)
 
     def complete_prdcr_start(self, text, line, begidx, endidx):
         return self.__complete_attr_list('prdcr_start', text)
@@ -369,7 +369,7 @@ class LdmsdCmdParser(cmd.Cmd):
         [interval=]  The connection retry interval in micro-seconds. If this is not
                    specified, the previously configured value will be used.
         """
-        self.handle('prdcr_start_regex', arg);
+        self.handle('prdcr_start_regex', arg)
 
     def complete_prdcr_start_regex(self, text, line, begidx, endidx):
         return self.__complete_attr_list('prdcr_start_regex', text)
@@ -380,7 +380,7 @@ class LdmsdCmdParser(cmd.Cmd):
         Parameters:
         name=  The producer name
         """
-        self.handle('prdcr_stop', arg);
+        self.handle('prdcr_stop', arg)
 
     def complete_prdcr_stop(self, text, line, begidx, endidx):
         return self.__complete_attr_list('prdcr_stop', text)
@@ -391,7 +391,7 @@ class LdmsdCmdParser(cmd.Cmd):
         Parameters:
         regex=   The regular expression
         """
-        self.handle('prdcr_stop_regex', arg);
+        self.handle('prdcr_stop_regex', arg)
 
     def complete_prdcr_stop_regex(self, text, line, begidx, endidx):
         return self.__complete_attr_list('prdcr_stop_regex', text)
@@ -403,7 +403,7 @@ class LdmsdCmdParser(cmd.Cmd):
         regex=     A regular expression matching producer names
         stream=    The stream name
         """
-        self.handle('prdcr_subscribe', arg);
+        self.handle('prdcr_subscribe', arg)
 
     def complete_prdcr_subscribe(self, text, line, begidx, endidx):
         return self.__complete_attr_list('prdcr_subscribe', text)
@@ -415,7 +415,7 @@ class LdmsdCmdParser(cmd.Cmd):
         regex=     A regular expression matching producer names
         stream=    The stream name
         """
-        self.handle('prdcr_unsubscribe', arg);
+        self.handle('prdcr_unsubscribe', arg)
 
     def complete_prdcr_unsubscribe(self, text, line, begidx, endidx):
         return self.__complete_attr_list('prdcr_unsubscribe', text)
@@ -531,7 +531,7 @@ class LdmsdCmdParser(cmd.Cmd):
                            the updater will schedule the set updates according
                            to the default schedule, i.e., the given interval and offset values.
         """
-        self.handle('updtr_start', arg);
+        self.handle('updtr_start', arg)
 
     def complete_updtr_start(self, text, line, begidx, endidx):
         return self.__complete_attr_list('updtr_start', text)
@@ -543,7 +543,7 @@ class LdmsdCmdParser(cmd.Cmd):
         Paramaeters:
         name=   The update policy name
         """
-        self.handle('updtr_stop', arg);
+        self.handle('updtr_stop', arg)
 
     def complete_updtr_stop(self, text, line, begidx, endidx):
         return self.__complete_attr_list('updtr_stop', text)
@@ -630,7 +630,7 @@ class LdmsdCmdParser(cmd.Cmd):
         Start storage policy.
         name=    The storage policy name
         """
-        self.handle('strgp_start', arg);
+        self.handle('strgp_start', arg)
 
     def complete_strgp_start(self, text, line, begidx, endidx):
         return self.__complete_attr_list('strgp_start', text)
@@ -642,7 +642,7 @@ class LdmsdCmdParser(cmd.Cmd):
         Paramaeters:
         name=    The storage policy name
         """
-        self.handle('strgp_stop', arg);
+        self.handle('strgp_stop', arg)
 
     def complete_strgp_stop(self, text, line, begidx, endidx):
         return self.__complete_attr_list('strgp_stop', text)
@@ -1168,7 +1168,7 @@ class LdmsdCmdParser(cmd.Cmd):
         self.handle('setgroup_rm', arg)
         pass
 
-    def complete_setgroup_ins(self, text, line, begidx, endidx):
+    def complete_setgroup_rm(self, text, line, begidx, endidx):
         return self.__complete_attr_list('setgroup_rm', text)
 
     def complete_example(self, text, line, begidx, endidx):
@@ -1253,7 +1253,7 @@ class LdmsdCmdParser(cmd.Cmd):
         {
             "prdcr_count" : <int>,
             "stopped" : <int>,
-            "disconnected" : <int>, 
+            "disconnected" : <int>,
             "connecting" : <int>,
             "connected" : <int>,
             "stopping"	: <int>,
@@ -1288,7 +1288,7 @@ class LdmsdCmdParser(cmd.Cmd):
         {
             "set_count" : <int>,
             "deleting_count" : <int>,
-            "mem_total" : <int>, 
+            "mem_total" : <int>,
             "mem_used" : <int>,
             "mem_free" : <int>,
             "compute_time" : <int>
@@ -1363,7 +1363,7 @@ class LdmsdCmdParser(cmd.Cmd):
         op_stats = stats['op_stats']
         for op_name in op_stats:
             s = op_stats[op_name]
-            print(f"{op_name:12} {s['count']:12} {s['min_us']:12} {s['mean_us']:12} {s['max_us']:12}")                            
+            print(f"{op_name:12} {s['count']:12} {s['min_us']:12} {s['mean_us']:12} {s['max_us']:12}")
 
     def do_xprt_stats(self, arg):
         """
@@ -1533,7 +1533,7 @@ if __name__ == "__main__":
                             help = "Execute the script and send the output \
                             commands to the connected ldmsd")
         parser.add_argument('-a', '--auth',
-                            help = "Authentication method.");
+                            help = "Authentication method.")
         parser.add_argument('-A', '--auth-arg', action = 'append',
                             help = "Authentication arguments (name=value). \
                                     This option can be given multiple times.")
@@ -1547,7 +1547,7 @@ if __name__ == "__main__":
         auth_opt = None
         if args.auth_arg:
             auth_opt = dict()
-            rx = re.compile("(\w+)=(.+)")
+            rx = re.compile(r"(\w+)=(.+)")
             for arg in args.auth_arg:
                 m = rx.match(arg)
                 if not m:

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -1971,21 +1971,12 @@ static int ldms_xprt_recv_reply(struct ldms_xprt *x, struct ldms_reply *reply)
 
 static int recv_cb(struct ldms_xprt *x, void *r)
 {
-	int rc, euid_set = 0;
 	struct ldms_request_hdr *h = r;
 	int cmd = ntohl(h->cmd);
-	uid_t euid = geteuid();
-	if ((int)x->ruid > 0 && euid == 0) {
-		euid_set = 1;
-		seteuid(x->ruid);
-	}
 	if (cmd > LDMS_CMD_REPLY)
 		return ldms_xprt_recv_reply(x, r);
 
-	rc = ldms_xprt_recv_request(x, r);
-	if (euid_set)
-		seteuid(euid);
-	return rc;
+	return ldms_xprt_recv_request(x, r);
 }
 
 zap_mem_info_t ldms_zap_mem_info()

--- a/ldms/src/ldmsd/ldmsd_stream.h
+++ b/ldms/src/ldmsd/ldmsd_stream.h
@@ -8,36 +8,130 @@ extern "C" {
 
 struct ldmsd_stream_client_s;
 typedef struct ldmsd_stream_client_s *ldmsd_stream_client_t;
-struct ldmsd_stream_s;
-typedef struct ldmsd_stream_s *ldmsd_stream_t;
 
 typedef enum ldmsd_stream_type_e {
 	LDMSD_STREAM_STRING,
 	LDMSD_STREAM_JSON
 } ldmsd_stream_type_t;
 
+/**
+ * \brief Publish data to a stream
+ * Publish JSON or STRING data to a stream. JSON data is formatted as
+ * a JSON object. JSON formatted data is validated at the subscriber;
+ * no error is returned for an incorrectly formatted JSON object, however,
+ * the data will be discarded at the subscriber.
+ *
+ * STRING data can be in any format, and is delivered as-is to
+ * subscribers.
+ *
+ * \param xprt The LDMS transport handle
+ * \param stream_name The stream name
+ * \param stream_type The format of the data to be published
+ * \param data Pointer to a buffer containting the data to pubish
+ * \param data_len The size of the buffer to publish
+ * \return 0 The data was succesfully sent
+ * \return !0 An error indicating why the data could not be published
+ */
 extern int ldmsd_stream_publish(ldms_t xprt, const char *stream_name,
 				ldmsd_stream_type_t stream_type,
 				const char *data, size_t data_len);
-typedef int (*ldmsd_stream_recv_cb_t)(ldmsd_stream_client_t c, void *ctxt,
+/**
+ * \brief Callback function invoked when stream data arrives
+ *
+ * \param c The stream client handle
+ * \param cb_arg The \c cb_arg parameter provided to ldmsd_stream_subscribe()
+ * \param stream_type One of LDMSD_STREAM_STRING or LDMSD_STREAM_JSON
+ * \param data Pointer to the published data
+ * \param data_len The number of bytes of data pointed to by \c data
+ * \param entity If stream_type is LDMSD_STREAM_JSON, a pointer to a
+ * parsed JSON object.
+ * \returns An integer indication the success or failure of handling the data
+ */
+typedef int (*ldmsd_stream_recv_cb_t)(ldmsd_stream_client_t c, void *cb_arg,
 				      ldmsd_stream_type_t stream_type,
 				      const char *data, size_t data_len,
 				      json_entity_t entity);
+/**
+ * \brief Subscribe to a named LDMSD stream
+ *
+ * \param stream_name The name of the stream
+ * \param cb_fn The function to call when data arrives on the stream
+ * \param cb_arg Provided as an argument to the callback function
+ * \returns The client handle
+ */
 extern ldmsd_stream_client_t
 ldmsd_stream_subscribe(const char *stream_name,
-		       ldmsd_stream_recv_cb_t cb_fn, void *ctxt);
+		       ldmsd_stream_recv_cb_t cb_fn, void *cb_arg);
+/**
+ * \brief Close a subscribed stream
+ * \param c The client handle
+ */
 extern void ldmsd_stream_close(ldmsd_stream_client_t c);
-extern const char* ldmsd_stream_name(ldmsd_stream_t s);
+/**
+ * \brief Return the name of the stream to which the client is subscribed
+ *
+ * \param c The client handle
+ * \returns The stream name
+ */
 extern const char* ldmsd_stream_client_name(ldmsd_stream_client_t c);
+/**
+ * \brief Publish the contents of a file to a stream
+ *
+ * \param stream The stream name
+ * \param type The format of the published data: "json", or "string"
+ * \param xprt The transport name
+ * \param host The host name
+ * \param port The port number
+ * \param auth The authentication plugin name
+ * \param auth_opt The authentication plugin options
+ * \param file The file name
+ * \returns 0 on success
+ * \returns errno on failure
+ */
 extern int ldmsd_stream_publish_file(const char *stream, const char *type,
 				     const char *xprt, const char *host, const char *port,
 				     const char *auth, struct attr_value_list *auth_opt,
 				     FILE *file);
+/**
+ * \brief Deliver stream data to a local subscriber
+ *
+ * \param stream_name The stream name
+ * \param stream_type The stream type: "json" or "string"
+ * \param data Pointer to the buffer containing the data
+ * \param data_len Bytes of data in \c data
+ * \param entity An optional parsed JSON object. If entity is NULL, and
+ * stream_type == JSON, the data will be parsed perior to delivery to the subscribers.
+ */
 void ldmsd_stream_deliver(const char *stream_name, ldmsd_stream_type_t stream_type,
 			  const char *data, size_t data_len,
 			  json_entity_t entity);
 
 int ldmsd_stream_response(ldms_xprt_event_t e);
+
+#define LDMSD_STREAM_F_RAW	1	/*< Don't parse incoming stream data */
+/**
+ * \brief Set stream delivery flags
+ *
+ * \param c The stream client handle
+ * \param flags The flags as a bitmap
+ */
+void ldmsd_stream_flags_set(ldmsd_stream_client_t c, uint32_t flags);
+/**
+ * \brief Get the stream delivery flags
+ *
+ * \param c The stream client handle
+ */
+uint32_t ldmsd_stream_flags_get(ldmsd_stream_client_t c);
+
+/**
+ * \brief Report the number of subscribers
+ *
+ * Returns the number of clients subscribed to \c stream_name
+ *
+ * \param stream_name The stream name
+ * \returns The number of stream subscribers
+ */
+int ldmsd_stream_subscriber_count(const char *stream_name);
 
 /**
  * Dump stream clients in JSON.

--- a/ldms/src/ldmsd/test/ldmsd_stream_publish.c
+++ b/ldms/src/ldmsd/test/ldmsd_stream_publish.c
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
 		case 'a':
 			auth = strdup(optarg);
 			if (!auth) {
-				printf("ERROR: out of memory\n"); 
+				printf("ERROR: out of memory\n");
 				exit(1);
 			}
 			break;
@@ -139,10 +139,15 @@ int main(int argc, char **argv)
 	if (!host || !port || !stream)
 		usage(argc, argv);
 
-	if (filename)
+	if (filename) {
 		file = fopen(filename, "r");
-	else
+		if (!file) {
+			perror(filename);
+			exit(1);
+		}
+	} else {
 		file = stdin;
+	}
 	int rc = ldmsd_stream_publish_file(stream, stream_type, xprt, host, port, auth, auth_opt, file);
 	if (rc) {
 		printf("Error %d publishing file.\n", rc);

--- a/ldms/src/ldmsd/test/ldmsd_stream_subscribe.c
+++ b/ldms/src/ldmsd/test/ldmsd_stream_subscribe.c
@@ -19,10 +19,13 @@
 
 static ldms_t ldms;
 static sem_t recv_sem;
-FILE *file;
+static FILE *file;
+static int quiet;
 
 void msglog(const char *fmt, ...)
 {
+	if (quiet)
+		return;
 	va_list ap;
 	static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -41,6 +44,7 @@ static struct option long_opts[] = {
 	{"auth",     required_argument, 0,  'a' },
 	{"auth_arg", required_argument, 0,  'A' },
 	{"daemonize",no_argument,       0,  'D' },
+	{"quiet",	no_argument,		0,	'q' },
 	{0,          0,                 0,  0 }
 };
 
@@ -54,7 +58,7 @@ void usage(int argc, char **argv)
 	exit(1);
 }
 
-static const char *short_opts = "p:f:s:x:a:A:D";
+static const char *short_opts = "p:f:s:x:a:A:Dq";
 
 #define AUTH_OPT_MAX 128
 
@@ -329,6 +333,9 @@ int main(int argc, char **argv)
 
 	while ((opt = getopt_long(argc, argv, short_opts, long_opts, &opt_idx)) > 0) {
 		switch (opt) {
+		case 'q':
+			quiet = 1;
+			break;
 		case 'p':
 			port_no = atoi(optarg);
 			break;


### PR DESCRIPTION
These changes significantly reduce the overhead of publishing
JSON data if that data is being forwarded and not otherwise consumed
at the subscriber.

The publisher is also acknowledged before delivering the data to the
subscribers. This reduces the latency at the producer waiting
for the ACK.
