### PR TITLE
Free leaked symbol list

### DIFF
--- a/ldms/src/ldmsd/ldmsd_stream.c
+++ b/ldms/src/ldmsd/ldmsd_stream.c
@@ -544,6 +544,7 @@ char * ldmsd_stream_client_dump()
 					first_client?"":",",
 					sym?sym[0]:_pbuf,
 					c->c_ctxt);
+			free(sym);
 			if (rc)
 				goto err_3;
 			first_client = 0;


### PR DESCRIPTION
The ldmsd_stream_client_dump allocated a symbol list that was
not being freed.