### PR TITLE
Don't take LDMS transport's reference in stream_republish_cb()

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -6039,7 +6039,7 @@ static int stream_republish_cb(ldmsd_stream_client_t c, void *ctxt,
 			       const char *data, size_t data_len,
 			       json_entity_t entity)
 {
-	ldms_t ldms = ldms_xprt_get(ctxt);
+	ldms_t ldms = (ldms_t)ctxt;
 	int rc, attr_id = LDMSD_ATTR_STRING;
 	const char *stream = ldmsd_stream_client_name(c);
 	ldmsd_req_cmd_t rcmd = ldmsd_req_cmd_new(ldms, LDMSD_STREAM_PUBLISH_REQ,


### PR DESCRIPTION
stream_republish_cb() takes an LDMS transport's reference but does not
put back. Sampler daemons would leak LDMS transports when it republishes
stream to the aggregator. ldmsd_req_cmd_new() already takes a reference
when it initializes the configuration transport.