### PR TITLE
store_csv: Repair constant file rename errors

### DIFF
--- a/ldms/src/store/store_csv.c
+++ b/ldms/src/store/store_csv.c
@@ -739,7 +739,8 @@ static void *get_ucontext(ldmsd_store_handle_t _s_handle)
 
 /*
  * note: this should be residual from v2 where we may not have had the header info until a store was called
- * which then meant we had the mvec. ideally the print_header will always happen from the store_open.
+ * which then meant we had the mvec. ideally the print_header will always happen from the open_store,
+ * but in point of fact is currently _never_ called in open_store.
  * Currently we still have to keep this to invert the metric order
  */
 static int print_header_from_store(struct csv_store_handle *s_handle, ldms_set_t set,
@@ -768,13 +769,13 @@ static int print_header_from_store(struct csv_store_handle *s_handle, ldms_set_t
 		else
 			ec = snprintf(tmp_path, PATH_MAX, "%s.HEADER",
 				s_handle->path);
-			} else {
+	} else {
 		if (rolltype >= MINROLLTYPE)
 			ec = snprintf(tmp_path, PATH_MAX, "%s.%d",
 				s_handle->path, (int)s_handle->otime);
 		else
 			ec = snprintf(tmp_path, PATH_MAX, "%s", s_handle->path);
-				}
+	}
 	(void)ec;
 	csv_format_header_common(fp, tmp_path, CCSHC(s_handle), s_handle->udata,
 		&PG, set, metric_array, metric_count);

--- a/ldms/src/store/store_csv.c
+++ b/ldms/src/store/store_csv.c
@@ -277,11 +277,11 @@ static void roll_cb(void *obj, void *cb_arg)
 	if (s_handle->headerfile) {
 		fclose(s_handle->headerfile);
 	}
-	if (s_handle->headerfilename) {
+	if (s_handle->altheader != 0 && s_handle->headerfilename) {
 		rename_output(s_handle->headerfilename, FTYPE_HDR,
-			CSHC(s_handle), cps);
+			      CSHC(s_handle), cps);
 	}
-	if (s_handle->typefilename) {
+	if (s_handle->typeheader != 0 && s_handle->typefilename) {
 		rename_output(s_handle->typefilename, FTYPE_KIND,
 			CSHC(s_handle), cps);
 		snprintf(tmp_typepath, PATH_MAX, "%s.KIND.%d",

--- a/ldms/src/store/store_csv_common.c
+++ b/ldms/src/store/store_csv_common.c
@@ -421,12 +421,9 @@ void rename_output(const char *name,
 	err = rename(name, newname);
 	if (err) {
 		int ec = errno;
-		if (ec != ENOENT) {
-			strerror_r(ec, errbuf, EBSIZE);
-			cps->msglog(LDMSD_LERROR,"%s: rename_output: failed rename(%s, %s): %s\n",
-				cps->pname, name, newname, errbuf);
-		}
-		/* enoent happens if altheader = 0 or typeheader = 0 */
+		strerror_r(ec, errbuf, EBSIZE);
+		cps->msglog(LDMSD_LERROR,"%s: rename_output: failed rename(%s, %s): %s\n",
+			    cps->pname, name, newname, errbuf);
 	}
 	free(newname);
 #undef EBSIZE


### PR DESCRIPTION
When altheader=0, the default setting for the store_csv store:

The store_csv code has a bug that results in chown/chmod error
messages every time a file is renamed. A sanitized version of
the error looks like:

  DEBUG: store_csv: rename_output: rename(A, B)
  ERROR: store_csv: rename_output: unable to chmod(A,660): No such file or directory.
  ERROR: store_csv: rename_output: unable to chown(A, <UID>, <GID>: No such file or directory.
  DEBUG: store_csv: rename_output: rename(A, B)

It _appears_ that the second redundant rename of "A" to "B" succeeds, even
though the chmod and chown of "A" fail immediately before. However, this is
not the case. In fact only the first rename succeeds as we would expect, and
the error from the second rename is simply ignored. The code comment
explaining the ignored error says:

 "enoent happens if altheader = 0 or typeheader = 0"

So it was recognized that the code was incorrect, but the error was ignored
rather than fixing the problem.

The issue seems to be that when altheader=0, the header is not a separate
file, but added as a comment in the main CSV file. However the code redundantly
fills in the same file name for the headerfile rather than recognizing this
fact.

This code has become a bit spaghettified over the years, and probably
needs an overhaul to make a fully clean fix.

In the mean time we use a small fix to avoid the incorrect file rename 
attempts when altheader is zero and when typeheader is zero.
