### PR TITLE
Add an attribute to stream publish requests to not receiving the ack

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -5933,7 +5933,13 @@ static int stream_publish_handler(ldmsd_req_ctxt_t reqc)
 	}
 
 	reqc->errcode = 0;
-	ldmsd_send_req_response(reqc, "ACK");
+	/*
+	 * If a LDMSD_ATTR_TYPE attribute exists, the publisher does not want
+	 * an acknowledge response.
+	 */
+	attr = ldmsd_req_attr_get_by_id(reqc->req_buf, LDMSD_ATTR_TYPE);
+	if (!attr)
+		ldmsd_send_req_response(reqc, "ACK");
 
 	if (!ldmsd_stream_subscriber_count(stream_name))
 		/* There are no subscribers, ignore the data */
@@ -5982,7 +5988,18 @@ static int stream_republish_cb(ldmsd_stream_client_t c, void *ctxt,
 	const char *stream = ldmsd_stream_client_name(c);
 	ldmsd_req_cmd_t rcmd = ldmsd_req_cmd_new(ldms, LDMSD_STREAM_PUBLISH_REQ,
 						 NULL, __on_republish_resp, NULL);
+	if (!rcmd) {
+		ldmsd_log(LDMSD_LCRITICAL, "ldmsd is out of memory\n");
+		return ENOMEM;
+	}
 	rc = ldmsd_req_cmd_attr_append_str(rcmd, LDMSD_ATTR_NAME, stream);
+	if (rc)
+		goto out;
+	/*
+	 * Add an LDMSD_ATTR_TYPE attribute to let the peer know
+	 * that we don't want an acknowledge response.
+	 */
+	rc = ldmsd_req_cmd_attr_append_str(rcmd, LDMSD_ATTR_TYPE, "");
 	if (rc)
 		goto out;
 	if (stream_type == LDMSD_STREAM_JSON)
@@ -5992,8 +6009,7 @@ static int stream_republish_cb(ldmsd_stream_client_t c, void *ctxt,
 		goto out;
 	rc = ldmsd_req_cmd_attr_term(rcmd);
  out:
-	if (rc)
-		ldmsd_req_cmd_free(rcmd);
+	ldmsd_req_cmd_free(rcmd);
 	return rc;
 }
 


### PR DESCRIPTION
Stream publishers could add an optional LDMSD_ATTR_TYPE attribute
to tell LDMSD's stream_publish_handler not to send an acknowledgement
back.

The stream republish path uses the attribute so that it would free the
command request right after it sends the request. This is to reduce the
memory footprint in the stream republish/forward path.