### PR TITLE
Configure simplification

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,51 +63,45 @@ test "$sharedstatedir" = '${prefix}/com' && sharedstatedir='${prefix}/var/lib'
 #
 # link and include flags for build to ensure self-consistency
 #
-
-# ideally, this should yield from lib/src ldms/src
-# "-I$(top_builddir)/lib/src -I$(top_builddir)/ldms/src -I$(top_srcdir)/lib/src -I$(top_srcdir)/ldms/src"
-# when all the includes are fixed.
 dnl contrib should never be in this list
-OPTION_INCLUDE_FLAGS([OVIS],[ \
-	. \
-	lib/src \
-	lib/src/coll \
-	lib/src/third \
-	lib/src/ovis_util \
-	lib/src/ovis_auth \
-	lib/src/ovis_ctrl \
-	lib/src/ovis_ev \
-	lib/src/ovis_event \
-	lib/src/ovis_json \
-	lib/src/zap \
-	lib/src/mmalloc \
-	ldms/src \
-	ldms/src/core \
-	ldms/src/auth \
-	ldms/src/ldmsd \
-	ldms/src/sampler \
-	ldms/src/store \
-])
+OVIS_INCLUDE_ABS="\
+	-I\${abs_top_srcdir}/lib/src \
+	-I\${abs_top_srcdir}/lib/src/coll \
+	-I\${abs_top_srcdir}/lib/src/third \
+	-I\${abs_top_srcdir}/lib/src/ovis_util \
+	-I\${abs_top_srcdir}/lib/src/ovis_auth \
+	-I\${abs_top_srcdir}/lib/src/ovis_ctrl \
+	-I\${abs_top_srcdir}/lib/src/ovis_ev \
+	-I\${abs_top_srcdir}/lib/src/ovis_event \
+	-I\${abs_top_srcdir}/lib/src/ovis_json \
+	-I\${abs_top_srcdir}/lib/src/zap \
+	-I\${abs_top_srcdir}/lib/src/mmalloc \
+	-I\${abs_top_srcdir}/ldms/src \
+	-I\${abs_top_srcdir}/ldms/src/core \
+	-I\${abs_top_srcdir}/ldms/src/auth \
+	-I\${abs_top_srcdir}/ldms/src/ldmsd \
+	-I\${abs_top_srcdir}/ldms/src/sampler \
+	-I\${abs_top_srcdir}/ldms/src/store"
+AC_SUBST([OVIS_INCLUDE_ABS])
 
-dnl contrib subdirs should never be in this list
-OPTION_LIB_FLAGS([OVIS],[ \
-	lib/src/coll \
-	lib/src/third \
-	lib/src/ovis_util \
-	lib/src/ovis_auth \
-	lib/src/ovis_ctrl \
-	lib/src/ovis_ev \
-	lib/src/ovis_event \
-	lib/src/ovis_json \
-	lib/src/zap \
-	lib/src/mmalloc \
-	ldms/src/core \
-	ldms/src/auth \
-	ldms/src/ldmsd \
-	ldms/src/sampler \
-	ldms/src/sampler/lustre \
-	ldms/src/store \
-])
+OVIS_LIB_ABS="\
+	-Wl,-rpath-link=\$(abs_top_builddir)/lib/src/coll/.libs -L\$(abs_top_builddir)/lib/src/coll/.libs \
+	-Wl,-rpath-link=\$(abs_top_builddir)/lib/src/third/.libs -L\$(abs_top_builddir)/lib/src/third/.libs \
+	-Wl,-rpath-link=\$(abs_top_builddir)/lib/src/ovis_util/.libs -L\$(abs_top_builddir)/lib/src/ovis_util/.libs \
+	-Wl,-rpath-link=\$(abs_top_builddir)/lib/src/ovis_auth/.libs -L\$(abs_top_builddir)/lib/src/ovis_auth/.libs \
+	-Wl,-rpath-link=\$(abs_top_builddir)/lib/src/ovis_ctrl/.libs -L\$(abs_top_builddir)/lib/src/ovis_ctrl/.libs \
+	-Wl,-rpath-link=\$(abs_top_builddir)/lib/src/ovis_ev/.libs -L\$(abs_top_builddir)/lib/src/ovis_ev/.libs \
+	-Wl,-rpath-link=\$(abs_top_builddir)/lib/src/ovis_event/.libs -L\$(abs_top_builddir)/lib/src/ovis_event/.libs \
+	-Wl,-rpath-link=\$(abs_top_builddir)/lib/src/ovis_json/.libs -L\$(abs_top_builddir)/lib/src/ovis_json/.libs \
+	-Wl,-rpath-link=\$(abs_top_builddir)/lib/src/zap/.libs -L\$(abs_top_builddir)/lib/src/zap/.libs \
+	-Wl,-rpath-link=\$(abs_top_builddir)/lib/src/mmalloc/.libs -L\$(abs_top_builddir)/lib/src/mmalloc/.libs \
+	-Wl,-rpath-link=\$(abs_top_builddir)/ldms/src/core/.libs -L\$(abs_top_builddir)/ldms/src/core/.libs \
+	-Wl,-rpath-link=\$(abs_top_builddir)/ldms/src/auth/.libs -L\$(abs_top_builddir)/ldms/src/auth/.libs \
+	-Wl,-rpath-link=\$(abs_top_builddir)/ldms/src/ldmsd/.libs -L\$(abs_top_builddir)/ldms/src/ldmsd/.libs \
+	-Wl,-rpath-link=\$(abs_top_builddir)/ldms/src/sampler/.libs -L\$(abs_top_builddir)/ldms/src/sampler/.libs \
+	-Wl,-rpath-link=\$(abs_top_builddir)/ldms/src/sampler/lustre/.libs -L\$(abs_top_builddir)/ldms/src/sampler/lustre/.libs \
+	-Wl,-rpath-link=\$(abs_top_builddir)/ldms/src/store/.libs -L\$(abs_top_builddir)/ldms/src/store/.libs"
+AC_SUBST([OVIS_LIB_ABS])
 
 ## stuff from lib
 

--- a/lib/src/coll/Makefile.am
+++ b/lib/src/coll/Makefile.am
@@ -4,8 +4,6 @@ AM_LDFLAGS=@OVIS_LIB_ABS@
 AM_CPPFLAGS=@OVIS_INCLUDE_ABS@
 
 check_PROGRAMS =
-libmapinclude_HEADERS =
-libmapincludedir = $(includedir)/coll
 
 if ENABLE_COLL
 libcoll_la_SOURCES = rbt.c rbt.h \

--- a/m4/options.m4
+++ b/m4/options.m4
@@ -181,63 +181,6 @@ AC_DEFINE_UNQUOTED([$1PORT],[$withval],[Default port for $1 to listen on])
 AC_SUBST([$1PORT],[$$1PORT])
 ])
 
-dnl SYNOPSIS: OPTION_INC_FLAGS(prefix, subdirs)
-dnl REASON: produce include flags lists
-dnl EXAMPLE: OPTION_INC_FLAGS([ovis],[dir1 dir2])
-dnl - prefix: variable prefix
-dnl - subdirs: search locations
-dnl Defines $prefix_INCLUDE_REL (relative to top_builddir for in-configure)
-dnl Defines $prefix_INCLUDE_ABS (path to use in make)
-AC_DEFUN([OPTION_INCLUDE_FLAGS], [
-[
-	tmprelflags=""
-	tmpabsflags=""
-	dirlist=""
-	for dirtmp in $2; do
-		if test -d $srcdir/$dirtmp; then
-			tmprelflags="$tmprelflags -I\$(top_srcdir)/$dirtmp -I\$(top_builddir)/$dirtmp"
-			tmpabsflags="$tmpabsflags -I\$(abs_top_srcdir)/$dirtmp -I\$(abs_top_builddir)/$dirtmp"
-		else
-			]AC_MSG_NOTICE([expected dir $srcdir/$dirtmp missing])[
-		fi
-	done
-	]m4_translit([$1], [-+.a-z], [___A-Z])[_INCLUDE_REL="$tmprelflags"
-	]m4_translit([$1], [-+.a-z], [___A-Z])[_INCLUDE_ABS="$tmpabsflags"
-]
-AC_SUBST(m4_translit([$1], [-+.a-z], [___A-Z])[_INCLUDE_REL])
-AC_SUBST(m4_translit([$1], [-+.a-z], [___A-Z])[_INCLUDE_ABS])
-])
-
-dnl SYNOPSIS: OPTION_LIB_FLAGS(prefix, subdirs)
-dnl REASON: produce lib flags list
-dnl EXAMPLE: OPTION_INC_FLAGS([ovis],[dir1 dir2])
-dnl - prefix: variable prefix
-dnl - subdirs: search locations
-dnl Defines $prefix_LIB_REL (relative to top_builddir for in-configure)
-dnl Defines $prefix_LIB_ABS (path to use in make)
-AC_DEFUN([OPTION_LIB_FLAGS], [
-[
-	tmprelflags=""
-	tmpabsflags=""
-	tmppathflags=""
-	dirlist=""
-	for dirtmp in $2; do
-		if test -d $srcdir/$dirtmp; then
-			tmprelflags="$tmprelflags -Wl,-rpath-link=\$(top_builddir)/$dirtmp/.libs"
-			tmpabsflags="$tmpabsflags -Wl,-rpath-link=\$(abs_top_builddir)/$dirtmp/.libs"
-			tmprelflags="$tmprelflags -L\$(top_builddir)/$dirtmp/.libs"
-			tmpabsflags="$tmpabsflags -L\$(abs_top_builddir)/$dirtmp/.libs"
-		else
-			]AC_MSG_NOTICE([expected dir $srcdir/$dirtmp missing])[
-		fi
-	done
-	]m4_translit([$1], [-+.a-z], [___A-Z])[_LIB_REL="$tmprelflags"
-	]m4_translit([$1], [-+.a-z], [___A-Z])[_LIB_ABS="$tmpabsflags"
-]
-AC_SUBST(m4_translit([$1], [-+.a-z], [___A-Z])[_LIB_REL])
-AC_SUBST(m4_translit([$1], [-+.a-z], [___A-Z])[_LIB_ABS])
-])
-
 dnl SYNOPSIS: OPTION_WITH_OR_BUILD(featurename,reldir,libsubdirs,
 dnl		configfile,package_name,buildlocation)
 dnl REASON: configuring against peer subprojects needs a little love.


### PR DESCRIPTION
OVIS_INCLUDE_ABS and OVIS_LIB_ABS are autoconf variables used
throughout many Makefile.am files in the tree. However, as it
stands it is less than easy to figureout how and where those
variables are set. One needs to make some educated guesses
and search the code to figure out that they are constructed
by the OPTION_LIB_FLAGS and OPTION_INCLUDE_FLAGS macros.

In practice these macros do more to obfuscate the code than to
improve it. Also, there is no reuse of these macros, so that
is not a good reason to make these macros.

Additionally, the macros set far more include paths than it
really should be.

We turn the OVIS_INCLUDE_ABS and OVIS_LIB_ABS variables into
simple lists.

This may be a first step in trying to fix ovis's header issues.