### PR TITLE
Make reqc->xprt point to memory on the heap instead of the stack

### DIFF
--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -555,7 +555,7 @@ int __process_config_file(const char *path, int *lno, int trust,
 	ssize_t off = 0;
 	ssize_t cnt;
 	size_t buf_len = 0;
-	struct ldmsd_cfg_xprt_s xprt;
+	struct ldmsd_cfg_xprt_s xprt = {0};
 	ldmsd_req_hdr_t request = NULL;
 	struct ldmsd_req_array *req_array = NULL;
 	if (!path)
@@ -1034,6 +1034,7 @@ void ldmsd_cfg_ldms_init(ldmsd_cfg_xprt_t xprt, ldms_t ldms)
 	xprt->max_msg = ldms_xprt_msg_max(ldms);
 	xprt->cleanup_fn = ldmsd_cfg_ldms_xprt_cleanup;
 	xprt->trust = 0;
+	xprt->type = LDMSD_CFG_TYPE_LDMS;
 }
 
 void ldmsd_mm_status(enum ldmsd_loglevel level, const char *prefix)


### PR DESCRIPTION
The LDMSD config transport’s memory addresses passed by ldmsd_process_msg_request()’s callers are on the stack. This is not an issue if the requests come from configuration files. In contrast, the memory address of an LDMS config transport could be invalid while the request context is in the message tree because ldmsd_recv_msg() had been returned already. Moreover, LDMSD could access the invalid address in the disconnected path when ldmsd_xprt_term() iterates through the message tree.