### PR TITLE
remove  dead store api

### DIFF
--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -713,15 +713,6 @@ int ldmsd_loglevel_to_syslog(enum ldmsd_loglevel level);
  */
 void ldmsd_sec_ctxt_get(ldmsd_sec_ctxt_t sctxt);
 
-
-#ifdef STORE_API_DEPRECATED
-int ldmsd_store_data_add(struct ldmsd_store_policy *lsp, ldms_set_t set);
-
-struct store_instance *
-ldmsd_store_instance_get(struct ldmsd_store *store,
-			 struct ldmsd_store_policy *sp);
-#endif
-
 static inline ldmsd_store_handle_t
 ldmsd_store_open(struct ldmsd_store *store,
 		const char *container, const char *schema,

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -714,11 +714,13 @@ int ldmsd_loglevel_to_syslog(enum ldmsd_loglevel level);
 void ldmsd_sec_ctxt_get(ldmsd_sec_ctxt_t sctxt);
 
 
+#ifdef STORE_API_DEPRECATED
 int ldmsd_store_data_add(struct ldmsd_store_policy *lsp, ldms_set_t set);
 
 struct store_instance *
 ldmsd_store_instance_get(struct ldmsd_store *store,
 			 struct ldmsd_store_policy *sp);
+#endif
 
 static inline ldmsd_store_handle_t
 ldmsd_store_open(struct ldmsd_store *store,


### PR DESCRIPTION
Would prefer to convert to deleting these, but folk need to look first.
These two functions stubs date from 2013/2015 and are nowhere implemented.