### PR TITLE
Fix wrong config transport type

### DIFF
--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -948,6 +948,7 @@ void ldmsd_recv_msg(ldms_t x, char *data, size_t data_len)
 	xprt.send_fn = send_ldms_fn;
 	xprt.max_msg = ldms_xprt_msg_max(x);
 	xprt.trust = 0; /* don't trust any network for CMD expansion */
+	xprt.type = LDMSD_CFG_TYPE_LDMS;
 
 	if (ntohl(request->rec_len) > xprt.max_msg) {
 		/* Send the record length advice */


### PR DESCRIPTION
LDMSD does not set the type of LDMS-endpoint configuration transports,
so the type is the configuration file. As a result, the connection ID is
the configuration transport memory address instead of the LDMS transport
ID.