### PR TITLE
fixes missing support for instance in lustre_client

### DIFF
--- a/ldms/src/sampler/lustre_client/Plugin_lustre_client.man
+++ b/ldms/src/sampler/lustre_client/Plugin_lustre_client.man
@@ -14,9 +14,10 @@ or a configuration file. The lustre_client plugin provide a metric set for each 
 mounts found on a node.  The schema is named "lustre_client".  The data for the metric sets is
 generally found in /proc/fs/lustre/llite/*/stats.
 
-This plugin currently employs zero configuration.  The producer name is set to the hostname, and the metric set instance names are
-derived from the llite instance name.  Any user-supplied configuration values will be ignored.  Future versions may add
-configuration options.
+This plugin currently employs zero configuration.  The producer name is set to the hostname
+by default, and the metric set instance names are
+derived from the llite instance name. Any user-supplied configuration values not
+documented here will be ignored.
 
 This plugin should work with at least Lustre versions 2.8, 2.10, and 2.12.
 
@@ -33,13 +34,18 @@ name=<plugin_name>
 .br
 This MUST be lustre_client.
 .TP
-job_set=<metric set name>
+job_set=<job metric set name>
 .br
 The name of the metric set that contains the job id information (default=job_id)
+.TP
+producer=<alternate host name>
+.br
+The default used for producer (if not provided) is the result of gethostname().
+The set instance names will be $producer/$llite_name.
 .RE
 
-.SH BUGS
-No known bugs.
+.SH NOTES
+Improperly spelled option names are not trapped as configuration errors.
 
 .SH EXAMPLES
 .PP
@@ -51,4 +57,4 @@ start name=lustre_client interval=1000000
 .fi
 
 .SH SEE ALSO
-ldmsd(8), ldms_quickstart(7), ldmsd_controller(8), ldms_sampler_base(7)
+ldmsd(8), ldms_quickstart(7), ldmsd_controller(8), ldms_sampler_base(7), gethostname(2)

--- a/ldms/src/sampler/lustre_client/lustre_client.c
+++ b/ldms/src/sampler/lustre_client/lustre_client.c
@@ -227,6 +227,15 @@ static int config(struct ldmsd_plugin *self,
                   struct attr_value_list *kwl, struct attr_value_list *avl)
 {
         log_fn(LDMSD_LDEBUG, SAMP" config() called\n");
+	char *ival = av_value(avl, "producer");
+	if (ival) {
+		if (strlen(ival) < sizeof(producer_name)) {
+			strncpy(producer_name, ival, sizeof(producer_name));
+		} else {
+                        log_fn(LDMSD_LERROR, SAMP": config: producer name too long.\n");
+                        return EINVAL;
+		}
+	}
 	jobid_helper_config(avl);
         return 0;
 }

--- a/ldms/src/sampler/lustre_client/lustre_client_general.c
+++ b/ldms/src/sampler/lustre_client/lustre_client_general.c
@@ -124,7 +124,7 @@ ldms_set_t llite_general_create(const char *producer_name,
 {
         ldms_set_t set;
         int index;
-        char instance_name[256];
+        char instance_name[LDMS_PRODUCER_NAME_MAX+64];
 
         log_fn(LDMSD_LDEBUG, SAMP" llite_general_create()\n");
         snprintf(instance_name, sizeof(instance_name), "%s/%s",


### PR DESCRIPTION
The producer parameter is now used (instead of ignored) as the
prefix of the instance names generated by appending /$llite_name.
This prevents breakage (redundant instance names) during scale testing
with multiple samplers per node. 

If producer is not specified, default of $hostname remains.
Man page updated accordingly.