### PR TITLE
Fix slurm_notifier stream publish

### DIFF
--- a/ldms/src/sampler/spank/slurm_notifier.c
+++ b/ldms/src/sampler/spank/slurm_notifier.c
@@ -535,7 +535,7 @@ static int send_event(int argc, char *argv[], jbuf_t jb)
 		DEBUG2("publishing to %s:%s\n", client->host, client->port);
 		DEBUG2("slurm %s:%d %s", __func__, __LINE__, jb->buf);
 		rc = ldmsd_stream_publish(client->ldms, stream,
-					  LDMSD_STREAM_JSON, jb->buf, jb->cursor);
+					  LDMSD_STREAM_JSON, jb->buf, jb->cursor+1);
 		if (rc) {
 			DEBUG2("ERROR %d publishing to %s:%s\n",
 				rc, client->host, client->port);

--- a/lib/src/ovis_json/ovis_json.c
+++ b/lib/src/ovis_json/ovis_json.c
@@ -55,7 +55,7 @@ jbuf_t jbuf_append_va(jbuf_t jb, const char *fmt, va_list _ap)
 	space = jb->buf_len - jb->cursor;
 	cnt = vsnprintf(&jb->buf[jb->cursor], space, fmt, ap);
 	va_end(ap);
-	if (cnt > space) {
+	if (cnt >= space) {
 		space = jb->buf_len + cnt + JSON_BUF_START_LEN;
 		jb = realloc(jb, space);
 		if (jb) {


### PR DESCRIPTION
This patch addressed two things that contributed to the issue of missing
'\0' in stream pulish data sent by slurm_notifier.
  1) From vsnprintf(3) "... a return value of size or more means that
     the output was truncated." Hence, the buffer must be expanded when
     `cnt >= space` (not `cnt > space`).
  2) JSON buffer `jb->cursor` is the current lenght of the output
     string. Since `vsnprintf()` put '\0' when the output is not
     truncated, `jb->jbuf[jb->cursor]` is always '\0', and
     `jb->cursor+1` is a valid data length that will include '\0' in the
     stream data.

This patch is required for slurm-related tests in `ldms-test` (e.g.
`agg_slurm_test`, and `mt-slurm-test`) to succeed.