### PR TITLE
Fix papi_sampler/syspapi deadlock on multi-tenant slurm

### DIFF
--- a/ldms/src/sampler/papi/Makefile.am
+++ b/ldms/src/sampler/papi/Makefile.am
@@ -12,7 +12,10 @@ COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
 		$(top_builddir)/lib/src/ovis_json/libovis_json.la \
 		-lm -lpthread
 
+libpapi_hook_la_SOURCES = papi_hook.c papi_hook.h
+pkglib_LTLIBRARIES += libpapi_hook.la
+
 libpapi_sampler_la_SOURCES = papi_sampler.h papi_sampler.c papi_config.c
-libpapi_sampler_la_LIBADD = $(COMMON_LIBADD) $(LTLIBPAPI)
+libpapi_sampler_la_LIBADD = $(COMMON_LIBADD) $(LTLIBPAPI) libpapi_hook.la
 libpapi_sampler_la_CFLAGS = -DSYSCONFDIR='"$(sysconfdir)"'
 pkglib_LTLIBRARIES += libpapi_sampler.la

--- a/ldms/src/sampler/papi/papi_hook.c
+++ b/ldms/src/sampler/papi/papi_hook.c
@@ -1,0 +1,90 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2021 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <pthread.h>
+#include <errno.h>
+
+#include "papi_hook.h"
+
+hook_fn _task_init_hook = NULL;
+hook_fn _task_empty_hook = NULL;
+
+static inline
+int _register_hook(hook_fn *p, hook_fn fn)
+{
+	hook_fn e = NULL;
+	if (__atomic_compare_exchange_n(p, &e, fn, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)) {
+		return 0;
+	}
+	return EEXIST;
+}
+
+static inline
+void _exec_hook(hook_fn *p)
+{
+	if (*p)
+		(*p)();
+}
+
+int register_task_init_hook(hook_fn fn)
+{
+	return _register_hook(&_task_init_hook, fn);
+}
+
+void exec_task_init_hook()
+{
+	_exec_hook(&_task_init_hook);
+}
+
+int register_task_empty_hook(hook_fn fn)
+{
+	return _register_hook(&_task_empty_hook, fn);
+}
+
+void exec_task_empty_hook()
+{
+	_exec_hook(&_task_empty_hook);
+}

--- a/ldms/src/sampler/papi/papi_hook.h
+++ b/ldms/src/sampler/papi/papi_hook.h
@@ -1,0 +1,60 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2021 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __PAPI_HOOK_H
+#define __PAPI_HOOK_H
+
+typedef void (*hook_fn)();
+
+/* task started */
+int register_task_init_hook(hook_fn fn);
+void exec_task_init_hook();
+
+/* no more task running */
+int register_task_empty_hook(hook_fn fn);
+void exec_task_empty_hook();
+
+#endif

--- a/ldms/src/sampler/papi/papi_sampler.c
+++ b/ldms/src/sampler/papi/papi_sampler.c
@@ -61,6 +61,7 @@
 #include "ldmsd_stream.h"
 #include "../sampler_base.h"
 #include "papi_sampler.h"
+#include "papi_hook.h"
 
 static ldmsd_msg_log_f msglog;
 static char *papi_stream_name;
@@ -399,8 +400,7 @@ static int sample(struct ldmsd_sampler *self)
 	}
 	if (rbt_empty(&job_tree)) {
 		/* resume syspapi when no job is running */
-		ldmsd_stream_deliver("syspapi_stream", LDMSD_STREAM_STRING,
-				"resume", 7, NULL);
+		exec_task_empty_hook();
 	}
 	pthread_mutex_unlock(&job_lock);
 	return 0;
@@ -669,8 +669,7 @@ static void handle_task_init(job_data_t job, json_entity_t e)
 	}
 
 	/* pause syspapi */
-	ldmsd_stream_deliver("syspapi_stream", LDMSD_STREAM_STRING,
-			     "pause", 6, NULL);
+	exec_task_init_hook();
 
 	LIST_FOREACH(t, &job->task_list, entry) {
 		rc = PAPI_create_eventset(&t->event_set);

--- a/ldms/src/sampler/syspapi/Makefile.am
+++ b/ldms/src/sampler/syspapi/Makefile.am
@@ -12,6 +12,7 @@ COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
 		$(top_builddir)/lib/src/coll/libcoll.la
 
 libsyspapi_sampler_la_SOURCES = syspapi_sampler.c
-libsyspapi_sampler_la_LIBADD = $(COMMON_LIBADD) $(LTLIBPAPI) $(LTLIBPFM) -lpthread
+libsyspapi_sampler_la_LIBADD = $(COMMON_LIBADD) $(LTLIBPAPI) $(LTLIBPFM) -lpthread \
+			       ../papi/libpapi_hook.la
 libsyspapi_sampler_la_CFLAGS = $(AM_CFLAGS) -DSYSCONFDIR='"$(sysconfdir)"'
 pkglib_LTLIBRARIES += libsyspapi_sampler.la


### PR DESCRIPTION
In the case of multi-tenant slurm, ldmsd may receive multiple job
events concurrently, i.e. `slurm` stream data are being delivered from
multiple threads. papi_sampler uses `ldmsd_stream_deliver()` to
notify syspapi about the task init event to pause syspapi, or
no-more-task event to resume syspapi, and resulted in the following
deadlock (found by `papi_store_test` over singularity in `ldms-test`
repository):

```
thr0:                                 thr1:
ldmsd_stream_deliver("slurm")         ldmsd_stream_deliver("slurm")
  __find_stream()                       __find_stream()
    take s_tree_lock                      wait s_tree_lock
    take s->s_lock                        .
    release s_tree_lock                   .
  cb()                                    take s_tree_lock
    ldmsd_stream_deliver("syspapi")       wait s->s_lock
      __find_stream()
        wait s_tree_lock
```

This patch avoid recursive calls of `ldmsd_stream_deliver()` (even
though on different streams) to avoid the deadlock shown above.
`papi_hook` library is introduced to be used only by syspapi and
papi_sampler to register/execute the job init hook and no-job hook.

This patch has been tested with all test cases in `ldms-test`
repository (with singularity).