### PR TITLE
Fix ldmsctl to provide the correct msg length to response handlers

### DIFF
--- a/ldms/src/ldmsd/ldmsctl.c
+++ b/ldms/src/ldmsd/ldmsctl.c
@@ -2291,7 +2291,6 @@ static int __handle_cmd(struct ldmsctl_ctrl *ctrl, char *cmd_str)
 		exit(1);
 	}
 
-	size_t msglen = 0;
 	rc = 0;
 	ldmsctl_buffer_t recv_buf;
 
@@ -2322,7 +2321,7 @@ done_recv:
 	/* We have received the whole message */
 	if (rsp) {
 		ldmsd_ntoh_req_msg(rsp);
-		cmd->resp(rsp, msglen, rsp->rsp_err);
+		cmd->resp(rsp, b->len, rsp->rsp_err);
 	} else {
 		assert(rsp);
 	}


### PR DESCRIPTION
The patch (5195ba3) that unifies the code to gather records into a whole
LDMSD message introduced the bug. The patch does not set the value of
the msglen variable in the __handle_cmd(). Resulting in __handle_cmd
always pass 0 as the response message length. The response handlers of
the status commands, e.g., prdcr_status, updtr_status, and
daemon_status, use the value provided by the __handle_cmd() when they
parse the string into a JSON object.