### PR TITLE
Added test cases to static runs list

### DIFF
--- a/ldms/src/test/ldms-static-test-bypass.in
+++ b/ldms/src/test/ldms-static-test-bypass.in
@@ -43,3 +43,5 @@ kgnilnd
 hello_stream
 llnl
 munge
+tx2mon
+auto-interval

--- a/ldms/src/test/ldms-static-test-list.sh.in
+++ b/ldms/src/test/ldms-static-test-list.sh.in
@@ -42,3 +42,5 @@
 @ENABLE_HELLO_STREAM_TRUE@ testlist[${#testlist[@]}]="hello_stream"
 @ENABLE_LLNL_EDAC_TRUE@ testlist[${#testlist[@]}]="llnl"
 @ENABLE_MUNGE_TRUE@ testlist[${#testlist[@]}]="munge"
+@ENABLE_TX2MON_TRUE@ testlist[${#testlist[@]}]="tx2mon"
+testlist[${#testlist[@]}]="auto-interval"


### PR DESCRIPTION
Added the "tx2mon" and "auto_interval" test cases to ldms-static-test-list.sh so they are tested during "make check" and "make installcheck". 
Since tx2mon is not default "enabled" and the auto-interval test case is under revision in pull request #635 , I've added them in the ldms-static-test-list-bypass file so automake does not fail (and then stop) during the make check process.