### PR TITLE
separate patches fix two memory misuse bugs

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -797,7 +797,15 @@ int ldmsd_set_register(ldms_set_t set, const char *pluing_name)
 			rc = ENOMEM;
 			goto free_inst_name;
 		}
-		rbn_init(&list->rbn, s->plugin_name);
+		char *pname = strdup(s->plugin_name);
+		if (!pname) {
+			free(list);
+			ldmsd_set_tree_unlock();
+			ldms_set_put(s->set);
+			rc = ENOMEM;
+			goto free_inst_name;
+		}
+		rbn_init(&list->rbn, pname);
 		LIST_INIT(&list->list);
 		rbt_ins(&set_tree, &list->rbn);
 	} else {
@@ -856,7 +864,9 @@ void ldmsd_set_deregister(const char *inst_name, const char *plugin_name)
 		free(set);
 	}
 	if (LIST_EMPTY(&list->list)) {
+		char *pname = list->rbn.key;
 		rbt_del(&set_tree, &list->rbn);
+		free(pname);
 		free(list);
 	}
 out:

--- a/ldms/src/sampler/sampler_base.c
+++ b/ldms/src/sampler/sampler_base.c
@@ -78,6 +78,7 @@ void base_del(base_data_t base)
 		ldms_schema_delete(base->schema);
 	if (base->job_set)
 		ldms_set_put(base->job_set);
+	free(base->job_set_name);
 	free(base);
 }
 


### PR DESCRIPTION
the bug in ldmsd.c causes wild frees to occur in multi-set samplers (any sampler with per-device sets) during ldmsd_set_deregister.
the bug in sampler_base is a forgotten string free in base_del.