### PR TITLE
update cfgobj_trees local redeclaration for ldmsd_auth

### DIFF
--- a/ldms/src/ldmsd/ldmsd_auth.c
+++ b/ldms/src/ldmsd/ldmsd_auth.c
@@ -110,7 +110,7 @@ ldmsd_auth_new_with_auth(const char *name, const char *plugin,
 }
 
 ldmsd_cfgobj_t __cfgobj_find(const char *name, ldmsd_cfgobj_type_t type);
-struct rbt **cfgobj_trees;
+extern struct rbt *cfgobj_trees[];
 
 int ldmsd_auth_del(const char *name, ldmsd_sec_ctxt_t ctxt)
 {


### PR DESCRIPTION
fixes #670 

This minimalist change fixes a duplicate global trapped as an error by gcc 10.2.
It now matches the cloned extern declarations in ldmsd_prdcr.c ldmsd_strgp.c ldmsd_updtr.c.
A better solution would be to add an ldmsd_config.h defining cfgobj_trees and include it
everywhere needed.