### PR TITLE
Fix ldmsd_stream_publish_file (message length violation)

### DIFF
--- a/ldms/src/ldmsd/ldmsd_stream.c
+++ b/ldms/src/ldmsd/ldmsd_stream.c
@@ -389,7 +389,7 @@ int ldmsd_stream_publish_file(const char *stream, const char *type,
 	}
 	max_msg_len = ldms_xprt_msg_max(x);
 
-	buf = ldmsd_msg_buf_new(max_msg_len+1);
+	buf = ldmsd_msg_buf_new(max_msg_len);
 	if (!buf) {
 		msglog("Out of memory\n");
 		ldms_xprt_put(x);
@@ -437,8 +437,8 @@ int ldmsd_stream_publish_file(const char *stream, const char *type,
 	if (rc)
 		goto close_xprt;
 
-	while ((cnt = fread(buffer, 1, max_msg_len, file)) > 0) {
-		if (cnt < max_msg_len) {
+	while ((cnt = fread(buffer, 1, max_msg_len-1, file)) > 0) {
+		if (cnt < max_msg_len-1) {
 			/* Ensure last buffer is '\0' terminated */
 			buffer[cnt] = '\0';
 			cnt += 1;


### PR DESCRIPTION
ldmsd_stream_publish_file set the message buffer length greater than the
maximum transport message length, which resulted in zap send error when
publish large enough file. This bug failed `ldmsd_stream_test` in
`ldms-test` repository.

`ldmsd_stream_test` requires this patch to succeed.