### PR TITLE
Adding/documenting free() semantics for various object free functions.

### DIFF
--- a/ldms/src/core/ldms_auth.c
+++ b/ldms/src/core/ldms_auth.c
@@ -105,6 +105,8 @@ ldms_auth_t ldms_auth_clone(ldms_auth_t auth)
 
 void ldms_auth_free(ldms_auth_t auth)
 {
+	if (!auth)
+		return;
 	auth->plugin->auth_free(auth);
 }
 

--- a/ldms/src/core/ldms_auth.h
+++ b/ldms/src/core/ldms_auth.h
@@ -173,7 +173,7 @@ ldms_auth_t ldms_auth_clone(ldms_auth_t auth);
 /**
  * \brief Free the authentication object
  *
- * \param auth The authentication object handle
+ * \param auth The authentication object handle. Ignores NULL input.
  */
 void ldms_auth_free(ldms_auth_t auth);
 

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -1975,6 +1975,9 @@ static void process_push_reply(struct ldms_xprt *x, struct ldms_reply *reply,
 
 void ldms_xprt_dir_free(ldms_t t, ldms_dir_t dir)
 {
+	(void)t;
+	if (!dir)
+		return;
 	int i, j;
 	for (i = 0; i < dir->set_count; i++) {
 		free(dir->set_data[i].inst_name);

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -574,8 +574,7 @@ void __free_req_ctxt(ldmsd_req_ctxt_t reqc)
 	rbt_del(&msg_tree, &reqc->rbn);
 	if (reqc->line_buf)
 		free(reqc->line_buf);
-	if (reqc->req_buf)
-		ldmsd_msg_buf_free(reqc->_req_buf);
+	ldmsd_msg_buf_free(reqc->_req_buf);
 	ldmsd_msg_buf_free(reqc->rep_buf);
 	free(reqc);
 }
@@ -709,6 +708,8 @@ ldmsd_req_cmd_t ldmsd_req_cmd_new(ldms_t ldms,
 /* Caller must hold the msg_tree locks. */
 void free_req_cmd_ctxt(ldmsd_req_cmd_t rcmd)
 {
+	if (!rcmd)
+		return;
 	if (rcmd->org_reqc)
 		req_ctxt_ref_put(rcmd->org_reqc);
 	if (rcmd->reqc && rcmd->reqc->xprt->cleanup_fn)
@@ -759,10 +760,8 @@ static int string2attr_list(char *str, struct attr_value_list **__av_list,
 	*__kw_list = kw_list;
 	return 0;
 err:
-	if (av_list)
-		av_free(av_list);
-	if (kw_list)
-		av_free(kw_list);
+	av_free(av_list);
+	av_free(kw_list);
 	*__av_list = NULL;
 	*__kw_list = NULL;
 	return rc;
@@ -4372,22 +4371,16 @@ einval:
 		       	attr_name);
 	goto send_reply;
 err:
-	if (kw_list)
-		av_free(kw_list);
-	if (av_list)
-		av_free(av_list);
+	av_free(kw_list);
+	av_free(av_list);
 	kw_list = NULL;
 	av_list = NULL;
 send_reply:
 	ldmsd_send_req_response(reqc, reqc->line_buf);
-	if (plugin_name)
-		free(plugin_name);
-	if (config_attr)
-		free(config_attr);
-	if (kw_list)
-		av_free(kw_list);
-	if (av_list)
-		av_free(av_list);
+	free(plugin_name);
+	free(config_attr);
+	av_free(kw_list);
+	av_free(av_list);
 	return 0;
 }
 
@@ -4850,12 +4843,9 @@ static int env_handler(ldmsd_req_ctxt_t reqc)
 	}
 out:
 	ldmsd_send_req_response(reqc, reqc->line_buf);
-	if (kw_list)
-		av_free(kw_list);
-	if (av_list)
-		av_free(av_list);
-	if (exp_val)
-		free(exp_val);
+	av_free(kw_list);
+	av_free(av_list);
+	free(exp_val);
 	return rc;
 }
 
@@ -5776,8 +5766,7 @@ static char * __thread_stats_as_json(size_t *json_sz)
 	return buff;
 __APPEND_ERR:
 	zap_thrstat_free_result(res);
-	if (buff)
-		free(buff);
+	free(buff);
 	return NULL;
 }
 
@@ -6556,14 +6545,10 @@ attr_required:
 send_reply:
 	ldmsd_send_req_response(reqc, reqc->line_buf);
 	/* cleanup */
-	if (name)
-		free(name);
-	if (plugin)
-		free(plugin);
-	if (auth_args)
-		free(auth_args);
-	if (auth_opts)
-		av_free(auth_opts);
+	free(name);
+	free(plugin);
+	free(auth_args);
+	av_free(auth_opts);
 	return 0;
 }
 

--- a/ldms/src/ldmsd/ldmsd_request.h
+++ b/ldms/src/ldmsd/ldmsd_request.h
@@ -375,7 +375,7 @@ struct ldmsd_req_array *ldmsd_parse_config_str(const char *cfg, uint32_t msg_no,
 					size_t xprt_max_msg, ldmsd_msg_log_f msglog);
 
 /**
- * \brief Destroy the result of ldmsd_parse_config_str.
+ * \brief Destroy the result of ldmsd_parse_config_str. Ignores NULL input.
  */
 void ldmsd_req_array_free(struct ldmsd_req_array *a);
 
@@ -557,7 +557,7 @@ ldmsd_req_cmd_t ldmsd_req_cmd_new(ldms_t ldms,
 				    void *ctxt);
 
 /**
- * \brief Free the request command.
+ * \brief Free the request command. Ignores NULL input.
  */
 void ldmsd_req_cmd_free(ldmsd_req_cmd_t rcmd);
 
@@ -629,7 +629,7 @@ struct ldmsd_msg_buf *ldmsd_msg_buf_new(size_t len);
 void ldmsd_msg_buf_init(struct ldmsd_msg_buf *buf);
 
 /**
- * \brief Free an LDMSD message buffer
+ * \brief Free an LDMSD message buffer. Ignores NULL input.
  */
 void ldmsd_msg_buf_free(struct ldmsd_msg_buf *buf);
 

--- a/ldms/src/ldmsd/ldmsd_request_util.c
+++ b/ldms/src/ldmsd/ldmsd_request_util.c
@@ -1024,6 +1024,8 @@ struct ldmsd_msg_buf *ldmsd_msg_buf_new(size_t len)
 
 void ldmsd_msg_buf_free(struct ldmsd_msg_buf *buf)
 {
+	if (!buf)
+		return;
 	free(buf->buf);
 	free(buf);
 }

--- a/lib/src/coll/heap.h
+++ b/lib/src/coll/heap.h
@@ -74,7 +74,7 @@ typedef struct ovis_heap *ovis_heap_t;
 ovis_heap_t ovis_heap_create(int heapsize, ovis_heap_comp comp);
 
 /**
- * Deallocate \c heap.
+ * Deallocate \c heap. Ignores NULL input.
  */
 void ovis_heap_free(ovis_heap_t heap);
 

--- a/lib/src/coll/libmap.c
+++ b/lib/src/coll/libmap.c
@@ -59,6 +59,8 @@ err0:
 
 void map_list_free(char *map_list[])
 {
+	if (!map_list)
+		return;
 	int i;
 	for (i=0;map_list[i]; i++) {
 		free(map_list[i]);

--- a/lib/src/coll/str_map.c
+++ b/lib/src/coll/str_map.c
@@ -86,6 +86,8 @@ struct str_map* str_map_create(size_t sz)
 
 void str_map_free(str_map_t m)
 {
+	if (!m)
+		return;
 	int i;
 	for (i=0; i<m->hash_size; i++) {
 		struct obj_list_head *lh = &m->lh_table[i];

--- a/lib/src/coll/str_map.h
+++ b/lib/src/coll/str_map.h
@@ -84,7 +84,7 @@ typedef struct str_map* str_map_t;
 struct str_map* str_map_create(size_t sz);
 
 /**
- * Free the map.
+ * Free the map. Ignores NULL input.
  */
 void str_map_free(str_map_t m);
 

--- a/lib/src/mmalloc/mmalloc.c
+++ b/lib/src/mmalloc/mmalloc.c
@@ -212,6 +212,8 @@ void mm_free(void *d)
 {
 	if (mm_is_disable_mm_free)
 		return;
+	if (!d)
+		return;
 
 	struct mm_prefix *p = d;
 	struct mm_prefix *q, *r;

--- a/lib/src/mmalloc/mmalloc.h
+++ b/lib/src/mmalloc/mmalloc.h
@@ -98,7 +98,7 @@ void *mm_alloc(size_t size);
 /**
  * \brief Return memory to the heap.
  *
- * \param ptr	Pointer to the buffer to free.
+ * \param ptr	Pointer to the buffer to free. Ignores NULL input.
  */
 void mm_free(void *ptr);
 

--- a/lib/src/ovis_event/ovis_event.c
+++ b/lib/src/ovis_event/ovis_event.c
@@ -81,8 +81,8 @@ void ovis_scheduler_ref_put(ovis_scheduler_t m)
 {
 	if (!m)
 		return;
-	pthread_mutex_lock(&m->mutex);
 	assert(m->refcount > 0);
+	pthread_mutex_lock(&m->mutex);
 	m->refcount--;
 	if (m->refcount == 0) {
 		pthread_mutex_unlock(&m->mutex);
@@ -225,7 +225,7 @@ loop:
 	if (rc < 0) {
 		if (errno == EAGAIN || errno == EWOULDBLOCK)
 			return;
-		assert(0 && errno);
+		assert(0 == "__ovis_event_pipe_cb: unexpected logic" && errno);
 	}
 	goto loop;
 }
@@ -615,7 +615,7 @@ int ovis_event_term_check(ovis_scheduler_t m)
 	pthread_mutex_lock(&m->mutex);
 	switch (m->state) {
 	case OVIS_EVENT_MANAGER_INIT:
-		assert(0);
+		assert(0 == "unexepected OVIS_EVENT_MANAGER_INIT in ovis_event_term_check");
 		break;
 	case OVIS_EVENT_MANAGER_RUNNING:
 	case OVIS_EVENT_MANAGER_WAITING:

--- a/lib/src/ovis_event/ovis_event.c
+++ b/lib/src/ovis_event/ovis_event.c
@@ -79,6 +79,8 @@ void ovis_scheduler_ref_get(ovis_scheduler_t m)
 static inline
 void ovis_scheduler_ref_put(ovis_scheduler_t m)
 {
+	if (!m)
+		return;
 	pthread_mutex_lock(&m->mutex);
 	assert(m->refcount > 0);
 	m->refcount--;

--- a/lib/src/ovis_event/ovis_event.h
+++ b/lib/src/ovis_event/ovis_event.h
@@ -278,7 +278,7 @@ ovis_scheduler_t ovis_scheduler_new();
 /**
  * Destroy the unused event manager.
  *
- * \param m the ovis event manager handle.
+ * \param m the ovis event manager handle. Ignores NULL input.
  */
 void ovis_scheduler_free(ovis_scheduler_t m);
 
@@ -345,7 +345,7 @@ int ovis_scheduler_epoll_event_mod(ovis_scheduler_t s, ovis_event_t ev,
 /**
  * Free memory allocated from ::ovis_event_create().
  *
- * \param ev the event handle to be freed.
+ * \param ev the event handle to be freed. Ignores NULL input.
  */
 void ovis_event_free(ovis_event_t ev);
 

--- a/lib/src/ovis_json/ovis_json.c
+++ b/lib/src/ovis_json/ovis_json.c
@@ -541,6 +541,8 @@ int json_attr_rem(json_entity_t d, char *name)
 static void json_list_free(json_list_t a)
 {
 	json_entity_t i;
+	if (!a)
+		return;
 	assert(a->base.type == JSON_LIST_VALUE);
 	while (!TAILQ_EMPTY(&a->item_list)) {
 		i = TAILQ_FIRST(&a->item_list);
@@ -552,6 +554,8 @@ static void json_list_free(json_list_t a)
 
 static void json_str_free(json_str_t s)
 {
+	if (!s)
+		return;
 	assert(s->base.type == JSON_STRING_VALUE);
 	free(s->str);
 	free(s);
@@ -559,6 +563,8 @@ static void json_str_free(json_str_t s)
 
 static void json_attr_free(json_attr_t a)
 {
+	if (!a)
+		return;
 	assert(a->base.type == JSON_ATTR_VALUE);
 	json_entity_free(a->name);
 	json_entity_free(a->value);
@@ -570,6 +576,8 @@ static void json_dict_free(json_dict_t d)
 	json_attr_t i;
 	hent_t ent;
 	htbl_t t;
+	if (!d)
+		return;
 
 	t = d->attr_table;
 	while (!htbl_empty(t)) {
@@ -768,7 +776,7 @@ json_entity_t __dict_new(json_entity_t d_, va_list ap)
 				goto err;
 			break;
 		default:
-			assert(0);
+			assert(0 || NULL == "unhandled type in ovis_json:__dict_new." );
 		}
 		json_attr_add(d, n, v);
 	next:

--- a/lib/src/ovis_util/big_dstring.h
+++ b/lib/src/ovis_util/big_dstring.h
@@ -103,7 +103,8 @@ static inline const char *bdstrval(const big_dstring_t *dsPtr); \
  \
 static void bdstr_free(big_dstring_t *dsPtr) \
 { \
-	assert(NULL != dsPtr); \
+	if (!dsPtr) \
+		return; \
 	if (dsPtr->string != dsPtr->staticSpace) { \
 		free(dsPtr->string); \
 	} \

--- a/lib/src/ovis_util/dstring.c
+++ b/lib/src/ovis_util/dstring.c
@@ -291,7 +291,6 @@ void dstr_trunc(dstring_t * dsPtr, int length)
 
 void dstr_free(dstring_t * dsPtr)
 {
-	assert(NULL != dsPtr);
 	if (!dsPtr)
 		return;
 	if (dsPtr->string != dsPtr->staticSpace) {

--- a/lib/src/ovis_util/dstring.c
+++ b/lib/src/ovis_util/dstring.c
@@ -292,6 +292,8 @@ void dstr_trunc(dstring_t * dsPtr, int length)
 void dstr_free(dstring_t * dsPtr)
 {
 	assert(NULL != dsPtr);
+	if (!dsPtr)
+		return;
 	if (dsPtr->string != dsPtr->staticSpace) {
 		free(dsPtr->string);
 	}

--- a/lib/src/ovis_util/dstring.h
+++ b/lib/src/ovis_util/dstring.h
@@ -161,7 +161,7 @@ extern char *dstrcat_uint(dstring_t * dsPtr, uint64_t);
  *  reinitializes the string to an empty state.  The previous
  *  contents of the dynamic string are lost, and the new value
  *  is an empty string.  Note that dsPtr may not be NULL
- *  (checked by assertion).
+ *  (checked by assertion). Ignore NULL input if assert is inactive.
  *
  *  \param dsPtr Structure describing dynamic string (non-NULL).
 */

--- a/lib/src/ovis_util/util.h
+++ b/lib/src/ovis_util/util.h
@@ -174,7 +174,7 @@ int av_add(struct attr_value_list *avl, const char *name, const char *value);
 struct attr_value_list *av_copy(struct attr_value_list *src);
 
 /**
- * \brief Free the memory consumed by the avl
+ * \brief Free the memory consumed by the avl. Ignores NULL input.
  */
 void av_free(struct attr_value_list *avl);
 

--- a/lib/src/zap/sock/zap_sock.c
+++ b/lib/src/zap/sock/zap_sock.c
@@ -637,6 +637,8 @@ struct z_sock_io *__sock_io_alloc(struct z_sock_ep *sep)
 
 void __sock_io_free(struct z_sock_ep *sep, struct z_sock_io *io)
 {
+	if (!sep)
+		return;
 	pthread_mutex_lock(&sep->ep.lock);
 	TAILQ_INSERT_TAIL(&sep->free_q, io, q_link);
 	pthread_mutex_unlock(&sep->ep.lock);

--- a/lib/src/zap/zap.c
+++ b/lib/src/zap/zap.c
@@ -587,6 +587,8 @@ zap_ep_state_t zap_ep_state(zap_ep_t ep)
 
 void zap_put_ep(zap_ep_t ep)
 {
+	if (!ep)
+		return;
 	assert(ep->ref_count);
 	if (0 == __sync_sub_and_fetch(&ep->ref_count, 1)) {
 		zap_event_queue_ep_put(ep->event_queue);
@@ -875,6 +877,8 @@ err_1:
 
 void zap_thrstat_free(zap_thrstat_t stats)
 {
+	if (!stats)
+		return;
 	pthread_mutex_lock(&thrstat_list_lock);
 	LIST_REMOVE(stats, entry);
 	thrstat_count --;
@@ -994,6 +998,8 @@ out:
 
 void zap_thrstat_free_result(struct zap_thrstat_result *res)
 {
+	if (!res)
+		return;
 	int i;
 	for (i = 0; i < res->count; i++) {
 		if (res->entries[i].name)

--- a/lib/src/zap/zap.h
+++ b/lib/src/zap/zap.h
@@ -356,7 +356,7 @@ void zap_set_priority(zap_ep_t ep, int prio);
 /** \brief Release an endpoint
  *
  * Drop the implicit zap_new() reference. This is functionally
- * equivalent to zap_put_ep().
+ * equivalent to zap_put_ep(). Ignores NULL arguments.
  *
  * Note that outstanding I/O may hold references on the endpoint and
  * this does not initiate a disconnect. See the zap_close() function
@@ -710,6 +710,7 @@ zap_thrstat_t zap_thrstat_new(const char *name, int window_size);
 
 /**
  * \brief Release the resources held by the Zap stats instance
+ * Ignores NULL instances.
  */
 void zap_thrstat_free(zap_thrstat_t stats);
 /**


### PR DESCRIPTION
For headered functions with names containing _free, this patch documents
and in some cases adds, the key semantics of free():
	do nothing if given a NULL pointer
	release resources if given a valid pointer.

Why?
 * This allows us to stop using syntax of the sort: if (x) free_operator(x), making for easier to read and write code.
 * This prevents data-corrupting random walks through memory that start by
dereferencing a NULL argument in destructor code.

Special cases:
 * where assert is in use, assertions are checked after the NULL check,
 