### PR TITLE
WIP: Add store-oriented hashes of schema content to sampler_base.

### DIFF
--- a/ldms/man/ldms_ls.man
+++ b/ldms/man/ldms_ls.man
@@ -90,7 +90,7 @@ pre-allocated memory specified when starting the remote ldmsd being queried.
 Display the user data for the metrics. (Usually compid)
 .TP
 .BR -v
-Display metadata information. Specifying this option multiple times increases the verbosity.
+Display metadata information. Specifying this option multiple times increases the verbosity. LDMS set_info strings are included in this output.
 .TP
 .BR -V
 Display LDMS version information and then exit.

--- a/ldms/src/sampler/sampler_base.h
+++ b/ldms/src/sampler/sampler_base.h
@@ -202,4 +202,47 @@ int base_auth_parse(struct attr_value_list *avl, struct base_auth *auth,
  */
 void base_auth_set(const struct base_auth *auth, ldms_set_t set);
 
+/** Define set_info key/value pairs on the set instance for keys
+ * matching the name in enum ldms_schema_hash.
+ * The values are the hex string form of 64 bit CityHash of
+ * strings composed of:
+ * schema_name (SH_NAME_ARRAY_LEN_CH64,SH_NAME_ARRAY_POLY_CH64)
+ * schema metric count
+ * metric types
+ * metric names
+ * array metric sizes (SH_NAME_ARRAY_POLY_CH64, SH_ARRAY_POLY_CH64)
+ * as documented by the enum ldms_schema_hash.
+ *
+ * When present, these hashes allow a set consumer to quickly know
+ * if two set instances have the same schema content.
+ * If corresponding *_ARRAY_LEN_* values are the same, everything
+ * including array sizes is the same.
+ * If corresponding *_ARRAY_POLY_* values are the same, array sizes
+ * may vary so long as the other included properties are the same.
+ *
+ * @param base used for the log function. If base == NULL, no logging occurs.
+ * @param set values are added to the set given. If NULL, values
+ * are added to the base->set. This allows partial use (mix-in) of the
+ * sampler_base logic.
+ * @return 0, or errno value if there is a problem in computations.
+ */
+int base_set_hashes_set(base_data_t base, ldms_set_t set);
+
+/** The hash types include set features as listed after each value.
+ * For a given store semantics, schema equivalence will be determined
+ * by one of these. */
+typedef enum ldms_schema_hash {
+	SH_ARRAY_LEN_CH64,      /**< count, metric_list_&_array_sizes */
+	SH_ARRAY_POLY_CH64,     /**< count, metric_list */
+	SH_NAME_ARRAY_LEN_CH64, /**< schema, count, metric_list_&_array_sizes */
+	SH_NAME_ARRAY_POLY_CH64,/**< schema, count, metric_list */
+} ldms_schema_hash_t;
+
+/** fetch the hash value indicated, or NULL if it is not defined.
+ * @param base source of set to query if and only if parameter 'set' is NULL.
+ * @param set source of the info values.
+ * @param lsh kind of hash code to be returned.
+ */
+const char * base_set_hash_get(base_data_t base, ldms_set_t set, ldms_schema_hash_t lsh);
+
 #endif

--- a/ldms/src/store/store_csv_common.c
+++ b/ldms/src/store/store_csv_common.c
@@ -59,6 +59,7 @@
 #include "store_csv_common.h"
 #define DSTRING_USE_SHORT
 #include "ovis_util/dstring.h"
+#include "third/city.h"
 
 
 /** parse an option of the form name=bool where bool is
@@ -955,3 +956,115 @@ void print_csv_store_handle_common(struct csv_store_handle_common *h, struct csv
 	p->msglog(LDMSD_LALL, "%s: create_gid: %" PRIu32 "\n", p->pname, h->create_gid);
 	p->msglog(LDMSD_LALL, "%s: create_perm: %o\n", p->pname, h->create_perm);
 }
+
+/* apply over all N dynamic strings. */
+#define DO_N(x) \
+	x(nalch64, CSH_NAME_ARRAY_LEN_CH64); \
+	x(alch64, CSH_ARRAY_LEN_CH64)
+
+int csv_set_hashes_set(ldmsd_msg_log_f mlg, ldms_set_t set)
+{
+
+#define DECL_DS(y, e) dstring_t y##_ds; dstr_init2(&y##_ds, 4096)
+#define ADD_CARD(y, e) dstrcat_uint(&y##_ds, (uint64_t)sc)
+#define ADD_COMMA(y, e) dstrcat(&y##_ds, ",", 1)
+#define ADD_METRIC(y, e) dstrcat(&y##_ds, mn, DSTRING_ALL)
+#define ADD_UBAR3(y, e) dstrcat(&y##_ds, "___", 3)
+#define ADD_TYPE(y, e) dstrcat(&y##_ds, mts, DSTRING_ALL)
+/* all errors on dstrcat fall safely through to the last use of it. */
+#define ADD_COMMA_CHECK_NULL(y, e) if ( NULL == dstrcat(&y##_ds, ",", 1)) \
+		{ \
+			rc = ENOMEM; \
+			goto err; \
+		}
+#define DECL_BUF(y, e) const char *y##_buf = dstrval(&y##_ds)
+#define DECL_LEN(y, e) int y##_len = dstrlen(&y##_ds)
+#define DECL_HASH_U64(y, e) uint64_t y##_hash_u = CityHash64(y##_buf, y##_len)
+#define DECL_HASH(y, e) char y##_hash[17]
+#define FORMAT_HASH(y, e) sprintf(y##_hash, "%" PRIX64, y##_hash_u)
+#define SET_HASH(y, e) ldms_set_info_set(set, #e, y##_hash)
+#define LOG_HASH(y, e) mlg(LDMSD_LDEBUG, "store_csv_common: %s %s %s\n", sn, #e, y##_hash)
+#define LOG_DESCRIPTION(y, e) mlg(LDMSD_LDEBUG, "store_csv_common: %s %s set description %s\n", sn, #e, y##_buf);
+#define FREE_DS(y, e) dstr_free(&y##_ds)
+
+	if (!set)
+		return EINVAL;
+	int rc = 0;
+	DO_N(DECL_DS);
+	const char *sn = ldms_set_schema_name_get(set);
+	uint32_t sc = ldms_set_card_get(set);
+
+	/* append [name,] in name-included cases */
+	dstrcat(&nalch64_ds, sn, DSTRING_ALL);
+	dstrcat(&nalch64_ds, ",", 1);
+
+	DO_N(ADD_CARD);
+	DO_N(ADD_COMMA);
+	int i;
+	for (i = 0; i < sc; i++) {
+		/* append name___type[len], */
+		const char *mn = ldms_metric_name_get(set, i);
+		enum ldms_value_type mt = ldms_metric_type_get(set, i);
+		const char * mts = ldms_metric_type_to_str(mt);
+		DO_N(ADD_METRIC);
+		DO_N(ADD_UBAR3);
+		DO_N(ADD_TYPE);
+		/* append array size in len-included cases */
+		if (ldms_type_is_array(mt)) {
+			uint32_t ml;
+			ml = ldms_metric_array_get_len(set, i);
+			dstrcat_int(&nalch64_ds, ml);
+			dstrcat_int(&alch64_ds, ml);
+		}
+		DO_N(ADD_COMMA_CHECK_NULL);
+	}
+	DO_N(DECL_BUF);
+	DO_N(DECL_LEN);
+	DO_N(DECL_HASH_U64);
+	DO_N(DECL_HASH);
+	DO_N(FORMAT_HASH);
+	DO_N(SET_HASH);
+	if (mlg) {
+		DO_N(LOG_HASH);
+#ifdef DEBUG
+		DO_N(LOG_DESCRIPTION);
+#endif
+	}
+
+err:
+	DO_N(FREE_DS);
+	return rc;
+#undef DECL_DS
+#undef FREE_DS
+#undef ADD_CARD
+#undef ADD_COMMA
+#undef ADD_METRIC
+#undef ADD_UBAR3
+#undef ADD_TYPE
+#undef ADD_COMMA_CHECK_NULL
+#undef DECL_BUF
+#undef DECL_LEN
+#undef DECL_HASH_U64
+#undef DECL_HASH
+#undef FORMAT_HASH
+#undef SET_HASH
+#undef LOG_HASH
+#undef LOG_DESCRIPTION
+}
+
+const char * csv_set_hash_get(ldms_set_t set, ldms_schema_hash_t lsh)
+{
+	const char * r = NULL;
+	if (!set)
+		return r;
+
+#define CASE_LSH(y, d) case d: r = ldms_set_info_get(set, #d); break
+	switch (lsh) {
+	DO_N(CASE_LSH);
+	default:
+		break;
+	}
+	return r;
+#undef CASE_LSH
+}
+#undef DO_N

--- a/ldms/src/store/store_csv_common.h
+++ b/ldms/src/store/store_csv_common.h
@@ -295,4 +295,42 @@ void print_csv_store_handle_common(struct csv_store_handle_common *s_handle, str
 
 #define LIB_DTOR_COMMON(cps)
 
+/** Define set_info key/value pairs on the set instance for keys
+ * matching the name in enum ldms_schema_hash.
+ * The values are the hex string form of 64 bit CityHash of
+ * strings composed of:
+ * schema_name (only for CSH_NAME_ARRAY_LEN_CH64)
+ * schema metric count
+ * metric types
+ * metric names
+ * array metric sizes
+ * as documented by the enum csv_schema_hash.
+ *
+ * When present, these hashes allow a set consumer to quickly know
+ * if two set instances have the same schema content.
+ * If corresponding *_ARRAY_LEN_* values are the same, everything
+ * including array sizes is the same.
+ *
+ * @param mlg the log function. If mlg == NULL, no logging occurs.
+ * @param set values are added to the set given. 
+ * @return 0, or errno value if there is a problem in computations.
+ */
+int csv_set_hashes_set(ldmsd_msg_log_f mlg, ldms_set_t set);
+
+/** The hash types include set features as listed after each value.
+ * For a given store semantics, schema equivalence will be determined
+ * by one of these.
+ */
+typedef enum csv_schema_hash {
+	CSH_ARRAY_LEN_CH64,      /**< count, metric_list_&_array_sizes */
+	CSH_NAME_ARRAY_LEN_CH64, /**< schema, count, metric_list_&_array_sizes */
+} ldms_schema_hash_t;
+
+/** fetch the hash value indicated, or NULL if it is not defined.
+ * @param base source of set to query if and only if parameter 'set' is NULL.
+ * @param set source of the info values.
+ * @param lsh kind of hash code to be returned.
+ */
+const char * csv_set_hash_get(ldms_set_t set, ldms_schema_hash_t lsh);
+
 #endif /* store_csv_common_h_seen */


### PR DESCRIPTION
Store authors often need to know if the schema
of two set instances are equivalent, independent of schema string name.
This removes strongly relying on administrators to invent globally
consistent schema names and provides a fast method (comparing hashes)
of verifying that no conflicts in schema content exist.

As computing a hash of the schema is
an expensive operation, computing it once at set creation minimizes work
globally. This patch defines 8 byte integer hash codes (stored in
set_info key/value pairs as 17 byte strings) for 4 kinds of schema
equivalence check: see sampler_base.h enum ldms_schema_hash_t.

The new sampler_base functions are designed with signatures and argument
handling such that they may be applied to multiple set instances in the same
sampler independently, should the specific sampler need it. This also
allows samplers not derived from sampler_base to apply the hash setting functions.

The update to the ldms_ls man page simply identifies that ldms_ls -v
will show set_info strings, such as the updater hints and these schema hash values.

Creating trees based on the string hash key or the string hash key converted
back to a uint64_t allows rapid determination of which store a set instance
can be safely routed to, for those stores (or storage policies)
requiring matching schema.

With this addition, it becomes trivially easy for a single CSV or SOS store
to be configured which accepts any set instance of any schema and dispatches to the appropriate table/file. (with suitable implementation extensions to the store plugins).

An alternative approach to storing the hashes in set_info is to store them in metadata. This might save transmission bytes at the expense of storage bytes, however.