### PR TITLE
Fix ldmsd_msg_gather to set the msg length to the total msg length

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request_util.c
+++ b/ldms/src/ldmsd/ldmsd_request_util.c
@@ -1088,6 +1088,7 @@ int ldmsd_msg_gather(struct ldmsd_msg_buf *buf, ldmsd_req_hdr_t req)
 	void *ptr;
 	size_t len = ntohl(req->rec_len);
 	uint32_t flags = ntohl(req->flags);
+	ldmsd_req_hdr_t hdr = (ldmsd_req_hdr_t)buf->buf;
 
 	if (flags & LDMSD_REQ_SOM_F) {
 		ptr = req;
@@ -1101,9 +1102,11 @@ int ldmsd_msg_gather(struct ldmsd_msg_buf *buf, ldmsd_req_hdr_t req)
 			return ENOMEM;
 		buf->buf = new_buf;
 		buf->len = 2 * buf->len + len;
+		hdr = (ldmsd_req_hdr_t)buf->buf;
 	}
 	memcpy(&buf->buf[buf->off], ptr, len);
 	buf->off += len;
+	hdr->rec_len = htonl(buf->off);
 	if (flags & LDMSD_REQ_EOM_F)
 		return 0;
 	return EBUSY;


### PR DESCRIPTION
…egnth

ldmsd_msg_gather does not update the request header object's message
length to include the subsequent records' legnths after the first
record. Therefore, the message length may be shorter than the actual
message length. At this time, the bug is asymptotic because no
ldmsd_msg_gather’s callers use the message length. The fix is to prevent
future pitfalls.