### PR TITLE
csv: fix typeheader create perms and extra close messages

### DIFF
--- a/ldms/scripts/examples/rollagain
+++ b/ldms/scripts/examples/rollagain
@@ -3,7 +3,7 @@ portbase=61098
 #export VGARGS="--track-origins=yes --leak-check=full --show-leak-kinds=all"
 LDMSD -p prolog.sampler 1
 #vgon
-LDMSD 2 3 4
+LDMSD $(seq 2 4)
 #vgoff
 MESSAGE ldms_ls on host 1:
 LDMS_LS 1 -l

--- a/ldms/scripts/examples/rollagain
+++ b/ldms/scripts/examples/rollagain
@@ -3,13 +3,13 @@ portbase=61098
 #export VGARGS="--track-origins=yes --leak-check=full --show-leak-kinds=all"
 LDMSD -p prolog.sampler 1
 #vgon
-LDMSD 2
+LDMSD 2 3 4
 #vgoff
 MESSAGE ldms_ls on host 1:
 LDMS_LS 1 -l
 MESSAGE ldms_ls on host 2:
-LDMS_LS 2 -l
+LDMS_LS 2 -v
 SLEEP 30
-KILL_LDMSD `seq 2`
+KILL_LDMSD `seq 4`
 rollover_created $STOREDIR/$HOSTNAME/$testname
 

--- a/ldms/scripts/examples/rollagain.3
+++ b/ldms/scripts/examples/rollagain.3
@@ -1,5 +1,5 @@
 load name=store_csv
-config name=store_csv path=${STOREDIR} altheader=0 rollover=5 rollagain=10 rolltype=5 rename_template=${STOREDIR}/%{HOSTNAME}/%B typeheader=2 create_perm=0643
+config name=store_csv path=${STOREDIR} altheader=1 typeheader=2 rollover=5 rollagain=10 rolltype=5 rename_template=${STOREDIR}/%{HOSTNAME}_headers/%B rename_perm=0777
 
 prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
 prdcr_start name=localhost1
@@ -8,6 +8,6 @@ updtr_add name=allhosts interval=1000000 offset=100000
 updtr_prdcr_add name=allhosts regex=.*
 updtr_start name=allhosts
 
-strgp_add name=store_${testname} plugin=store_csv schema=${testname} container=node
+strgp_add name=store_${testname} plugin=store_csv schema=${testname} container=node_headers
 strgp_prdcr_add name=store_${testname} regex=.*
 strgp_start name=store_${testname}

--- a/ldms/scripts/examples/rollagain.4
+++ b/ldms/scripts/examples/rollagain.4
@@ -1,5 +1,5 @@
 load name=store_csv
-config name=store_csv path=${STOREDIR} altheader=0 rollover=5 rollagain=10 rolltype=5 rename_template=${STOREDIR}/%{HOSTNAME}/%B typeheader=2 create_perm=0643
+config name=store_csv path=${STOREDIR} altheader=1 typeheader=2 rollover=5 rollagain=10 rolltype=5 rename_template=${STOREDIR}/%{HOSTNAME}_defperm/%B
 
 prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
 prdcr_start name=localhost1
@@ -8,6 +8,6 @@ updtr_add name=allhosts interval=1000000 offset=100000
 updtr_prdcr_add name=allhosts regex=.*
 updtr_start name=allhosts
 
-strgp_add name=store_${testname} plugin=store_csv schema=${testname} container=node
+strgp_add name=store_${testname} plugin=store_csv schema=${testname} container=node_defperm
 strgp_prdcr_add name=store_${testname} regex=.*
 strgp_start name=store_${testname}

--- a/ldms/src/store/store_csv.c
+++ b/ldms/src/store/store_csv.c
@@ -789,14 +789,14 @@ static int print_header_from_store(struct csv_store_handle *s_handle, ldms_set_t
 
 	/* dump data types header, or whine and continue to other headers. */
 	if (s_handle->typeheader > 0 && s_handle->typeheader <= TH_MAX) {
-		fp = fopen(s_handle->typefilename, "w");
+		fp = fopen_perm(s_handle->typefilename, "w", LDMSD_DEFAULT_FILE_PERM);
 		if (!fp) {
 			int rc = errno;
 			PG.msglog(LDMSD_LERROR, PNAME ": print_header: %s "
 				"failed to open types file (%d).\n",
 				s_handle->typefilename, rc);
 		} else {
-			ch_output(fp, tmp_path, CSHC(s_handle), &PG);
+			ch_output(fp, s_handle->typefilename, CSHC(s_handle), &PG);
 			csv_format_types_common(s_handle->typeheader, fp, 
 				s_handle->typefilename, CCSHC(s_handle),
 				s_handle->udata, &PG, set,

--- a/ldms/src/store/store_csv_common.c
+++ b/ldms/src/store/store_csv_common.c
@@ -916,8 +916,10 @@ void close_store_common(struct csv_store_handle_common *s_handle, struct csv_plu
 	}
 
 	rename_output(s_handle->filename, FTYPE_DATA, s_handle, cps);
-	rename_output(s_handle->headerfilename, FTYPE_HDR, s_handle, cps);
-	rename_output(s_handle->typefilename, FTYPE_KIND, s_handle, cps);
+	if (s_handle->altheader)
+		rename_output(s_handle->headerfilename, FTYPE_HDR, s_handle, cps);
+	if (s_handle->typeheader)
+		rename_output(s_handle->typefilename, FTYPE_KIND, s_handle, cps);
 	replace_string(&(s_handle->filename), NULL);
 	replace_string(&(s_handle->headerfilename),  NULL);
 	replace_string(&(s_handle->typefilename),  NULL);


### PR DESCRIPTION
this extends to close the improvement from #655 and fixes the related perms on the typeheader file.