### PR TITLE
replace sys_errlist which finally is gone from gnu libc.

### DIFF
--- a/lib/src/ovis_util/test_util.c
+++ b/lib/src/ovis_util/test_util.c
@@ -71,6 +71,7 @@ int main(int argc, char **argv)
 	t = "narate/nichamon/tom";
 	t2 = "naratenichamontom";
 	int errcnt = 0;
+	printf("%s\n", ovis_strerror(0));
 
 	/* success cases */
 	r = ovis_join(NULL,s1,s2,s3,NULL);
@@ -116,14 +117,14 @@ int main(int argc, char **argv)
 	rc = ovis_join_buf(shortbuf, sizeof(shortbuf), NULL,s1,s2,s3,NULL);
 	if (rc == 0 || strcmp(t,shortbuf) == 0) {
 		printf("error 6: ovis_join_buf(sb,ss,NULL,s1,s2,s3,NULL) %d %s\n",
-			rc, strerror(rc));
+			rc, ovis_strerror(rc));
 		errcnt++;
 	}
 	snprintf(shortbuf,12,"0123456789"); // insufficient buf
 	rc = ovis_join_buf(shortbuf, sizeof(shortbuf), NULL,s1,s2,s3,NULL);
 	if (rc == 0 || strcmp(t,shortbuf) == 0) {
 		printf("error 7: ovis_join_buf(sb,ss,NULL,s1,s2,s3,NULL) %d %s\n",
-			rc, strerror(rc));
+			rc, ovis_strerror(rc));
 		errcnt++;
 	}
 	/* do not test for unterminated list. compiler warning from attribute sentinel

--- a/lib/src/ovis_util/util.h
+++ b/lib/src/ovis_util/util.h
@@ -334,9 +334,9 @@ const char* ovis_errno_abbvr(int e);
 /**
  * \brief thread-safe strerror.
  *
- * \retval str The sys_errlist value, or the result of
- * .ovis_errno_abbvr(e) if sys_errlist is not available.
- * \retval "unknown_errno" if the errno \c e is unknown.
+ * \retval str The corresponding strerror value, or the result of
+ * ovis_errno_abbvr(e) if e is out of the range of strerror.
+ * \retval a pointer to an unchanging string.
  */
 const char *ovis_strerror(int e);
 


### PR DESCRIPTION
Looks like gnu libc drops sys_errlist from headers and libraries on or before 2.32.