### PR TITLE
add procnet sampler to report per-device network metrics

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -294,6 +294,7 @@ if test -z "$ENABLE_MPI_SAMPLER_TRUE" ; then
 	AX_MPI([:],[ AC_MSG_ERROR([MPICC required by mpi_sampler ])])
 fi
 OPTION_DEFAULT_ENABLE([procinterrupts], [ENABLE_PROCINTERRUPTS])
+OPTION_DEFAULT_ENABLE([procnet], [ENABLE_PROCNET])
 OPTION_DEFAULT_ENABLE([procnetdev], [ENABLE_PROCNETDEV])
 OPTION_DEFAULT_ENABLE([procnfs], [ENABLE_PROCNFS])
 OPTION_DEFAULT_ENABLE([dstat], [ENABLE_DSTAT])
@@ -840,6 +841,7 @@ ldms/src/sampler/cray_system_sampler/Makefile
 ldms/src/sampler/aries_mmr/Makefile
 ldms/src/sampler/aries_mmr/aries_mmr_set_configs/Makefile
 ldms/src/sampler/ibnet/Makefile
+ldms/src/sampler/procnet/Makefile
 ldms/src/sampler/rdc_sampler/Makefile
 ldms/src/sampler/slurm/Makefile
 ldms/src/sampler/spank/Makefile

--- a/ldms/scripts/examples/procnet
+++ b/ldms/scripts/examples/procnet
@@ -1,0 +1,16 @@
+export plugname=procnet
+IFACES=`ifconfig -a |grep UP |sed -e 's/:.*//g' | tr -s '[:space:]' , | sed -e 's/,$//g'`
+export IFACES
+
+portbase=61024
+VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=definite"
+#vgon
+LDMSD 1 2
+vgoff
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1 -l
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2 -l
+SLEEP 5
+KILL_LDMSD 1 2
+file_created $STOREDIR/node/$testname

--- a/ldms/scripts/examples/procnet.1
+++ b/ldms/scripts/examples/procnet.1
@@ -1,0 +1,7 @@
+load name=${testname}
+config name=${testname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} exclude_ports=lo
+start name=${testname} interval=1000000 offset=0
+
+load name=${testname}dev
+config name=${testname}dev producer=localhost${i} schema=${testname}dev instance=localhost${i}/${testname}dev component_id=${i} ifaces=lo,virbr0,ens33,ens34
+start name=${testname}dev interval=1000000 offset=0

--- a/ldms/scripts/examples/procnet.2
+++ b/ldms/scripts/examples/procnet.2
@@ -1,0 +1,21 @@
+load name=${testname}
+config name=${testname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} ifaces=lo
+start name=${testname} interval=1000000 offset=0
+
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=1000000
+prdcr_start name=localhost1
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+strgp_add name=store_${testname} plugin=store_csv schema=${testname} container=node
+strgp_prdcr_add name=store_${testname} regex=.*
+strgp_start name=store_${testname}
+
+strgp_add name=store_${testname}dev plugin=store_csv schema=${testname}dev container=node
+strgp_prdcr_add name=store_${testname}dev regex=.*
+strgp_start name=store_${testname}dev

--- a/ldms/src/sampler/Makefile.am
+++ b/ldms/src/sampler/Makefile.am
@@ -237,6 +237,10 @@ if ENABLE_FILESINGLE
 SUBDIRS += filesingle
 endif
 
+if ENABLE_PROCNET
+SUBDIRS += procnet
+endif
+
 if ENABLE_PROCSTAT
 SUBDIRS += procstat
 endif

--- a/ldms/src/sampler/procnet/Makefile.am
+++ b/ldms/src/sampler/procnet/Makefile.am
@@ -1,0 +1,16 @@
+pkglib_LTLIBRARIES =
+lib_LTLIBRARIES =
+dist_man7_MANS =
+dist_man1_MANS =
+
+AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
+AM_LDFLAGS = @OVIS_LIB_ABS@
+COMMON_LIBADD = -lsampler_base -lldms -lovis_util -lcoll \
+		@LDFLAGS_GETTIME@
+
+if ENABLE_PROCNET
+dist_man7_MANS += Plugin_procnet.man
+libprocnet_la_SOURCES = procnet.c
+libprocnet_la_LIBADD = $(COMMON_LIBADD)
+pkglib_LTLIBRARIES += libprocnet.la
+endif

--- a/ldms/src/sampler/procnet/Plugin_procnet.man
+++ b/ldms/src/sampler/procnet/Plugin_procnet.man
@@ -1,0 +1,53 @@
+.\" Manpage for Plugin_procnet
+.\" Contact ovis-help@ca.sandia.gov to correct errors or typos.
+.TH man 7 "9 Apr 2021" "v4" "LDMS Plugin procnet man page"
+
+.SH NAME
+Plugin_procnet - man page for the LDMS procnet plugin
+
+.SH SYNOPSIS
+Within ldmsd_controller or a configuration file:
+.br
+config name=procnet [common attributes] [exclude_ports=<devs>]
+
+.SH DESCRIPTION
+With LDMS (Lightweight Distributed Metric Service), plugins for the ldmsd (ldms daemon) are configured via ldmsd_controller
+or a configuration file. The procnet plugin provides network info from /proc/net/dev, creating a different set for each device, reporting only active devices, and reporting an active device only when counters change.
+
+.SH CONFIGURATION ATTRIBUTE SYNTAX
+The procnet plugin uses the sampler_base base class. This man page covers only the configuration attributes, or those with default values, specific to the this plugin; see ldms_sampler_base.man for the attributes of the base class.
+
+.TP
+.BR config
+name=<plugin_name> exclude_ports=<devs>
+.br
+configuration line
+.RS
+.TP
+name=<plugin_name>
+.br
+This MUST be procnet.
+.TP
+exclude_ports=<devs>
+.br
+Comma separated list of ports to exclude.
+.TP
+schema=<schema>
+.br
+Optional schema name. If not specified, will default to `procnet`.
+.RE
+
+.SH BUGS
+Interfaces reported and exclude_ports lists are each limited to 20.
+
+.SH EXAMPLES
+.PP
+Within ldmsd_controller or a configuration file:
+.nf
+load name=procnet
+config name=procnet producer=vm1_1 instance=vm1_1/procnet exclude_ports=lo
+start name=procnet interval=1000000
+.fi
+
+.SH SEE ALSO
+ldmsd(8), ldms_quickstart(7), ldmsd_controller(8), ldms_sampler_base(7)

--- a/ldms/src/sampler/procnet/procnet.c
+++ b/ldms/src/sampler/procnet/procnet.c
@@ -1,0 +1,502 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2021 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ * Copyright (c) 2821 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \file procnet.c
+ * \brief /proc/net/dev data provider with set per device
+ */
+#include <inttypes.h>
+#include <unistd.h>
+#include <sys/errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <sys/types.h>
+#include <time.h>
+#include <sys/time.h>
+#include "ldms.h"
+#include "ldmsd.h"
+#include "sampler_base.h"
+#include <pthread.h>
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(*a))
+#endif
+
+static pthread_mutex_t cfg_lock = PTHREAD_MUTEX_INITIALIZER;
+
+#define PROC_FILE "/proc/net/dev"
+static char *procfile = PROC_FILE;
+#define NVARS 16
+static char *varname[] =
+{"rx_bytes", "rx_packets", "rx_errs", "rx_drop", "rx_fifo", "rx_frame",
+	"rx_compressed", "rx_multicast", "tx_bytes", "tx_packets", "tx_errs",
+	"tx_drop", "tx_fifo", "tx_colls", "tx_carrier", "tx_compressed"};
+
+struct port {
+	char name[20]; /* device name */
+	ldms_set_t set;
+	uint64_t last_sum; /* sum of integer metrics at last sampling. rollover in this sum is ok. */
+	int meta_done; /* have we set the device metric */
+	uint64_t update;
+};
+int niface = 0;
+//max number of interfaces we can include. TODO: alloc as added
+
+#define MAXIFACE 21
+static struct port ports[MAXIFACE];
+static int n_ports; /* number of ports in use */
+static char ignore_port[MAXIFACE][20];
+static size_t n_ignored; /* number of names ignored */
+static int configured;
+static int termed;
+
+#define SAMP "procnet"
+static FILE *mf = NULL;
+static ldmsd_msg_log_f msglog;
+static int metric_offset;
+static base_data_t base;
+
+struct kw {
+	char *token;
+	int (*action)(struct attr_value_list *kwl, struct attr_value_list *avl, void *arg);
+};
+
+static ldms_set_t get_set(struct ldmsd_sampler *self)
+{
+	return NULL;
+}
+
+static void procnet_reset()
+{
+	if (mf)
+		fclose(mf);
+	mf = NULL;
+	int j;
+	for (j = 0; j < n_ports; j++) {
+		ldms_set_t set = ports[j].set;
+		if (set) {
+                        const char *tmp = ldms_set_instance_name_get(set);
+                        ldmsd_set_deregister(tmp, base->pi_name);
+                        ldms_set_unpublish(set);
+                        ldms_set_delete(set);
+		}
+		memset(&ports[j], 0, sizeof(ports[0]));
+	}
+	for (j = 0; j < MAXIFACE; j++) {
+		memset(ignore_port[j], 0, sizeof(ignore_port[0]));
+	}
+	if (base) {
+		free(base->instance_name);
+		base->instance_name = NULL;
+		base_del(base);
+		base = NULL;
+	}
+	metric_offset = 0;
+	n_ignored = 0;
+	n_ports = 0;
+	configured = 0;
+}
+
+static int add_port(const char *name)
+{
+	msglog(LDMSD_LDEBUG, SAMP ": adding port %s.\n", name);
+	/* temporarily override default instance name behavior */
+	char *tmp = base->instance_name;
+	size_t len = strlen(tmp);
+	int rc;
+	base->instance_name = malloc( len + 20);
+	if (!base->instance_name) {
+		base->instance_name = tmp;
+		rc = ENOMEM;
+		goto err;
+	}
+	/* override single set assumed in sampler_base api */
+	snprintf(base->instance_name, len + 20, "%s/%s", tmp, name);
+	ldms_set_t set = base_set_new(base);
+	if (!set) {
+		msglog(LDMSD_LERROR, "failed to make %s set for %s\n",
+			name, SAMP);
+		rc = errno;
+		base->instance_name = tmp;
+		goto err;
+	}
+	ports[n_ports].set = set;
+	strncpy(ports[n_ports].name, name, sizeof(ports[n_ports].name));
+	base->set = NULL;
+	free(base->instance_name);
+	base->instance_name = tmp;
+	n_ports++;
+	rc = 0;
+err:
+	return rc;
+}
+
+static int create_metric_schema(base_data_t base)
+{
+	int rc;
+	ldms_schema_t schema;
+	int  j;
+
+	mf = fopen(procfile, "r");
+	if (!mf) {
+		msglog(LDMSD_LERROR, "Could not open " SAMP " file "
+				"'%s'...exiting\n",
+				procfile);
+		return ENOENT;
+	}
+
+	/* Create a metric set of the required size */
+	schema = base_schema_new(base);
+	if (!schema) {
+		msglog(LDMSD_LERROR,
+		       "%s: The schema '%s' could not be created, errno=%d.\n",
+		       __FILE__, base->schema_name, errno);
+		rc = EINVAL;
+		goto err;
+	}
+
+	/* Location of first metric from proc file */
+	metric_offset = ldms_schema_metric_count_get(schema);
+
+	rc = ldms_schema_metric_array_add(schema, "device", LDMS_V_CHAR_ARRAY, sizeof(ports[0].name));
+	if (rc < 0) {
+		msglog(LDMSD_LERROR, SAMP ": out of memory: device\n");
+		rc = ENOMEM;
+		goto err;
+	}
+	rc = ldms_schema_metric_add(schema, "update", LDMS_V_U64);
+	if (rc < 0) {
+		msglog(LDMSD_LERROR, SAMP ": out of memory: update\n");
+		rc = ENOMEM;
+		goto err;
+	}
+	for (j = 0; j < NVARS; j++) {
+		rc = ldms_schema_metric_add(schema, varname[j], LDMS_V_U64);
+		if (rc < 0) {
+			rc = ENOMEM;
+			goto err;
+		}
+	}
+	return 0;
+
+err:
+
+	if (mf)
+		fclose(mf);
+	mf = NULL;
+
+	return rc;
+}
+
+
+/**
+ * check for invalid flags, with particular emphasis on warning the user about
+ */
+static int config_check(struct attr_value_list *kwl, struct attr_value_list *avl, void *arg)
+{
+	char *value;
+	int i;
+
+	char* deprecated[]={"set"};
+
+	for (i = 0; i < ARRAY_SIZE(deprecated); i++){
+		value = av_value(avl, deprecated[i]);
+		if (value){
+			msglog(LDMSD_LERROR, SAMP ": config argument %s has been deprecated.\n",
+			       deprecated[i]);
+			return EINVAL;
+		}
+	}
+
+	return 0;
+}
+
+static const char *usage(struct ldmsd_plugin *self)
+{
+	return "config name=" SAMP " exclude_ports=<devs>\n" \
+		BASE_CONFIG_USAGE \
+		"    <devs>          A comma-separated list of interfaces to be ignored.\n"
+		"                    By default all active interfaces discovered will be reported.\n";
+}
+
+static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct attr_value_list *avl)
+{
+	char* ignorelist = NULL;
+	char* pch = NULL;
+	char *saveptr = NULL;
+	char *ivalue = NULL;
+	void *arg = NULL;
+	int rc;
+
+	rc = config_check(kwl, avl, arg);
+	if (rc != 0){
+		return rc;
+	}
+	pthread_mutex_lock(&cfg_lock);
+
+	if (termed) {
+		rc = 0;
+		goto err1;
+	}
+	if (configured) {
+		procnet_reset();
+		msglog(LDMSD_LDEBUG, SAMP ": reconfiguring.\n");
+	}
+	n_ignored = 0;
+	ivalue = av_value(avl, "exclude_ports");
+	if (ivalue == NULL)
+		ivalue = "";
+	ignorelist = strdup(ivalue);
+	if (!ignorelist) {
+		msglog(LDMSD_LERROR, SAMP ": out of memory\n");
+		goto err;
+	}
+	pch = strtok_r(ignorelist, ",", &saveptr);
+	while (pch != NULL){
+		if (n_ignored >= (MAXIFACE-1)) {
+			msglog(LDMSD_LERROR, SAMP ": too many devices being ignored: <%s>\n",
+				pch);
+			goto err;
+		}
+		snprintf(ignore_port[n_ignored], sizeof(ignore_port[0]), "%s", pch);
+		msglog(LDMSD_LDEBUG, SAMP ": ignoring net device <%s>\n", pch);
+		n_ignored++;
+		pch = strtok_r(NULL, ",", &saveptr);
+	}
+	free(ignorelist);
+	ignorelist = NULL;
+
+	base = base_config(avl, SAMP, SAMP, msglog);
+	if (!base) {
+		rc = EINVAL;
+		goto err;
+	}
+
+	rc = create_metric_schema(base);
+	if (rc) {
+		msglog(LDMSD_LERROR, SAMP ": failed to create a metric schema.\n");
+		goto err;
+	}
+	pthread_mutex_unlock(&cfg_lock);
+	configured = 1;
+	return 0;
+
+err:
+	free(ignorelist);
+	base_del(base);
+err1:
+	pthread_mutex_unlock(&cfg_lock);
+	return rc;
+}
+
+static int update_port(int j, uint64_t msum, union ldms_value *v)
+{
+	ldms_set_t set = ports[j].set;
+	if (!set || j < 0 || j >= MAXIFACE)
+		return EINVAL;
+	base->set = set;
+	int metric_no = metric_offset;
+	base_sample_begin(base);
+	if (!ports[j].meta_done) {
+		ldms_metric_array_set_str( set, metric_no,
+			ports[j].name);
+		ports[j].meta_done = 1;
+	}
+	metric_no++;
+	ldms_metric_set_u64(set, metric_no, ports[j].update);
+	metric_no++;
+	int i;
+	for (i = 0; i < NVARS; i++) {
+		ldms_metric_set(set, metric_no++, &v[i]);
+	}
+	ports[j].update++;
+	base_sample_end(base);
+	base->set = NULL;
+	return 0;
+}
+
+static int sample(struct ldmsd_sampler *self)
+{
+	char *s;
+	char lbuf[256];
+	char curriface[20];
+	union ldms_value v[NVARS];
+	int j;
+	int rc;
+
+	pthread_mutex_lock(&cfg_lock);
+
+	if (!configured) {
+		msglog(LDMSD_LDEBUG, SAMP ": plugin not initialized\n");
+		rc = 0;
+		goto err;
+	}
+
+	if (!mf)
+		mf = fopen(procfile, "r");
+	if (!mf) {
+		msglog(LDMSD_LERROR, SAMP ": Could not open /proc/net/dev file "
+				"'%s'...exiting\n", procfile);
+		rc = ENOENT;
+		goto err;
+	}
+
+	fseek(mf, 0, SEEK_SET); //seek should work if get to EOF
+	/* consume headers */
+	s = fgets(lbuf, sizeof(lbuf), mf);
+	s = fgets(lbuf, sizeof(lbuf), mf);
+
+	/* parse all data */
+	do {
+		s = fgets(lbuf, sizeof(lbuf), mf);
+		if (!s)
+			break;
+
+		char *pch = strchr(lbuf, ':');
+		if (pch != NULL){
+			*pch = ' ';
+		}
+
+		rc = sscanf(lbuf, "%s %" PRIu64 " %" PRIu64 " %" PRIu64
+				" %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64
+				" %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64
+				" %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64
+				" %" PRIu64 "\n", curriface, &v[0].v_u64,
+				&v[1].v_u64, &v[2].v_u64, &v[3].v_u64,
+				&v[4].v_u64, &v[5].v_u64, &v[6].v_u64,
+				&v[7].v_u64, &v[8].v_u64, &v[9].v_u64,
+				&v[10].v_u64, &v[11].v_u64, &v[12].v_u64,
+				&v[13].v_u64, &v[14].v_u64, &v[15].v_u64);
+		if (rc != 17) {
+			msglog(LDMSD_LINFO, SAMP ": wrong number of "
+					"fields in sscanf. skipping line %s\n", lbuf);
+			continue;
+		}
+		for (j = 0; j < n_ignored; j++) {
+			if (!strcmp(curriface, ignore_port[j]))
+				goto skip;
+		}
+
+		uint64_t msum = 0;
+		/* don't care if msum rolls; just want to know if it
+		 * changed from prior or is 0. */
+		for (j = 0; j < NVARS; j++)
+			msum += v[j].v_u64;
+
+		int done = 0;
+		for (j = 0; j < n_ports; j++) {
+			if (strcmp(curriface, ports[j].name) == 0) {
+				if (msum != ports[j].last_sum) {
+					rc = update_port(j, msum, v);
+					if (rc)
+						goto err;
+				}
+				done = 1;
+				break;
+			}
+		}
+		if (!done && msum) {
+			if (n_ports >= MAXIFACE) {
+				msglog(LDMSD_LERROR, SAMP ": Cannot add %d-th port %s. "
+					"Too many ports.\n", MAXIFACE+1, curriface);
+				rc = ENOMEM;
+				goto err;
+			}
+			/* add discovered interface if it's active. */
+			rc = add_port(curriface);
+			if (rc)
+				goto err;
+			rc = update_port(n_ports-1, msum, v);
+			if (rc)
+				goto err;
+		}
+	skip:
+		continue;
+	} while (s);
+	rc = 0;
+err:
+	pthread_mutex_unlock(&cfg_lock);
+	return rc;
+}
+
+
+static void term(struct ldmsd_plugin *self)
+{
+	(void)self;
+	pthread_mutex_lock(&cfg_lock);
+	procnet_reset();
+	termed = 1;
+	pthread_mutex_unlock(&cfg_lock);
+
+}
+
+static struct ldmsd_sampler procnet_plugin = {
+	.base = {
+		.name = SAMP,
+		.type = LDMSD_PLUGIN_SAMPLER,
+		.term = term,
+		.config = config,
+		.usage = usage,
+	},
+	.get_set = get_set,
+	.sample = sample,
+};
+
+struct ldmsd_plugin *get_plugin(ldmsd_msg_log_f pf)
+{
+	msglog = pf;
+	return &procnet_plugin.base;
+}
+
+static void __attribute__ ((destructor)) procnet_plugin_fini(void);
+static void procnet_plugin_fini()
+{
+	term(NULL);
+}


### PR DESCRIPTION
This sampler reports data from /proc/net/dev with a set per port.
It reports all active ports that are not excluded.
It only reports a new set when some metric actually changes, including an update number so that analysis can tell the difference between missing and unchanging data (a sequence gap in 'update' indicates lost data); this has been a frequently requested feature in the past by admins.