### PR TITLE
Use unique connection identifier in message keys

### DIFF
--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -361,6 +361,15 @@ ldms_t ldms_xprt_new_with_auth(const char *xprt_name, ldms_log_fn_t log_fn,
 			       const char *auth_name,
 			       struct attr_value_list *auth_av_list);
 
+
+/**
+ * \brief Return the unique connection id for a transport instance
+ *
+ * \param x The transport handle
+ * \returns The unique connection id for the transport
+ */
+uint64_t ldms_xprt_conn_id(ldms_t x);
+
 /**
  * \brief Return the transport type name string
  * \param x The transport handle

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2872,9 +2872,16 @@ static int __rbd_rbt_key_comp(void *tree_key, const void *key)
 	return 0;
 }
 
+static uint64_t __ldms_conn_id;
+uint64_t ldms_xprt_conn_id(ldms_t ldms)
+{
+	return ldms->conn_id;
+}
+
 void __ldms_xprt_init(struct ldms_xprt *x, const char *name,
 					ldms_log_fn_t log_fn)
 {
+	x->conn_id = __sync_add_and_fetch(&__ldms_conn_id, 1);
 	x->name[LDMS_MAX_TRANSPORT_NAME_LEN - 1] = 0;
 	memccpy(x->name, name, 0, LDMS_MAX_TRANSPORT_NAME_LEN - 1);
 	x->ref_count = 1;

--- a/ldms/src/core/ldms_xprt.h
+++ b/ldms/src/core/ldms_xprt.h
@@ -412,6 +412,9 @@ struct ldms_xprt {
 
 	ldms_auth_t auth; /* authentication object */
 
+	/* Unique connection id */
+	uint64_t conn_id;
+
 	/* Remote Credential */
 	uid_t ruid;
 	gid_t rgid;

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -666,7 +666,7 @@ ldmsd_req_cmd_t alloc_req_cmd_ctxt(ldms_t ldms,
 		goto err0;
 
 	key.msg_no = ldmsd_msg_no_get();
-	key.conn_id = (uint64_t)(long unsigned)ldms;
+	key.conn_id = ldms_xprt_conn_id(ldms);
 	rcmd->reqc = alloc_req_ctxt(&key, max_msg_sz);
 	if (!rcmd->reqc)
 		goto err1;
@@ -1035,7 +1035,10 @@ int ldmsd_process_config_request(ldmsd_cfg_xprt_t xprt, ldmsd_req_hdr_t request)
 	char *oom_errstr = "ldmsd out of memory";
 
 	key.msg_no = ntohl(request->msg_no);
-	key.conn_id = (uint64_t)(long unsigned)xprt;
+	if (xprt->ldms.ldms)
+		key.conn_id = ldms_xprt_conn_id(xprt->ldms.ldms);
+	else
+		key.conn_id = (uint64_t)xprt;
 
 	if (ntohl(request->marker) != LDMSD_RECORD_MARKER) {
 		char *msg = "Config request is missing record marker";
@@ -1132,7 +1135,10 @@ int ldmsd_process_config_response(ldmsd_cfg_xprt_t xprt, ldmsd_req_hdr_t respons
 	int rc = 0;
 
 	key.msg_no = ntohl(response->msg_no);
-	key.conn_id = (uint64_t)(long unsigned)xprt->ldms.ldms;
+	if (xprt->ldms.ldms)
+		key.conn_id = ldms_xprt_conn_id(xprt->ldms.ldms);
+	else
+		key.conn_id = (uint64_t)xprt;
 
 	if (ntohl(response->marker) != LDMSD_RECORD_MARKER) {
 		ldmsd_log(LDMSD_LERROR,

--- a/ldms/src/ldmsd/ldmsd_stream.c
+++ b/ldms/src/ldmsd/ldmsd_stream.c
@@ -342,7 +342,7 @@ static void event_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
  * \returns 0 on success, or an errno
  */
 #define LDMSD_STREAM_CONNECT_TIMEOUT 5 /* 5 seconds */
-#define LDMSD_STREAM_ACK_TIMEOUT 2 /* 2 seconds */
+#define LDMSD_STREAM_ACK_TIMEOUT 20 /* 20 seconds */
 int ldmsd_stream_publish_file(const char *stream, const char *type,
 			      const char *xprt, const char *host, const char *port,
 			      const char *auth, struct attr_value_list *auth_opt,


### PR DESCRIPTION
A [pointer:msg_no] key was being used to match
requests with responses. However, if an ldms transport
were disconnected, and then reconnected, the pointer
could be reused in a subsequent connection resulting
in matching a response with the wrong request. This
change generates a unique uint64_t identifier
that is used as part of the key instead of a pointer
to the transport instance.