### PR TITLE
Fix occasional SEGEV when ldmsd_controller exited

### DIFF
--- a/ldms/python/ldms.pxd
+++ b/ldms/python/ldms.pxd
@@ -179,6 +179,11 @@ cdef extern from "semaphore.h" nogil:
     int sem_timedwait(sem_t *sem, const timespec *abs_timeout)
     int sem_post(sem_t *sem)
 
+cdef extern from "time.h" nogil:
+    int clock_gettime(int clk_id, timespec *tp)
+    enum:
+        CLOCK_REALTIME
+
 cdef extern from "ovis_util/util.h" nogil:
     struct attr_value_list:
         pass

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1588,6 +1588,7 @@ if __name__ == "__main__":
                 cmdParser.do_quit(None)
             else:
                 cmdParser.cmdloop("Welcome to the LDMSD control processor")
+                cmdParser.do_quit(None)
     except KeyboardInterrupt:
         sys.exit(0)
     except Exception as e:


### PR DESCRIPTION
When ldmsd_controller exit, ldms_xprt was closed but the Python main
thread did not wait for the DISCONNECTED event. The segmentation fault
happened when zap_thread delivered DISCONNECTED event which took the
Python GIL in the callback path, but the Python GIL was already
destroyed because the Python main thread was exiting. This was supposed
not to happen because ldmsd_controller used Xprt in a blocking mode and
Xprt.close() shall timed-wait for the DICONNECTED event (like it did for
blocking `Xprt.connect()`).

This patch fixes the Cython `Xprt.close()` to timed-wait in the blocking
mode and adds the missing `do_quit()` call in ldmsd_controller in the
case of EOF (Ctrl-D) command loop exit.