### PR TITLE
Include auto_interval test scripts

### DIFF
--- a/ldms/scripts/examples/.canned
+++ b/ldms/scripts/examples/.canned
@@ -1,4 +1,5 @@
 # working
+auto-interval
 aggl2 # ldms_ls inconsistent, set duplicates at L2
 aggl2simple
 all_example

--- a/ldms/scripts/examples/auto-interval
+++ b/ldms/scripts/examples/auto-interval
@@ -1,0 +1,28 @@
+export plugname=meminfo
+portbase=61200
+VGARGS="--leak-check=full --track-origins=yes"
+DAEMONS $(seq 1 5)
+vgoff
+LDMSD 1 2 3 4 5
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1 -v
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2 -v
+MESSAGE ldms_ls on host 3:
+LDMS_LS 3 -v
+MESSAGE ldms_ls on host 4:
+LDMS_LS 4 -l
+LDMS_LS 4 -v
+MESSAGE ldms_ls on host 5:
+LDMS_LS 5 -l
+LDMS_LS 5 -v
+SLEEP 35
+KILL_LDMSD `seq 5`
+export agg=agg
+file_created $STOREDIR/node_${agg}/${testname}_fast
+file_created $STOREDIR/node_${agg}/${testname}_medium
+file_created $STOREDIR/node_${agg}/${testname}_slow
+export agg=agg_backoff
+file_created $STOREDIR/node_${agg}/${testname}_fast
+file_created $STOREDIR/node_${agg}/${testname}_medium
+file_created $STOREDIR/node_${agg}/${testname}_slow

--- a/ldms/scripts/examples/auto-interval.1
+++ b/ldms/scripts/examples/auto-interval.1
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} schema=${testname}_fast instance=localhost${i}/${testname} component_id=${i}
+start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/auto-interval.2
+++ b/ldms/scripts/examples/auto-interval.2
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} schema=${testname}_medium instance=localhost${i}/${testname} component_id=${i}
+start name=${plugname} interval=5000000 offset=0

--- a/ldms/scripts/examples/auto-interval.3
+++ b/ldms/scripts/examples/auto-interval.3
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} schema=${testname}_slow instance=localhost${i}/${testname} component_id=${i}
+start name=${plugname} interval=10000000 offset=0

--- a/ldms/scripts/examples/auto-interval.4
+++ b/ldms/scripts/examples/auto-interval.4
@@ -1,0 +1,30 @@
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+# first aggregator at 2 sec intervals
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=1000000
+prdcr_start name=localhost1
+
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=1000000
+prdcr_start name=localhost2
+
+prdcr_add name=localhost3 host=${HOST} type=active xprt=${XPRT} port=${port3} interval=1000000
+prdcr_start name=localhost3
+
+updtr_add name=allhosts interval=2000000 offset=1000000 auto_interval=true
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+# schemas are auto-interval_slow, auto-interval_medium and auto-interval_fast
+strgp_add name=store_${testname}_fast plugin=store_csv schema=${testname}_fast container=node_agg
+strgp_prdcr_add name=store_${testname}_fast regex=.*
+strgp_start name=store_${testname}_fast
+
+strgp_add name=store_${testname}_medium plugin=store_csv schema=${testname}_medium container=node_agg
+strgp_prdcr_add name=store_${testname}_medium regex=.*
+strgp_start name=store_${testname}_medium
+
+strgp_add name=store_${testname}_slow plugin=store_csv schema=${testname}_slow container=node_agg
+strgp_prdcr_add name=store_${testname}_slow regex=.*
+strgp_start name=store_${testname}_slow
+

--- a/ldms/scripts/examples/auto-interval.5
+++ b/ldms/scripts/examples/auto-interval.5
@@ -1,0 +1,30 @@
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+# Second aggregator at 15 sec intervals
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_start name=localhost1
+
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=10000000
+prdcr_start name=localhost2
+
+prdcr_add name=localhost3 host=${HOST} type=active xprt=${XPRT} port=${port3} interval=10000000
+prdcr_start name=localhost3
+
+updtr_add name=allhosts interval=15000000 offset=1000000 auto_interval=true
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+# schemas are auto-interval_slow, auto-interval_medium and auto-interval_fast
+strgp_add name=store_${testname}_fast plugin=store_csv schema=${testname}_fast container=node_agg_backoff
+strgp_prdcr_add name=store_${testname}_fast regex=.*
+strgp_start name=store_${testname}_fast
+
+strgp_add name=store_${testname}_medium plugin=store_csv schema=${testname}_medium container=node_agg_backoff
+strgp_prdcr_add name=store_${testname}_medium regex=.*
+strgp_start name=store_${testname}_medium
+
+strgp_add name=store_${testname}_slow plugin=store_csv schema=${testname}_slow container=node_agg_backoff
+strgp_prdcr_add name=store_${testname}_slow regex=.*
+strgp_start name=store_${testname}_slow
+


### PR DESCRIPTION
Include test scripts for the "auto_interval" option when updating the aggregator daemons. 

There are 3 sampler daemons with interval hints of 1sec (fast), 5secs (medium), and 10 secs (slow) and two aggregator daemons that aggregate the data at 1 sec and 10 secs, respectively. 

Test scripts have been checked will Valgrind. 
 