### PR TITLE
Change calloc to malloc in LDMSD request logic

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request_util.c
+++ b/ldms/src/ldmsd/ldmsd_request_util.c
@@ -1008,7 +1008,7 @@ struct ldmsd_msg_buf *ldmsd_msg_buf_new(size_t len)
 	buf = malloc(sizeof(*buf));
 	if (!buf)
 		return NULL;
-	buf->buf = calloc(1, len);
+	buf->buf = malloc(len);
 	if (!buf->buf) {
 		free(buf);
 		return NULL;


### PR DESCRIPTION
Using calloc results in bzero'ing max_msg_size
which is 1M of memory on socket transports.