### PR TITLE
Fix ldmsd message with no attributes

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -3050,7 +3050,7 @@ int ldms_xprt_send(ldms_t _x, char *msg_buf, size_t msg_len)
 	if (!ldms_xprt_connected(x))
 		return ENOTCONN;
 
-	assert(msg_len > 4);
+	assert(msg_len >= 4);
 	if (!msg_buf)
 		return EINVAL;
 

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -928,7 +928,7 @@ int ldmsd_req_cmd_attr_append(ldmsd_req_cmd_t rcmd,
 		attr.discrim = 0;
 		return __ldmsd_append_buffer(rcmd->reqc, (void*)&attr.discrim,
 					     sizeof(attr.discrim),
-					     LDMSD_REQ_EOM_F,
+					     rcmd->msg_flags|LDMSD_REQ_EOM_F,
 					     LDMSD_REQ_TYPE_CONFIG_CMD);
 	}
 	if (attr_id >= LDMSD_ATTR_LAST)


### PR DESCRIPTION
For an ldmsd message that has no attributes (e.g.
LDMSD_FAILOVER_PEERCFG_REQ message), the flag of the message was
incorrectly set to only EOM instead of `SOM|EOM`. In addition, the
message length would be exactly 4 bytes. This patch addresses the
message length assertion and the message flags to correctly handle the
message with no attributes.