### PR TITLE
Fix ldmsd_request:stream_xprt_term()

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -6080,10 +6080,8 @@ static int stream_republish_cb(ldmsd_stream_client_t c, void *ctxt,
 
 /* RSE: remote stream entry */
 struct __RSE_key_s {
-	/* remote addr */
-	struct sockaddr addr;
-	/* remote addr len */
-	uint32_t addr_len;
+	/* xprt ref */
+	ldms_t xprt;
 	/* stream name */
 	char name[];
 };
@@ -6097,26 +6095,14 @@ typedef struct __RSE_s {
 int __RSE_cmp(void *tree_key, const void *key)
 {
 	const struct __RSE_key_s *k0, *k1;
-	size_t len;
-	int rc, ln_rc;
+
 	k0 = tree_key;
 	k1 = key;
-	if (k0->addr_len < k1->addr_len) {
-		len = k0->addr_len;
-		ln_rc = -1;
-	} else if (k0->addr_len > k1->addr_len) {
-		len = k1->addr_len;
-		ln_rc = 1;
-	} else {
-		len = k0->addr_len;
-		ln_rc = 0;
-	}
-	rc = memcmp(&k0->addr, &k1->addr, len);
-	if (rc)
-		return rc;
-	if (ln_rc)
-		return ln_rc;
-	/* reaching here means same address */
+	if (k0->xprt < k1->xprt)
+		return -1;
+	if (k0->xprt > k1->xprt)
+		return 1;
+	/* reaching here means same xprt */
 	return strcmp(k0->name, k1->name);
 }
 
@@ -6136,22 +6122,23 @@ void __RSE_rbt_unlock()
 }
 
 static inline
-__RSE_t __RSE_alloc(const char *name, struct sockaddr *sa, socklen_t sa_len)
+__RSE_t __RSE_alloc(const char *name, ldms_t xprt)
 {
 	__RSE_t ent;
 	ent = calloc(1, sizeof(*ent) + strlen(name) + 1);
 	if (!ent)
 		return NULL;
 	sprintf(ent->key.name, "%s", name);
-	memcpy(&ent->key.addr, sa, sa_len);
-	ent->key.addr_len = sa_len;
+	ent->key.xprt = xprt;
 	rbn_init(&ent->rbn, &ent->key);
+	ldms_xprt_get(xprt);
 	return ent;
 }
 
 static inline
 void __RSE_free(__RSE_t ent)
 {
+	ldms_xprt_put(ent->key.xprt);
 	free(ent);
 }
 
@@ -6184,8 +6171,7 @@ static int stream_subscribe_handler(ldmsd_req_ctxt_t reqc)
 {
 	char *stream_name;
 	int cnt;
-	int rc, len;
-	struct sockaddr local_sa;
+	int len;
 	__RSE_t ent;
 	char _buff[sizeof(struct __RSE_key_s) + 256]; /* should be enough for stream name */
 	struct __RSE_key_s *key = (void*)_buff;
@@ -6197,24 +6183,13 @@ static int stream_subscribe_handler(ldmsd_req_ctxt_t reqc)
 			       "The stream name is missing.");
 		goto send_reply;
 	}
+	key->xprt = reqc->xprt->ldms.ldms;
 	len = snprintf(key->name, 256, "%s", stream_name);
 	if (len >= 256) {
 		reqc->errcode = ENAMETOOLONG;
 		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
 			       "The stream name is too long (%d >= %d).",
 			       len, 256);
-		goto send_reply;
-	}
-	key->addr_len = sizeof(key->addr);
-	rc = ldms_xprt_sockaddr(reqc->xprt->ldms.ldms, &local_sa, &key->addr,
-				&key->addr_len);
-	if (rc) {
-		ldmsd_log(LDMSD_LWARNING,
-			  "%s:%d:%s ldms_xprt_sockaddr() error: %d\n",
-			  __FILE__, __LINE__, __func__, errno);
-		reqc->errcode = EREMOTEIO;
-		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
-			       "ldms_xprt_sockaddr() error: %d", errno);
 		goto send_reply;
 	}
 	__RSE_rbt_lock();
@@ -6227,7 +6202,7 @@ static int stream_subscribe_handler(ldmsd_req_ctxt_t reqc)
 			       stream_name);
 		goto send_reply;
 	}
-	ent = __RSE_alloc(stream_name, &key->addr, key->addr_len);
+	ent = __RSE_alloc(stream_name, reqc->xprt->ldms.ldms);
 	if (!ent) {
 		__RSE_rbt_unlock();
 		reqc->errcode = ENOMEM;
@@ -6237,10 +6212,10 @@ static int stream_subscribe_handler(ldmsd_req_ctxt_t reqc)
 	}
 
 	ent->client = ldmsd_stream_subscribe(stream_name, stream_republish_cb,
-					ldms_xprt_get(reqc->xprt->ldms.ldms));
+					     ent->key.xprt);
 	if (!ent->client) {
 		__RSE_rbt_unlock();
-		free(ent);
+		__RSE_free(ent);
 		reqc->errcode = errno;
 		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
 			       "ldmsd_stream_subscribe() error: %d", errno);
@@ -6261,8 +6236,7 @@ static int stream_unsubscribe_handler(ldmsd_req_ctxt_t reqc)
 {
 	char *stream_name;
 	int cnt;
-	int rc, len;
-	struct sockaddr local_sa;
+	int len;
 	__RSE_t ent;
 	char _buff[sizeof(struct __RSE_key_s) + 256]; /* should be enough for stream name */
 	struct __RSE_key_s *key = (void*)_buff;
@@ -6274,24 +6248,13 @@ static int stream_unsubscribe_handler(ldmsd_req_ctxt_t reqc)
 			       "The stream name is missing.");
 		goto send_reply;
 	}
+	key->xprt = reqc->xprt->ldms.ldms;
 	len = snprintf(key->name, 256, "%s", stream_name);
 	if (len >= 256) {
 		reqc->errcode = ENAMETOOLONG;
 		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
 			       "The stream name is too long (%d >= %d).",
 			       len, 256);
-		goto send_reply;
-	}
-	key->addr_len = sizeof(key->addr);
-	rc = ldms_xprt_sockaddr(reqc->xprt->ldms.ldms, &local_sa, &key->addr,
-				&key->addr_len);
-	if (rc) {
-		ldmsd_log(LDMSD_LWARNING,
-			  "%s:%d:%s ldms_xprt_sockaddr() error: %d\n",
-			  __FILE__, __LINE__, __func__, errno);
-		reqc->errcode = EREMOTEIO;
-		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
-			       "ldms_xprt_sockaddr() error: %d", errno);
 		goto send_reply;
 	}
 	__RSE_rbt_lock();
@@ -6303,9 +6266,9 @@ static int stream_unsubscribe_handler(ldmsd_req_ctxt_t reqc)
 			       "`%s` stream not found", stream_name);
 		goto send_reply;
 	}
-	ldmsd_stream_close(ent->client);
 	__RSE_del(ent);
-	free(ent);
+	ldmsd_stream_close(ent->client);
+	__RSE_free(ent);
 	reqc->errcode = 0;
 	cnt = Snprintf(&reqc->line_buf, &reqc->line_len, "OK");
 	__RSE_rbt_unlock();
@@ -6348,25 +6311,17 @@ static int stream_client_dump_handler(ldmsd_req_ctxt_t reqc)
 
 void stream_xprt_term(ldms_t x)
 {
-	struct sockaddr local_sa;
 	__RSE_t ent;
 	struct rbn *rbn;
 	char _buff[sizeof(struct __RSE_key_s) + 256] = {};
 	struct __RSE_key_s *key = (void*)_buff;
-	int rc;
 
-	key->addr_len = sizeof(key->addr);
-	rc = ldms_xprt_sockaddr(x, &local_sa, &key->addr,
-				&key->addr_len);
-	if (rc)
-		return;
+	key->xprt = x;
 	__RSE_rbt_lock();
 	rbn = rbt_find_lub(&__RSE_rbt, key);
 	while (rbn) {
 		ent = container_of(rbn, struct __RSE_s, rbn);
-		if (key->addr_len != ent->key.addr_len)
-			break;
-		if (memcmp(&key->addr, &ent->key.addr, key->addr_len))
+		if (key->xprt != ent->key.xprt)
 			break;
 		/* points rbn to the successor before removing ent */
 		rbn = rbn_succ(rbn);
@@ -6374,7 +6329,6 @@ void stream_xprt_term(ldms_t x)
 		__RSE_del(ent);
 		ldmsd_stream_close(ent->client);
 		__RSE_free(ent);
-		ldms_xprt_put(x);
 	}
 	__RSE_rbt_unlock();
 }


### PR DESCRIPTION
When LDMS xprt terminated in ldmsd, ldmsd went through the collection
of stream clients to clean up the stream clients associated with the
transport. The collection of clients used `<remote_addr,stream_name>`
for rbt keys. However, on rdma transport, the remote addresses of two
transports from the same remote host got resolved to the same address.
This resulted in premature stream client cleanup due to the address
mixed-up. In addition, on the socket transport, `ldms_xprt_sockaddr()`
call in `stream_xprt_term()` returned ENOTCONN the
`ldms_xprt_sockaddr()` exited immediately, leaking the stream client
and the associated LDMS xprt.

This patch modifies the key to of the stream collections to use
`xprt` pointer instead.

NOTE: This has been tested on rdma and sock transports with GDB to
verify the correct find/removal.