### PR TITLE
Fix a key collision problem between sent requests and received requests

### DIFF
--- a/ldms/src/ldmsd/ldmsd_failover.c
+++ b/ldms/src/ldmsd/ldmsd_failover.c
@@ -343,7 +343,7 @@ struct ldmsd_sec_ctxt __get_sec_ctxt(struct ldmsd_req_ctxt *req)
 {
 	struct ldmsd_sec_ctxt sctxt;
 	if (req) {
-		ldms_xprt_cred_get(req->xprt->xprt, NULL, &sctxt.crd);
+		ldms_xprt_cred_get(req->xprt->ldms.ldms, NULL, &sctxt.crd);
 	} else {
 		ldmsd_sec_ctxt_get(&sctxt);
 	}

--- a/ldms/src/ldmsd/ldmsd_request.h
+++ b/ldms/src/ldmsd/ldmsd_request.h
@@ -248,6 +248,7 @@ typedef struct ldmsd_req_hdr_s {
  * +---------------------------------------------------------+
  */
 typedef struct req_ctxt_key {
+	uint8_t flags;
 	uint32_t msg_no;
 	uint64_t conn_id;
 } *msg_key_t;
@@ -259,23 +260,20 @@ typedef struct ldmsd_cfg_ldms_s {
 	ldms_t ldms;
 } *ldmsd_cfg_ldms_t;
 
-typedef struct ldmsd_cfg_sock_s {
-	int fd;
-	struct sockaddr_storage ss;
-} *ldmsd_cfg_sock_t;
-
 typedef struct ldmsd_cfg_file_s {
-	uint32_t next_msg_no;
+	uint64_t cfgfile_id;
 } *ldmsd_cfg_file_t;
 
 struct ldmsd_cfg_xprt_s;
 typedef int (*ldmsd_msg_send_fn_t)(void *xprt, char *data, size_t data_len);
 typedef void (*ldmsd_cfg_cleanup_fn_t)(struct ldmsd_cfg_xprt_s *xprt);
 typedef struct ldmsd_cfg_xprt_s {
+	enum {
+		LDMSD_CFG_TYPE_FILE,
+		LDMSD_CFG_TYPE_LDMS,
+	} type;
 	union {
-		void *xprt;
 		struct ldmsd_cfg_file_s file;
-		struct ldmsd_cfg_sock_s sock;
 		struct ldmsd_cfg_ldms_s ldms;
 	};
 	size_t max_msg;


### PR DESCRIPTION
Without the patch, an LDMSD’s request context key consists of a message
number and a connection ID. The host generates the message number of
to-be-sent requests. In contrast, the peer generates the message number
of received requests. LDMSD has a single tree that contains the contexts
of both sent requests and received requests. The connection IDs in the
request sent to a peer and in the request received from the same peer
will be the same.
Moreover, the message numbers of the two requests could be the same
because the host and the peer generate them. When this happens, we would
see error messages “Duplicate message number …” or “Cannot find the
original request …”.

The patch adds a flag in request context keys to differentiate between
to-be-sent requests and received requests. It prevents the key collision
problem above.