### PR TITLE
Fix buffer reallocation in ldmsd_request

### DIFF
--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -307,6 +307,13 @@ typedef void (*ldms_lookup_cb_t)(ldms_t t, enum ldms_lookup_status status,
 #define LDMS_SET_ID_DATA	0x1000000
 
 /**
+ * Round up \c _sz_ to the \c _align_.
+ *
+ * \c _align_ must be a power of 2.
+ */
+#define LDMS_ROUNDUP(_sz_, _align_) (((_sz_) + (_align_) - 1) & ~((_align_)-1))
+
+/**
  * \addtogroup ldms_conn_mgmt LDMS Connection Management
  *
  * These functions initiate, terminate and manage connections with
@@ -912,7 +919,7 @@ struct ldms_xprt_rate_data {
 
 /**
  * Query daemon telemetry data across transports
- * 
+ *
  * \param data A pointer to the ldms_xprt_rate_data structure in which
  *             the results will be returned
  * \param reset Set to a non-zero value to reset the stats after

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -5503,10 +5503,10 @@ struct op_summary {
 	int len = snprintf(s, sz, __VA_ARGS__);			\
 	if (len >= sz) {					\
 		uint64_t off = (uint64_t)s - (uint64_t)buff;	\
-		sz += __APPEND_SZ;				\
-		s = realloc(buff, sz);				\
+		sz += LDMS_ROUNDUP(len-sz, __APPEND_SZ);	\
+		s = realloc(buff, off + sz);			\
 		if (!s) {					\
-			goto __APPEND_ERR;				\
+			goto __APPEND_ERR;			\
 		}						\
 		buff = s;					\
 		s = &buff[off];					\


### PR DESCRIPTION
The size provided to the `realloc()` call was not the size of the entire
buffer. Instead, the remaining size (`sz`) was given. This caused a
buffer overrun on `ldmsd` (e.g. when processing `thread_stats` request).
This patch corrects the size of the reallocation to be the size of the
entire buffer (`off + sz`).