### PR TITLE
add cpu_num metric and more error checking to tx2mon

### DIFF
--- a/ldms/src/sampler/tx2mon/Plugin_tx2mon.man
+++ b/ldms/src/sampler/tx2mon/Plugin_tx2mon.man
@@ -96,6 +96,7 @@ ext_evt_cnt       Total number of exteral events.
 temp_throttle_ms  Time duration of all temperature events in ms.
 pwr_throttle_ms   Time duration of all power events in ms.
 ext_throttle_ms   Time duration of all external events in ms.
+cpu_num        Which processor the data comes from.
 .fi
 
 .PP


### PR DESCRIPTION
This records the socket number (cpu_num) in the data set so it doesn't have to be extracted from the set instance name.
Additional nits fixed:
 * It adds return checking so that config fails if a metric add fails.
 * It fixes an array overrun that happens and is trapped only when compiled in hardened mode
per ARM/rhel7 RPM build defaults (-Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong).
 * It converts a lingering printf into a log call.