### PR TITLE
compensate for gnu libc 2.32 removal of sys_errlist and use alternate strerror thread safely

### DIFF
--- a/ldms/src/ldmsd/ldmsctl.c
+++ b/ldms/src/ldmsd/ldmsctl.c
@@ -2267,7 +2267,8 @@ static int __handle_cmd(struct ldmsctl_ctrl *ctrl, char *cmd_str)
 
 		rc = ctrl->send_req(ctrl, request, len);
 		if (rc) {
-			printf("Failed to send data to ldmsd. %s\n", strerror(errno));
+			printf("Failed to send data to ldmsd. %s\n",
+				STRERROR(errno));
 			return rc;
 		}
 	}
@@ -2301,7 +2302,7 @@ static int __handle_cmd(struct ldmsctl_ctrl *ctrl, char *cmd_str)
 				goto done_recv;
 			} else if (EBUSY != rc) {
 				printf("Failed to process messages from LDMSD. %s\n",
-						strerror(rc));
+						STRERROR(rc));
 				exit(rc);
 			}
 			ldmsctl_buffer_free(recv_buf);
@@ -2370,7 +2371,7 @@ struct ldmsctl_ctrl *__ldms_xprt_ctrl(const char *host, const char *port,
 	ctrl->ldms_xprt.x = ldms_xprt_new_with_auth(xprt, NULL, auth, auth_opt);
 	if (!ctrl->ldms_xprt.x) {
 		printf("Failed to create an ldms transport. %s\n",
-						strerror(errno));
+						STRERROR(errno));
 		return NULL;
 	}
 

--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -1934,7 +1934,7 @@ int main(int argc, char *argv[])
 		if (!pfile) {
 			int piderr = errno;
 			ldmsd_log(LDMSD_LERROR, "Could not open the pid file named '%s': %s\n",
-				pidfile, strerror(piderr));
+				pidfile, STRERROR(piderr));
 			free(pidfile);
 			pidfile = NULL;
 		} else {
@@ -1959,7 +1959,7 @@ int main(int argc, char *argv[])
 			if (!bfile) {
 				int banerr = errno;
 				ldmsd_log(LDMSD_LERROR, "Could not open the banner file named '%s': %s\n",
-					bannerfile, strerror(banerr));
+					bannerfile, STRERROR(banerr));
 				free(bannerfile);
 				bannerfile = NULL;
 			} else {

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -575,9 +575,8 @@ int __process_config_file(const char *path, int *lno, int trust,
 	fin = fopen(path, "rt");
 	if (!fin) {
 		rc = errno;
-		strerror_r(rc, line, line_sz - 1);
 		ldmsd_log(LDMSD_LERROR, "Failed to open the config file '%s'. %s\n",
-				path, buff);
+				path, STRERROR(rc));
 		goto cleanup;
 	}
 
@@ -655,7 +654,7 @@ parse:
 	if (!req_array) {
 		rc = errno;
 		ldmsd_log(LDMSD_LERROR, "Process config file error at line %d "
-				"(%s). %s\n", lineno, path, strerror(rc));
+				"(%s). %s\n", lineno, path, STRERROR(rc));
 		goto cleanup;
 	}
 

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -4844,7 +4844,7 @@ static int env_handler(ldmsd_req_ctxt_t reqc)
 			rc = errno;
 			cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
 					"Failed to set '%s=%s': %s",
-					v->name, v->value, strerror(rc));
+					v->name, v->value, STRERROR(rc));
 			goto out;
 		}
 	}
@@ -4878,7 +4878,7 @@ static int include_handler(ldmsd_req_ctxt_t reqc)
 		if (lineno == 0) {
 			cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
 				"Failed to process cfg '%s' at line %d: %s",
-				path, lineno, strerror(reqc->errcode));
+				path, lineno, STRERROR(reqc->errcode));
 		} else {
 			cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
 				"Failed to process cfg '%s' at line '%d'",
@@ -4949,7 +4949,7 @@ static int logrotate_handler(ldmsd_req_ctxt_t reqc)
 	if (reqc->errcode) {
 		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
 				"Failed to rotate the log file. %s",
-				strerror(reqc->errcode));
+				STRERROR(reqc->errcode));
 	}
 	ldmsd_send_req_response(reqc, reqc->line_buf);
 	return 0;

--- a/ldms/src/sampler/appinfo.c
+++ b/ldms/src/sampler/appinfo.c
@@ -314,7 +314,7 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl,
 	ldmsapp_mutex = sem_open(sem_name, O_CREAT, 0666, 1);
 	if (ldmsapp_mutex == SEM_FAILED) {
 		msglog(LDMSD_LERROR, SAMP ": Semaphore open error: %s\n",
-			strerror(errno));
+			STRERROR(errno));
 		goto err;
 	}
 
@@ -327,7 +327,7 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl,
 	shmem_fd = shm_open(shmem_name, O_CREAT|O_RDWR, 0666);
 	if (shmem_fd == -1) {
 		msglog(LDMSD_LERROR, SAMP ": Shmem open/create error: %s\n",
-			strerror(errno));
+			STRERROR(errno));
 		goto err;
 	}
 	/* Set size of shared memory segment */
@@ -337,7 +337,7 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl,
 	/* Get stats (size) of shared memory segment and check */
 	if (fstat(shmem_fd, &shmem_stat) == -1) {
 		msglog(LDMSD_LERROR, SAMP ": Shmem stat error: %s\n",
-			strerror(errno));
+			STRERROR(errno));
 		goto err;
 	}
 	if (shmem_stat.st_size < 256 /* TODO CHECK ACTUAL SIZE */) {
@@ -351,7 +351,7 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl,
 				PROT_READ|PROT_WRITE, MAP_SHARED, shmem_fd, 0);
 	if (shmem_header == MAP_FAILED) {
 		msglog(LDMSD_LERROR, SAMP ": Shmem mmap error: %s\n",
-			strerror(errno));
+			STRERROR(errno));
 		goto err;
 	}
 

--- a/ldms/src/sampler/appinfo_lib/ldms_appinfo.c
+++ b/ldms/src/sampler/appinfo_lib/ldms_appinfo.c
@@ -172,7 +172,8 @@ int ldmsapp_initialize(int ldmsapp_enable, int appid, int jobid,
 	ldmsapp_mutex = sem_open(sem_name, 0);
 	if (ldmsapp_mutex == SEM_FAILED) {
 		if (!silent) fprintf(stderr,"LDMSAPP_LERROR: "
-				"Semaphore open error: %s\n", strerror(errno));
+				"Semaphore open error: %s\n",
+				STRERROR(errno));
 		goto err;
 	}
 
@@ -182,13 +183,15 @@ int ldmsapp_initialize(int ldmsapp_enable, int appid, int jobid,
 	shmem_fd = shm_open(shmem_name, O_RDWR, 0);
 	if (shmem_fd == -1) {
 		if (!silent) fprintf(stderr,"LDMSAPP_LERROR: "
-				"Shmem open error: %s\n", strerror(errno));
+				"Shmem open error: %s\n",
+				STRERROR(errno));
 		goto err;
 	}
 	/* Get stats (size) of shared memory segment */
 	if (fstat(shmem_fd, &shmem_stat) == -1) {
 		if (!silent) fprintf(stderr,"LDMSAPP_LERROR: "
-				"Shmem stat error: %s\n", strerror(errno));
+				"Shmem stat error: %s\n",
+				STRERROR(errno));
 		goto err;
 	}
 	if (shmem_stat.st_size < sizeof(shmem_header_t)) {
@@ -201,7 +204,8 @@ int ldmsapp_initialize(int ldmsapp_enable, int appid, int jobid,
 				PROT_READ|PROT_WRITE, MAP_SHARED, shmem_fd, 0);
 	if (shmem_header == MAP_FAILED) {
 		if (!silent) fprintf(stderr,"LDMSAPP_LERROR: "
-				"Shmem mmap error: %s\n", strerror(errno));
+				"Shmem mmap error: %s\n",
+				STRERROR(errno));
 		goto err;
 	}
 

--- a/ldms/src/sampler/dstat/dstat.c
+++ b/ldms/src/sampler/dstat/dstat.c
@@ -278,7 +278,7 @@ static int create_metric_set(base_data_t base)
 		iorc = parse_proc_pid_io(&io, pids);
 		if (iorc != 0) {
 			msglog(LDMSD_LERROR, SAMP ": unable to read /proc/%s/io (%s)\n",
-				pids, strerror(iorc));
+				pids, STRERROR(iorc));
 			return iorc;
 		}
 	}
@@ -286,7 +286,7 @@ static int create_metric_set(base_data_t base)
 		statrc = parse_proc_pid_stat(&stat, pids);
 		if (statrc != 0) {
 			msglog(LDMSD_LERROR, SAMP ": unable to read /proc/%s/stat (%s)\n",
-				pids, strerror(statrc));
+				pids, STRERROR(statrc));
 			return statrc;
 		}
 	}
@@ -294,7 +294,7 @@ static int create_metric_set(base_data_t base)
 		statmrc = parse_proc_pid_statm(&statm, pids);
 		if (statmrc != 0) {
 			msglog(LDMSD_LERROR, SAMP ": unable to read /proc/%s/statm (%s)\n",
-				pids, strerror(statmrc));
+				pids, STRERROR(statmrc));
 			return statmrc;
 		}
 	}
@@ -303,7 +303,7 @@ static int create_metric_set(base_data_t base)
 		fdrc = parse_proc_pid_fd(&fd, pids, details);
 		if (fdrc != 0) {
 			msglog(LDMSD_LERROR, SAMP ": unable to read /proc/%s/fd (%s)\n",
-				pids, strerror(fdrc));
+				pids, STRERROR(fdrc));
 			return fdrc;
 		}
 	}

--- a/ldms/src/sampler/dstat/parse_stat.c
+++ b/ldms/src/sampler/dstat/parse_stat.c
@@ -8,6 +8,7 @@
 #include <dirent.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include "ovis_util/util.h"
 
 #define PIDFMAX 32
 #define BUFMAX 512
@@ -392,42 +393,42 @@ int main() {
 
 	printf("io test\n");
 	if (rc != 0) {
-		printf("fail: %d %s\n", rc, strerror(rc));
+		printf("fail: %d %s\n", rc, STRERROR(rc));
 		return rc;
 	}
 	dump_proc_pid_io(&si);
 
 	printf("stat test\n");
 	if (rc2 != 0) {
-		printf("fail: %d %s\n", rc2, strerror(rc2));
+		printf("fail: %d %s\n", rc2, STRERROR(rc2));
 		return rc2;
 	}
 	dump_proc_pid_stat(&s);
 
 	printf("statm test\n");
 	if (rc3 != 0) {
-		printf("fail: %d %s\n", rc3, strerror(rc3));
+		printf("fail: %d %s\n", rc3, STRERROR(rc3));
 		return rc3;
 	}
 	dump_proc_pid_statm(&sm);
 
 	printf("fd test\n");
 	if (rc4 != 0) {
-		printf("fail: %d %s\n", rc4, strerror(rc4));
+		printf("fail: %d %s\n", rc4, STRERROR(rc4));
 		return rc4;
 	}
 	dump_proc_pid_fd(&sf);
 
 	printf("fd test details\n");
 	if (rc5 != 0) {
-		printf("fail: %d %s\n", rc5, strerror(rc5));
+		printf("fail: %d %s\n", rc5, STRERROR(rc5));
 		return rc5;
 	}
 	dump_proc_pid_fd(&sfd);
 
 	printf("fd root test details\n");
 	if (rc6 != 0) {
-		printf("xfail: %d %s\n", rc6, strerror(rc6));
+		printf("xfail: %d %s\n", rc6, STRERROR(rc6));
 	} else
 		dump_proc_pid_fd(&rfd);
 

--- a/ldms/src/sampler/examples/synthetic/synthetic.c
+++ b/ldms/src/sampler/examples/synthetic/synthetic.c
@@ -101,7 +101,7 @@ static ldms_set_t clone_metric_set(base_data_t base, uint64_t k)
 	snprintf(buf,nl,"%s.%" PRIu64, base->instance_name, k);
 	c = ldms_set_new(buf, base->schema);
 	if (!c) {
-		const char *serr = ovis_strerror(errno);
+		const char *serr = STRERROR(errno);
 		base->log(LDMSD_LERROR,"clone_metric_set: ldms_set_new failed %d(%s) for %s\n",
 				errno, serr, buf);
 		return NULL;

--- a/ldms/src/sampler/ibnet/ibnet_data.c
+++ b/ldms/src/sampler/ibnet/ibnet_data.c
@@ -690,9 +690,8 @@ static int ibnet_data_cr_opt_parse(struct ibnet_data *d, const char *conf)
 	size_t sz = 128;
 	char s[sz];
 	if (!f) {
-		char *serr;
-		serr = strerror_r(errno, s, sz);
-		d->log(LDMSD_LERROR, SAMP " failed to open %s. %s\n", conf, serr);
+		d->log(LDMSD_LERROR, SAMP " failed to open %s. %s\n", conf,
+			STRERROR(errno));
 		return errno;
 	}
 	int rc = fseek(f, 0, SEEK_END);

--- a/ldms/src/sampler/ldms_jobid.c
+++ b/ldms/src/sampler/ldms_jobid.c
@@ -437,7 +437,7 @@ static int create_metric_set(const char *instance_name, char* schema_name,
 		ldms_schema_delete(schema);
 		schema = NULL;
 	}
-	msglog(LDMSD_LDEBUG, SAMP ": rc=%d: %s.\n", rc, strerror(-rc));
+	msglog(LDMSD_LDEBUG, SAMP ": rc=%d: %s.\n", rc, STRERROR(-rc));
 	return -rc;
 }
 

--- a/ldms/src/sampler/llnl/edac.c
+++ b/ldms/src/sampler/llnl/edac.c
@@ -386,9 +386,6 @@ static int sample(struct ldmsd_sampler *self)
 	metric_no = metric_offset;
 
 	errno = 0;
-#define EBSZ 256
-	char ebuf[EBSZ];
-	char *emsg;
 	// Begin getting numbers
 	for ( i=0; i<totalCommands; i+=1 )
 	{
@@ -396,9 +393,8 @@ static int sample(struct ldmsd_sampler *self)
 		if (myFile == NULL)
 		{
 			rc = errno;
-			emsg = strerror_r(errno, ebuf, EBSZ);
 			msglog(LDMSD_LERROR, SAMP ": failed to open file %s: %s\n",
-				command[i], emsg);
+				command[i], STRERROR(rc));
 			goto out;
 		}
 		s = fgets(lineBuffer, LBSZ, myFile);
@@ -411,8 +407,8 @@ static int sample(struct ldmsd_sampler *self)
 		rc = sscanf(lineBuffer, "%" PRIu64, &v.v_u64);
 		if (rc != 1) {
 			rc = errno;
-			emsg = strerror_r(errno, ebuf, EBSZ);
-			msglog(LDMSD_LERROR, SAMP ": read a uint64_t failed from %s: \"%s\": %s\n", command[i], lineBuffer, emsg);
+			msglog(LDMSD_LERROR, SAMP ": read a uint64_t failed from %s: \"%s\": %s\n",
+				command[i], lineBuffer, STRERROR(rc));
 			goto out;
 		}
 		ldms_metric_set(set, metric_no, &v);

--- a/ldms/src/sampler/opa2.c
+++ b/ldms/src/sampler/opa2.c
@@ -239,7 +239,7 @@ static int build_port_list(char *port_list)
 				if (rc) {
 					msglog(LDMSD_LERROR, SAMP
 						": create_hfi_port error %s\n",
-						strerror(rc));
+						STRERROR(rc));
 
 				}
 			}
@@ -273,7 +273,7 @@ static int build_port_list(char *port_list)
 				if (rc) {
 					msglog(LDMSD_LERROR, SAMP
 						": create_hfi_port error %s\n",
-						strerror(rc));
+						STRERROR(rc));
 
 				}
 				break;

--- a/ldms/src/sampler/sampler_base.c
+++ b/ldms/src/sampler/sampler_base.c
@@ -293,7 +293,7 @@ ldms_set_t base_set_new(base_data_t base)
 	errno = 0;
 	base->set = ldms_set_new(base->instance_name, base->schema);
 	if (!base->set) {
-		const char *serr = ovis_strerror(errno);
+		const char *serr = STRERROR(errno);
 		base->log(LDMSD_LERROR,"base_set_new: ldms_set_new failed %d(%s) for %s\n",
 				errno, serr, base->instance_name);
 		return NULL;

--- a/ldms/src/sampler/shm/shm_util/ldms_shm_index.c
+++ b/ldms/src/sampler/shm/shm_util/ldms_shm_index.c
@@ -61,6 +61,7 @@
 #include "../../../../../lib/src/third/city.h"
 #include "ldms_shm_obj.h"
 #include "ldms_shm_index.h"
+#include "ovis_util/util.h" /* for strerror macro only */
 
 #define LDMS_SHM_GLOBAL_SEM_MUTEX_NAME_PREFIX "/ldms_shm_global_mutex"
 static char* ldms_shm_global_sem_mutex_name;
@@ -328,7 +329,7 @@ static ldms_shm_index_entry_t create_index_entry(const char *fslocation,
 	if(SEM_FAILED == new_entry->mutex_sem) {
 		printf(
 				"ERROR: failed to open a semaphore with the name %s  %d: %s\n\r",
-				fslocation, errno, strerror(errno));
+				fslocation, errno, STRERROR(errno));
 		if(NULL != new_entry)
 			free(new_entry);
 		return NULL;
@@ -371,7 +372,7 @@ int ldms_shm_index_entry_clean_shared_resources(ldms_shm_index_entry_t entry)
 			printf(
 					"ERROR: failed to unlink the semaphore %s  %d: %s\n\r",
 					entry->p->fslocation, errno,
-					strerror(errno));
+					STRERROR(errno));
 		}
 	}
 	return rc;
@@ -387,7 +388,7 @@ int ldms_shm_index_clean_shared_resources(ldms_shm_index_t shm_index)
 			printf(
 					"ERROR: failed to unlink the semaphore %s  %d: %s\n\r",
 					ldms_shm_index_mutex_name, errno,
-					strerror(errno));
+					STRERROR(errno));
 		} else {
 			free(ldms_shm_index_mutex_name);
 			ldms_shm_index_mutex_name = NULL;
@@ -396,7 +397,7 @@ int ldms_shm_index_clean_shared_resources(ldms_shm_index_t shm_index)
 				printf(
 						"ERROR: failed to unlink the semaphore %s  %d: %s\n\r",
 						ldms_shm_global_sem_mutex_name,
-						errno, strerror(errno));
+						errno, STRERROR(errno));
 			} else {
 				free(ldms_shm_index_mutex_name);
 				ldms_shm_index_mutex_name = NULL;

--- a/ldms/src/sampler/shm/shm_util/ldms_shm_obj.c
+++ b/ldms/src/sampler/shm/shm_util/ldms_shm_obj.c
@@ -58,6 +58,7 @@
 #include <string.h>
 #include <errno.h>
 #include "ldms_shm_obj.h"
+#include "ovis_util/util.h" /* for strerror macro only */
 
 /**
  * opens the shared memory and creates the mapping
@@ -91,7 +92,7 @@ ldms_shm_obj_t ldms_shm_init(const char *name, int size)
 			if(shm_obj->fd == -1) {
 				free(shm_obj);
 				printf("ERROR: shm_open error: %d: %s\n\r",
-						errno, strerror(errno));
+						errno, STRERROR(errno));
 				return NULL;
 			} else {
 				struct stat sb;
@@ -101,7 +102,7 @@ ldms_shm_obj_t ldms_shm_init(const char *name, int size)
 		} else {
 			free(shm_obj);
 			printf("ERROR: shm_open error: %d: %s\n\r", errno,
-					strerror(errno));
+					STRERROR(errno));
 			return NULL;
 		}
 	}
@@ -110,7 +111,7 @@ ldms_shm_obj_t ldms_shm_init(const char *name, int size)
 		if(ftruncate(shm_obj->fd, shm_obj->size) == -1) {
 			free(shm_obj);
 			printf("ERROR: ftruncate error: %d: %s\n\r", errno,
-					strerror(errno));
+					STRERROR(errno));
 			return NULL;
 		}
 	}
@@ -120,7 +121,7 @@ ldms_shm_obj_t ldms_shm_init(const char *name, int size)
 		free(shm_obj);
 		printf(
 				"ERROR: mmap error! (%d): %s, shm_obj->size=%ld, name=%s, requested size=%d\n\r",
-				errno, strerror(errno), shm_obj->size, name,
+				errno, STRERROR(errno), shm_obj->size, name,
 				size);
 		return NULL;
 	}
@@ -137,28 +138,28 @@ int ldms_shm_clean(const char *name)
 		rc = ENOMEM;
 		printf(
 				"ERROR: failed to free the shared memory(%s)  %d: %s\n\r",
-				name, errno, strerror(errno));
+				name, errno, STRERROR(errno));
 		return rc;
 	}
 	rc = munmap(shm_obj->addr, shm_obj->size);
 	if(rc) {
 		printf(
 				"ERROR: failed to free the shared memory(%s)  %d: %s\n\r",
-				name, errno, strerror(errno));
+				name, errno, STRERROR(errno));
 		return rc;
 	}
 	rc = shm_unlink(name);
 	if(rc) {
 		printf(
 				"ERROR: failed to free the shared memory(%s)  %d: %s\n\r",
-				name, errno, strerror(errno));
+				name, errno, STRERROR(errno));
 		return rc;
 	}
 	rc = close(shm_obj->fd);
 	if(rc) {
 		printf(
 				"ERROR: failed to free the shared memory(%s)  %d: %s\n\r",
-				name, errno, strerror(errno));
+				name, errno, STRERROR(errno));
 		return rc;
 	}
 	free(shm_obj->name);

--- a/ldms/src/sampler/tx2mon/tx2mon.c
+++ b/ldms/src/sampler/tx2mon/tx2mon.c
@@ -359,7 +359,7 @@ static int create_metric_set(base_data_t base)
 	mcprc = parse_mc_oper_region();
 	if (mcprc != 0) {
 		msglog(LDMSD_LERROR, SAMP ": unable to read the node file for the sample (%s)\n",
-		       pids, strerror(mcprc));
+		       pids, STRERROR(mcprc));
 		return mcprc;
 	}
 
@@ -827,7 +827,7 @@ static int parse_socinfo(void)
 	socinfo = fopen(path, "r");
 	if (!socinfo) {
 		msglog(LDMSD_LERROR, SAMP ": cannot open '%s', %s.\n",
-		       path, strerror(errno));
+		       path, STRERROR(errno));
 		free(path);
 		return errno;
 	}

--- a/ldms/src/store/store_csv_common.c
+++ b/ldms/src/store/store_csv_common.c
@@ -49,6 +49,7 @@
 
 
 #define PLUGNAME 0
+#define _GNU_SOURCE
 #define store_csv_common_lib
 #include <stdlib.h>
 #include <stdio.h>
@@ -161,8 +162,6 @@ static int validate_env(const char *var, const char *val, struct csv_plugin_stat
 
 int create_outdir(const char *path, struct csv_store_handle_common *s_handle,
 	struct csv_plugin_static *cps) {
-#define EBSIZE 512
-	char errbuf[EBSIZE];
 	if (!cps) {
 		return EINVAL;
 	}
@@ -194,23 +193,19 @@ int create_outdir(const char *path, struct csv_store_handle_common *s_handle,
 		case EEXIST:
 			break;
 		default:
-			strerror_r(err, errbuf, EBSIZE);
 			cps->msglog(LDMSD_LERROR,"create_outdir: failed to create directory for %s: %s\n",
-				path, errbuf);
+				path, STRERROR(err));
 			return err;
 		}
 	}
 
 	/* cps->msglog(LDMSD_LDEBUG,"create_outdir: f_mkdir+p(%s, %o)\n", path, mode); */
 	return 0;
-#undef EBSIZE
 }
 
 void rename_output(const char *name,
 	const char *ftype, struct csv_store_handle_common *s_handle,
 	struct csv_plugin_static *cps) {
-#define EBSIZE 512
-	char errbuf[EBSIZE];
 	if (!cps) {
 		return;
 	}
@@ -240,9 +235,9 @@ void rename_output(const char *name,
 		int merr = chmod(name, mode);
 		int rc = errno;
 		if (merr) {
-			strerror_r(rc, errbuf, EBSIZE);
 			cps->msglog(LDMSD_LERROR,"%s: rename_output: unable to chmod(%s,%o): %s.\n",
-				cps->pname, name, s_handle->rename_perm, errbuf);
+				cps->pname, name, s_handle->rename_perm,
+				STRERROR(rc));
 		}
 	}
 
@@ -254,9 +249,8 @@ void rename_output(const char *name,
 		int merr = chown(name, newuid, newgid);
 		int rc = errno;
 		if (merr) {
-			strerror_r(rc, errbuf, EBSIZE);
 			cps->msglog(LDMSD_LERROR,"%s: rename_output: unable to chown(%s, %u, %u): %s.\n",
-				cps->pname, name, newuid, newgid, errbuf);
+				cps->pname, name, newuid, newgid, STRERROR(rc));
 		}
 	}
 
@@ -407,9 +401,8 @@ void rename_output(const char *name,
 		case EEXIST:
 			break;
 		default:
-			strerror_r(err, errbuf, EBSIZE);
 			cps->msglog(LDMSD_LERROR, "%s: rename_output: failed to create directory for %s: %s\n",
-				cps->pname, newname, errbuf);
+				cps->pname, newname, STRERROR(err));
 			free(newname);
 			return;
 		}
@@ -421,19 +414,15 @@ void rename_output(const char *name,
 	err = rename(name, newname);
 	if (err) {
 		int ec = errno;
-		strerror_r(ec, errbuf, EBSIZE);
 		cps->msglog(LDMSD_LERROR,"%s: rename_output: failed rename(%s, %s): %s\n",
-			    cps->pname, name, newname, errbuf);
+			    cps->pname, name, newname, STRERROR(ec));
 	}
 	free(newname);
-#undef EBSIZE
 }
 
 void ch_output(FILE *f, const char *name,
 	struct csv_store_handle_common *s_handle,
 	struct csv_plugin_static *cps) {
-#define EBSIZE 512
-	char errbuf[EBSIZE];
 	if (!cps) {
 		return;
 	}
@@ -455,9 +444,8 @@ void ch_output(FILE *f, const char *name,
 		int merr = fchmod(fd, mode);
 		int rc = errno;
 		if (merr) {
-			strerror_r(rc, errbuf, EBSIZE);
 			cps->msglog(LDMSD_LERROR,"ch_output: unable to chmod(%s,%o): %s.\n",
-				name, s_handle->create_perm, errbuf);
+				name, s_handle->create_perm, STRERROR(rc));
 		}
 	}
 
@@ -469,12 +457,11 @@ void ch_output(FILE *f, const char *name,
 		int merr = fchown(fd, newuid, newgid);
 		int rc = errno;
 		if (merr) {
-			strerror_r(rc, errbuf, EBSIZE);
 			cps->msglog(LDMSD_LERROR,"ch_output: unable to fchown(%d, (%s),%lu, %lu): %s.\n",
-				fd, name, newuid, newgid, errbuf);
+				fd, name, newuid, newgid, STRERROR(rc));
 		}
 		cps->msglog(LDMSD_LDEBUG,"ch_output: fchown(%d, (%s),%lu, %lu): %s.\n",
-			fd, name, newuid, newgid, errbuf);
+			fd, name, newuid, newgid, STRERROR(rc));
 	}
 }
 

--- a/ldms/src/store/store_flatfile/store_flatfile.c
+++ b/ldms/src/store/store_flatfile/store_flatfile.c
@@ -237,7 +237,7 @@ open_store(struct ldmsd_store *s, const char *container, const char *schema,
 			if (!ms->file) {
 				int eno = errno;
 				msglog(LDMSD_LERROR, STRFF ": Error opening %s: %d: %s at %s:%d\n",
-					ms->path, eno, strerror(eno),
+					ms->path, eno, STRERROR(eno),
 					__FILE__, __LINE__);
 				goto err4;
 			}
@@ -382,7 +382,7 @@ store(ldmsd_store_handle_t _sh, ldms_set_t set, int *metric_arry, size_t metric_
 			last_errno = errno;
 			last_rc = (rc != 0 ? rc : rc2);
 			msglog(LDMSD_LERROR, STRFF ": Error %d: %s at %s:%d\n", last_errno,
-					strerror(last_errno), __FILE__,
+					STRERROR(last_errno), __FILE__,
 					__LINE__);
 		}
 		pthread_mutex_unlock(&si->ms[i]->lock);
@@ -408,7 +408,8 @@ static int flush_store(ldmsd_store_handle_t _sh)
 		if (lrc) {
 			rc = lrc;
 			eno = errno;
-			msglog(LDMSD_LERROR, STRFF ": Errro %d: %s at %s:%d\n", eno, strerror(eno),
+			msglog(LDMSD_LERROR, STRFF ": Error %d: %s at %s:%d\n",
+				eno, STRERROR(eno),
 					__FILE__, __LINE__);
 		}
 		pthread_mutex_unlock(&ms->lock);

--- a/ldms/src/store/store_rabbitkw.c
+++ b/ldms/src/store/store_rabbitkw.c
@@ -1037,7 +1037,7 @@ store(ldmsd_store_handle_t _sh, ldms_set_t set, int *metric_arry, size_t metric_
 				continue;
 			default:
 				msglog(LDMSD_LDEBUG,"Error %d: %s at %s:%d: loop index %d, metric_id %d\n",
-				       rc, strerror(rc),
+				       rc, STRERROR(rc),
 					__FILE__, __LINE__, i, metric_id);
 				goto estr;
 			}

--- a/ldms/src/store/store_rabbitv3.c
+++ b/ldms/src/store/store_rabbitv3.c
@@ -1232,7 +1232,7 @@ store(ldmsd_store_handle_t _sh, ldms_set_t set, int *metric_arry, size_t metric_
 				last_errno = errno;
 				last_rc = rc;
 				msglog(LDMSD_LDEBUG,"Error %d: %s at %s:%d\n",
-				       last_errno, strerror(last_errno),
+				       last_errno, STRERROR(last_errno),
 					__FILE__, __LINE__);
 				// fixme: probably need to handle close/reopen here if server dies.
 			}

--- a/ldms/src/store/store_sos.c
+++ b/ldms/src/store/store_sos.c
@@ -675,7 +675,7 @@ store(ldmsd_store_handle_t _sh, ldms_set_t set,
 	if (!obj) {
 		pthread_mutex_unlock(&si->lock);
 		LOG_(LDMSD_LERROR, "Error %d: %s at %s:%d\n", errno,
-		       strerror(errno), __FILE__, __LINE__);
+		       STRERROR(errno), __FILE__, __LINE__);
 		errno = ENOMEM;
 		return -1;
 	}
@@ -758,7 +758,7 @@ store(ldmsd_store_handle_t _sh, ldms_set_t set,
 		last_errno = errno;
 		last_rc = rc;
 		LOG_(LDMSD_LERROR, "Error %d: %s at %s:%d\n", errno,
-		       strerror(errno), __FILE__, __LINE__);
+		       STRERROR(errno), __FILE__, __LINE__);
 	}
 	if (last_errno)
 		errno = last_errno;

--- a/lib/src/ovis_auth/auth.c
+++ b/lib/src/ovis_auth/auth.c
@@ -1,8 +1,8 @@
 /* -*- c-basic-offset: 8 -*-
- * Copyright (c) 2015-2016,2018 National Technology & Engineering Solutions
+ * Copyright (c) 2015-2021 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
- * Copyright (c) 2015-2016,2018 Open Grid Computing, Inc. All rights reserved.
+ * Copyright (c) 2015-2021 Open Grid Computing, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -65,6 +65,7 @@
 #include <stdio.h>
 #include <arpa/inet.h>
 #include "auth.h"
+#include "ovis_util/util.h"
 
 #define _str(x) #x
 #define str(x) _str(x)
@@ -142,7 +143,7 @@ char *ovis_auth_get_secretword(const char *path, ovis_auth_log_fn_t log)
 	if (stat(path, &pstat)) {
 		ret = errno;
 		log("Auth error: %s while trying to stat %s\n",
-			strerror(errno), path);
+			STRERROR(ret), path);
 		goto err;
 	}
 

--- a/lib/src/ovis_ctrl/ctrl.c
+++ b/lib/src/ovis_ctrl/ctrl.c
@@ -269,7 +269,7 @@ struct ctrlsock *ctrl_connect(char *my_name, char *sockname,
 		/* Ignore the error if the path already exists */
 		if (errno != EEXIST) {
 			printf("Error creating '%s: %s\n", my_un.sun_path,
-							strerror(errno));
+							STRERROR(errno));
 			close(sock->sock);
 			goto err;
 		}

--- a/lib/src/ovis_util/olog.c
+++ b/lib/src/ovis_util/olog.c
@@ -57,6 +57,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
+#include "ovis_util/util.h"
 
 #define OVIS_LOG_SYSLOG ((FILE*)0x7)
 #define OVIS_LOG_CLOSED ((FILE*)0xF7)
@@ -125,7 +126,7 @@ void ovis_logrotate() {
 			log_fp = new_log;
 		} else {
 			fprintf(log_fp,"logrotate failed. %d %s\n",
-				rc, strerror(rc));
+				rc, STRERROR(rc));
 		}
 		pthread_mutex_unlock(&log_lock);
 	}
@@ -149,7 +150,7 @@ int ovis_log_init(const char * progname, const char *logfile, const char *s)
 	log_fp = open_log(&rc);
 	if (!log_fp) {
 		log_fp = stdout;
-		olerr("rc = %d %s\n",rc, strerror(rc));
+		olerr("rc = %d %s\n",rc, STRERROR(rc));
 	}
 
 	return rc;

--- a/lib/src/ovis_util/test_util.c
+++ b/lib/src/ovis_util/test_util.c
@@ -116,14 +116,14 @@ int main(int argc, char **argv)
 	rc = ovis_join_buf(shortbuf, sizeof(shortbuf), NULL,s1,s2,s3,NULL);
 	if (rc == 0 || strcmp(t,shortbuf) == 0) {
 		printf("error 6: ovis_join_buf(sb,ss,NULL,s1,s2,s3,NULL) %d %s\n",
-			rc, strerror(rc));
+			rc, STRERROR(rc));
 		errcnt++;
 	}
 	snprintf(shortbuf,12,"0123456789"); // insufficient buf
 	rc = ovis_join_buf(shortbuf, sizeof(shortbuf), NULL,s1,s2,s3,NULL);
 	if (rc == 0 || strcmp(t,shortbuf) == 0) {
 		printf("error 7: ovis_join_buf(sb,ss,NULL,s1,s2,s3,NULL) %d %s\n",
-			rc, strerror(rc));
+			rc, STRERROR(rc));
 		errcnt++;
 	}
 	/* do not test for unterminated list. compiler warning from attribute sentinel

--- a/lib/src/ovis_util/util.c
+++ b/lib/src/ovis_util/util.c
@@ -990,21 +990,8 @@ const char* ovis_errno_abbvr(int e)
 	return "UNKNOWN_ERRNO";
 }
 
-/**
- * \brief thread-safe strerror.
- *
- * \retval str The sys_errlist value.
- * \retval "unknown_errno" if the errno \c e is unknown.
- */
 const char *ovis_strerror(int e) {
-	if (e >=0 && e < sys_nerr)
-		return sys_errlist[e];
-	return "unknown_errno";
-/* the gnu linker nuisance warning about sys_errlist.
- * If we truly hate it, we can use the code from nginx ngx_strerror
- * here. See: http://nginx.org/en/docs/sys_errlist.html
- * for why this is a good idea.
- */
+	return strerror(e);
 }
 
 /*


### PR DESCRIPTION
This solves reported issue #670, by switching everywhere to STRERROR macro defined in ovis_util/util.h.