### PR TITLE
Cleanup up contexts in msg_tree on disconnect

### DIFF
--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -1232,4 +1232,6 @@ ldmsd_auth_t ldmsd_auth_find(const char *name)
 {
 	return (ldmsd_auth_t)ldmsd_cfgobj_find(name, LDMSD_CFGOBJ_AUTH);
 }
+void ldmsd_xprt_term(ldms_t x);
+
 #endif

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -968,16 +968,13 @@ void ldmsd_recv_msg(ldms_t x, char *data, size_t data_len)
 	}
 }
 
-/* implemented in ldmsd_request.c */
-void stream_xprt_term(ldms_t x);
-
 static void __listen_connect_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 {
 	switch (e->type) {
 	case LDMS_XPRT_EVENT_CONNECTED:
 		break;
 	case LDMS_XPRT_EVENT_DISCONNECTED:
-		stream_xprt_term(x);
+		ldmsd_xprt_term(x);
 	case LDMS_XPRT_EVENT_REJECTED:
 	case LDMS_XPRT_EVENT_ERROR:
 		ldms_xprt_put(x);

--- a/ldms/src/ldmsd/ldmsd_prdcr.c
+++ b/ldms/src/ldmsd/ldmsd_prdcr.c
@@ -621,9 +621,11 @@ reset_prdcr:
 		assert(0 == "STOPPED shouldn't have xprt event");
 		break;
 	}
-	if (prdcr->xprt)
+	if (prdcr->xprt) {
+		ldmsd_xprt_term(prdcr->xprt);
 		ldms_xprt_put(prdcr->xprt);
-	prdcr->xprt = NULL;
+		prdcr->xprt = NULL;
+	}
 	ldmsd_prdcr_unlock(prdcr);
 }
 

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -6304,7 +6304,7 @@ static int stream_client_dump_handler(ldmsd_req_ctxt_t reqc)
 	return rc;
 }
 
-void stream_xprt_term(ldms_t x)
+void ldmsd_xprt_term(ldms_t x)
 {
 	__RSE_t ent;
 	struct rbn *rbn;
@@ -6326,6 +6326,19 @@ void stream_xprt_term(ldms_t x)
 		__RSE_free(ent);
 	}
 	__RSE_rbt_unlock();
+
+	/* Free outstanding configuration requests */
+	req_ctxt_tree_lock();
+	ldmsd_req_ctxt_t reqc;
+	rbn = rbt_min(&msg_tree);
+	while (rbn) {
+		struct rbn *next_rbn = rbn_succ(rbn);
+		reqc = container_of(rbn, struct ldmsd_req_ctxt, rbn);
+		if (reqc->xprt->ldms.ldms == x)
+			__free_req_ctxt(reqc);
+		rbn = next_rbn;
+	}
+	req_ctxt_tree_unlock();
 }
 
 int ldmsd_auth_opt_add(struct attr_value_list *auth_attrs, char *name, char *val)


### PR DESCRIPTION
The message tree maintains configuration requests and replies. If a connection were to reset while there were outstanding configuration requests, these context would remain in the tree forever.

I have added the changes recommended by Nichamon. I have tested this at 3 levels of aggregation, but would appreciate any testing that you have.
