### PR TITLE
Remove deprecated rec_len check in ldmsd_stream_subscribe

### DIFF
--- a/ldms/src/ldmsd/test/ldmsd_stream_subscribe.c
+++ b/ldms/src/ldmsd/test/ldmsd_stream_subscribe.c
@@ -296,11 +296,6 @@ static void recv_msg(ldms_t x, char *data, size_t data_len)
 {
 	ldmsd_req_hdr_t request = (ldmsd_req_hdr_t)data;
 
-	if (ntohl(request->rec_len) > ldms_xprt_msg_max(x)) {
-		msglog("Test command does not support multi-record stream data");
-		exit(1);
-	}
-
 	switch (ntohl(request->type)) {
 	case LDMSD_REQ_TYPE_CONFIG_CMD:
 		(void)process_request(x, request);


### PR DESCRIPTION
ldmsd_stream_subscribe checked the record length. If the record length
was greater than the transport maximum message length, the record needed
data aggregation from multiple messages. The logic to aggregate data was
there, i.e. the program did support record aggregation, and the record
length check logic was deprecated and must be removed to support big
stream.

This patch is required for `ldmsd_stream_test` to succeed.