### PR TITLE
Add a stream blob writing plugin.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -288,6 +288,7 @@ OPTION_DEFAULT_DISABLE([filesingle], [ENABLE_FILESINGLE])
 OPTION_DEFAULT_DISABLE([msr_interlagos], [ENABLE_MSR_INTERLAGOS])
 OPTION_DEFAULT_ENABLE([array_example], [ENABLE_ARRAY_EXAMPLE])
 OPTION_DEFAULT_ENABLE([hello_stream], [ENABLE_HELLO_STREAM])
+OPTION_DEFAULT_ENABLE([blob_stream], [ENABLE_BLOB_STREAM])
 OPTION_DEFAULT_DISABLE([perfevent], [ENABLE_PERFEVENT])
 OPTION_DEFAULT_DISABLE([mpi_sampler], [ENABLE_MPI_SAMPLER])
 OPTION_DEFAULT_DISABLE([mpi_noprofile], [ENABLE_MPI_NOPROFILE])
@@ -816,6 +817,7 @@ ldms/src/auth/Makefile
 ldms/src/store/Makefile
 ldms/src/sampler/Makefile
 ldms/src/contrib/Makefile
+ldms/src/sampler/blob_stream/Makefile
 ldms/src/store/hello_stream/Makefile
 ldms/src/store/kokkos/Makefile
 ldms/src/store/papi/Makefile

--- a/ldms/scripts/examples/.canned
+++ b/ldms/scripts/examples/.canned
@@ -5,6 +5,7 @@ aggl2simple
 all_example
 all_example.sos
 array_example
+blob_writer
 clock
 lnet_stats
 meminfo

--- a/ldms/scripts/examples/blob_writer
+++ b/ldms/scripts/examples/blob_writer
@@ -1,0 +1,13 @@
+export plugname=dstat
+export dsname=$(ldms_dstat_schema_name mmalloc=1 io=1 fd=1 auto-schema=1)
+export dstat_schema=$dsname
+portbase=61060
+LDMSD 1 2
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1 -l
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2 -l
+SLEEP 10
+KILL_LDMSD 1 2
+file_created $STOREDIR/blobs/slurm.DAT.1*
+file_created $STOREDIR/blobs/slurm.OFFSET.1*

--- a/ldms/scripts/examples/blob_writer
+++ b/ldms/scripts/examples/blob_writer
@@ -2,12 +2,28 @@ export plugname=dstat
 export dsname=$(ldms_dstat_schema_name mmalloc=1 io=1 fd=1 auto-schema=1)
 export dstat_schema=$dsname
 portbase=61060
+VGARGS="--trace-children=yes --track-origins=yes --leak-check=full --show-leak-kinds=all"
+# track everything notifier config:
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --retry=1 -D 10 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+#vgon
 LDMSD 1 2
+#vgoff
 MESSAGE ldms_ls on host 1:
 LDMS_LS 1 -l
 MESSAGE ldms_ls on host 2:
 LDMS_LS 2 -l
-SLEEP 10
+SLEEP 1
+SLEEP 1
+SLEEP 1
+SLEEP 1
+SLEEP 1
+SLEEP 1
+SLEEP 1
+SLEEP 1
+SLEEP 1
+SLEEP 1
+SLEEP 1
 KILL_LDMSD 1 2
+file_created $STOREDIR/blobs/slurm.TIMING.1*
 file_created $STOREDIR/blobs/slurm.DAT.1*
 file_created $STOREDIR/blobs/slurm.OFFSET.1*

--- a/ldms/scripts/examples/blob_writer.1
+++ b/ldms/scripts/examples/blob_writer.1
@@ -1,0 +1,3 @@
+#load name=dstat
+#config name=dstat producer=localhost${i} instance=localhost${i}/${dstat_schema} component_id=${i} mmalloc=1 io=1 fd=1 auto-schema=1)
+#start name=dstat interval=1000000 offset=0

--- a/ldms/scripts/examples/blob_writer.2
+++ b/ldms/scripts/examples/blob_writer.2
@@ -1,0 +1,18 @@
+load name=blob_stream_writer plugin=blob_stream_writer
+config name=blob_stream_writer path=${STOREDIR} container=blobs stream=slurm
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_subscribe regex=.* stream=slurm
+prdcr_start name=localhost1
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+# load name=store_csv
+# config name=store_csv path=${STOREDIR} altheader=0
+
+# strgp_add name=store_${testname} plugin=store_csv schema=${dstat_schema} container=node
+# strgp_prdcr_add name=store_${testname} regex=.*
+# strgp_start name=store_${testname}
+

--- a/ldms/scripts/examples/blob_writer.2
+++ b/ldms/scripts/examples/blob_writer.2
@@ -1,5 +1,5 @@
 load name=blob_stream_writer plugin=blob_stream_writer
-config name=blob_stream_writer path=${STOREDIR} container=blobs stream=slurm
+config name=blob_stream_writer path=${STOREDIR} container=blobs stream=slurm timing=1 types=1
 
 prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
 prdcr_subscribe regex=.* stream=slurm

--- a/ldms/src/sampler/Makefile.am
+++ b/ldms/src/sampler/Makefile.am
@@ -301,3 +301,7 @@ endif
 if ENABLE_HELLO_STREAM
 SUBDIRS += hello_stream
 endif
+
+if ENABLE_BLOB_STREAM
+SUBDIRS += blob_stream
+endif

--- a/ldms/src/sampler/blob_stream/Makefile.am
+++ b/ldms/src/sampler/blob_stream/Makefile.am
@@ -1,0 +1,24 @@
+SUBDIRS =
+lib_LTLIBRARIES =
+pkglib_LTLIBRARIES =
+dist_man7_MANS=
+
+
+AM_LDFLAGS = @OVIS_LIB_ABS@
+AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
+STORE_LIBADD = $(top_builddir)/ldms/src/core/libldms.la \
+	       $(top_builddir)/lib/src/coll/libcoll.la \
+	       $(top_builddir)/lib/src/ovis_util/libovis_util.la
+
+
+
+if ENABLE_BLOB_STREAM
+libblob_stream_writer_la_SOURCES = blob_stream_writer.c
+libblob_stream_writer_la_LIBADD = $(STORE_LIBADD) -lovis_json
+pkglib_LTLIBRARIES += libblob_stream_writer.la
+dist_man7_MANS += Plugin_blob_stream_writer.man
+
+endif
+
+EXTRA_DIST = \
+	Plugin_blob_stream_writer.man

--- a/ldms/src/sampler/blob_stream/Plugin_blob_stream_writer.man
+++ b/ldms/src/sampler/blob_stream/Plugin_blob_stream_writer.man
@@ -1,0 +1,94 @@
+.\" Manpage for Plugin_blob_stream_writer
+.\" Contact ovis-help@ca.sandia.gov to correct errors or typos.
+.TH man 7 "15 Jun 2021" "v4" "LDMS Plugin blob_stream_writer man page"
+
+.SH NAME
+Plugin_blob_stream_writer - man page for the LDMS blob_stream_writer plugin
+
+.SH SYNOPSIS
+Within ldmsd_controller or a configuration file:
+.br
+config name=blob_stream_writer [ <attr>=<value> ]
+
+.SH DESCRIPTION
+With LDMS (Lightweight Distributed Metric Service), plugins for the ldmsd (ldms daemon) are configured via ldmsd_controller or a configuration file. The blob_stream_writer plugin writes out raw stream messages
+and offsets of the messages in separate files. Messages are not appended with '\n' or '\0'.
+Multiple streams may be specified.
+
+
+.SH CONFIGURATION ATTRIBUTE SYNTAX
+.TP
+.BR config
+name=blob_stream_writer path=<path> container=<container> stream=<stream> debug=1
+.br
+configuration line
+.RS
+.TP
+name=<plugin_name>
+.br
+This MUST be blob_stream_writer.
+.TP
+path=<path>
+.br
+path to the directory of the output files
+.TP
+container=<container>
+.br
+directory of the output file
+.TP
+stream=<stream>
+.br
+stream to which to subscribe. This argument may be repeated. Each stream will be written in a separate file pair.
+.TP
+debug=1
+.br
+Enable logging of messages stored to the log file.
+.RE
+
+.SH OUTPUT FORMAT
+.PP
+There is no requirement that any message must the same format as any other.
+
+The writer writes all messages received to a file pair:
+$path/$container/$stream.OFFSET.$create_time
+$path/$container/$stream.DAT.$create_time
+where OFFSET is the byte offsets into the corresponding .DAT
+of the messages seen on the stream.
+
+Each byte offset is written as a little-endian 64 bit number.
+Data read from .OFFSET should be converted to host order
+with le64toh.
+
+Both DAT and OFFSET files begin with an 8 byte magic number: blobdat\\0 and bloboff\\0, respectively.
+
+
+.SH NOTES
+.PP
+This writer is in development and may be changed at any time.
+.PP
+Cannot support stream=.* as there is no corresponding regex subscription policy
+currently available in the C stream API.
+.PP
+The config operation may called at any time or repeated.
+The start and stop operations will start and stop storage of all streams.
+.PP
+The plugin appears in C code as a sampler plugin, since the storage policy and store
+plugin interfaces are set-oriented and no sets are involved here.
+
+.SH EXAMPLES
+.PP
+Within ldmsd_controller or a configuration file:
+.nf
+load name=blob_stream_writer
+config name=blob_stream_writer path=/writer/streams container=${CLUSTER} stream=foo stream=slurm stream=kokkos
+start name=name=blob_stream_writer
+.fi
+.PP
+Examining offsets in a shell:
+.nf
+od -t u8 -w4 slurm.OFFSET.1624033344 |sed -e 's/[0-9,A-F,a-f]* *//'
+.fi
+
+
+.SH SEE ALSO
+ldmsd(8), ldms_quickstart(7), ldmsd_controller(8), le64toh(3), fseek(3), od(1)

--- a/ldms/src/sampler/blob_stream/Plugin_blob_stream_writer.man
+++ b/ldms/src/sampler/blob_stream/Plugin_blob_stream_writer.man
@@ -43,6 +43,10 @@ stream to which to subscribe. This argument may be repeated. Each stream will be
 debug=1
 .br
 Enable logging of messages stored to the log file.
+.TP
+timing=1
+.br
+Enable writing timestamps to a separate file.
 .RE
 
 .SH OUTPUT FORMAT
@@ -61,6 +65,14 @@ with le64toh.
 
 Both DAT and OFFSET files begin with an 8 byte magic number: blobdat\\0 and bloboff\\0, respectively.
 
+Optionally (if timing=1 given) the additional file
+$path/$container/$stream.TIMING.$create_time
+is created containing binary timestamps corresponding to the messages.
+The TIMING file begins with an 8 byte magic number: blobtim\\0.
+Each time is the delivery time to the plugin performing the blob storage.
+Each timestamp is written to the .TIMING file as a binary pair (tv_sec, tv_usec)
+with each value stored as a little-endian 64 bit value which should be
+read and then converted with le64toh.
 
 .SH NOTES
 .PP
@@ -86,7 +98,11 @@ start name=name=blob_stream_writer
 .PP
 Examining offsets in a shell:
 .nf
-od -t u8 -w4 slurm.OFFSET.1624033344 |sed -e 's/[0-9,A-F,a-f]* *//'
+od od -A d -t u8 -j 8 -w8 slurm.OFFSET.1624033344 |sed -e 's/[0-9,A-F,a-f]* *//'
+.fi
+Examining timestamps in a shell:
+.nf
+od -A d -j 8 -t u8
 .fi
 
 

--- a/ldms/src/sampler/blob_stream/blob_stream_writer.c
+++ b/ldms/src/sampler/blob_stream/blob_stream_writer.c
@@ -201,7 +201,7 @@ static int stream_cb(ldmsd_stream_client_t c, void *ctxt,
 	}
 	rc = fwrite(msg, 1, msg_len, sd->streamfile);
 	sd->offset += rc;
-	if (rc != 1) {
+	if (rc != msg_len) {
 		int ferr = ferror(sd->streamfile);
 		msglog(LDMSD_LERROR, PNAME ": short write starting at %s:%ld: %s\n",
 			sd->streamfile_name, sd->offset, STRERROR(ferr));

--- a/ldms/src/sampler/blob_stream/blob_stream_writer.c
+++ b/ldms/src/sampler/blob_stream/blob_stream_writer.c
@@ -1,0 +1,482 @@
+/**
+ * Copyright (c) 2021 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ * Copyright (c) 2021 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ctype.h>
+#include <sys/queue.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <linux/limits.h>
+#include <pthread.h>
+#include <errno.h>
+#include <unistd.h>
+#include <ovis_json/ovis_json.h>
+#include "ldms.h"
+#include "ldmsd.h"
+#include "ldmsd_stream.h"
+
+#define PNAME "blob_stream_writer"
+
+static ldmsd_msg_log_f msglog;
+static pthread_mutex_t cfg_lock;
+static int closing;
+static char* root_path;
+static char* container;
+enum writer_state {
+	WS_NEW,
+	WS_OPEN,
+	WS_REOPEN,
+	WS_CLOSED,
+	WS_ERR
+};
+
+typedef struct stream_data {
+	/* set at create */
+	pthread_mutex_t write_lock;
+	enum writer_state ws;
+	char* stream_name;
+	char* streamfile_name;
+	char* offsetfile_name;
+	ldmsd_stream_client_t subscription;
+	/* set at first write */
+	FILE* offsetfile;
+	FILE* streamfile;
+	long offset;
+	LIST_ENTRY(stream_data) entry;
+} *stream_data_t;
+
+LIST_HEAD(stream_data_list, stream_data);
+static struct stream_data_list data_list;
+
+static void stream_data_open(stream_data_t sd);
+
+static int debug;
+
+/* open, if not open or already closed, and write to stream files. */
+static int stream_cb(ldmsd_stream_client_t c, void *ctxt,
+		     ldmsd_stream_type_t stream_type,
+		     const char *msg, size_t msg_len,
+		     json_entity_t e)
+{
+	int rc = 0;
+	stream_data_t sd = ctxt;
+	if (!sd) {
+		msglog(LDMSD_LERROR, PNAME ": stream_cb ctxt is NULL\n");
+		return EINVAL;
+	}
+
+	pthread_mutex_lock(&sd->write_lock);
+	if (sd->ws == WS_NEW) {
+		stream_data_open(sd);
+	}
+	if (sd->ws != WS_OPEN) {
+		goto out;
+	}
+	assert(sd->streamfile != NULL);
+
+	uint64_t le = htole64(sd->offset);
+	rc = fwrite(&le, sizeof(uint64_t), 1, sd->offsetfile);
+	if ( rc != 1) {
+		msglog(LDMSD_LERROR, PNAME ": error writing offset to %s\n",
+			sd->offsetfile_name);
+	}
+	if (debug)
+		msglog(LDMSD_LDEBUG, PNAME ": offset=%ld ...\n", sd->offset);
+
+	rc = fwrite(msg, 1, msg_len, sd->streamfile);
+	sd->offset += rc;
+	if (rc != msg_len) {
+		int ferr = ferror(sd->streamfile);
+		msglog(LDMSD_LERROR, PNAME ": short write of starting at %s:%ld: %s\n",
+			sd->streamfile_name, sd->offset, STRERROR(ferr));
+	}
+	if (debug)
+		msglog(LDMSD_LDEBUG, PNAME ": msg=%.50s ...\n", msg);
+
+out:
+	pthread_mutex_unlock(&sd->write_lock);
+	return rc;
+}
+
+
+static stream_data_t stream_data_create(const char *stream)
+{
+	stream_data_t sd;
+	sd = calloc(1, sizeof(*sd));
+	if (!sd)
+		return NULL;
+	sd->stream_name = strdup(stream);
+	if (!sd->stream_name) {
+		free(sd);
+		return NULL;
+	}
+	pthread_mutex_init(&sd->write_lock, NULL);
+	return sd;
+}
+
+static void stream_data_open(stream_data_t sd)
+{
+	if (!sd->streamfile_name || !sd->offsetfile_name) {
+		sd->ws = WS_ERR;
+		return;
+	}
+	time_t t = time(NULL);
+	size_t end = strlen(sd->offsetfile_name);
+	sprintf(sd->offsetfile_name + end, "%ld", (long)t);
+	end = strlen(sd->streamfile_name);
+	sprintf(sd->streamfile_name + end, "%ld", (long)t);
+
+	sd->offsetfile = fopen_perm(sd->offsetfile_name, "w", 0640);
+	sd->streamfile = fopen_perm(sd->streamfile_name, "w", 0640);
+	if (!sd->offsetfile || !sd->streamfile) {
+		msglog(LDMSD_LERROR, PNAME ": Error '%s' opening the files %s, %s.\n",
+		       STRERROR(errno), sd->offsetfile_name, sd->streamfile_name);
+		sd->ws = WS_ERR;
+		return;
+	}
+	sd->ws = WS_OPEN;
+	char magic[] = "bloboff";
+	int rc = fwrite(magic, strlen(magic)+1, 1, sd->offsetfile);
+	sd->offset += 8;
+	if (rc != 1) {
+		msglog(LDMSD_LERROR, PNAME ": Error '%s' writing to file %s.\n",
+		       STRERROR(errno), sd->offsetfile_name);
+		sd->ws = WS_ERR;
+		return;
+	}
+	char magic2[] = "blobdat";
+	rc = fwrite(magic2, strlen(magic2)+1, 1, sd->streamfile);
+	if (rc != 1) {
+		msglog(LDMSD_LERROR, PNAME ": Error '%s' writing to file %s.\n",
+		       STRERROR(errno), sd->streamfile_name);
+		sd->ws = WS_ERR;
+		return;
+	}
+}
+
+static void reset_paths(stream_data_t sd)
+{
+	if (!sd)
+		return;
+	free(sd->offsetfile_name);
+	sd->offsetfile_name = NULL;
+	free(sd->streamfile_name);
+	sd->streamfile_name = NULL;
+	if (sd->streamfile) {
+		fclose(sd->streamfile);
+		sd->streamfile = NULL;
+	}
+	if (sd->offsetfile) {
+		fclose(sd->offsetfile);
+		sd->offsetfile = NULL;
+	}
+	sd->ws = WS_NEW;
+}
+
+/* base directory path name space for:
+ * path/container/stream.OFFSET.time()_at_open
+ * time substring must be reset at open.
+ * write_lock must be held when this is called.
+ */
+static int set_paths(stream_data_t sd)
+{
+	if (!sd)
+		return EINVAL;
+	size_t pathlen = strlen(root_path) + strlen(sd->stream_name)
+		+ strlen(container) + 32;
+	char dpath[pathlen];
+	sprintf(dpath, "%s/%s", root_path, container);
+	int rc = f_mkdir_p(dpath, 0750);
+	if ((rc != 0) && (errno != EEXIST)) {
+		msglog(LDMSD_LERROR, PNAME ": Failure %d creating directory '%s'\n",
+			 errno, dpath);
+		rc = ENOENT;
+		sd->ws = WS_ERR;
+		return rc;
+	}
+
+	sd->streamfile_name = malloc(pathlen);
+	if (!sd->streamfile_name) {
+		sd->ws = WS_ERR;
+		return ENOMEM;
+	}
+	snprintf(sd->streamfile_name, pathlen, "%s/%s/%s.DAT.", root_path,
+		container, sd->stream_name);
+	sd->offsetfile_name = malloc(pathlen);
+	if (!sd->offsetfile_name) {
+		sd->ws = WS_ERR;
+		return ENOMEM;
+	}
+	snprintf(sd->offsetfile_name, pathlen, "%s/%s/%s.OFFSET.", root_path,
+		container, sd->stream_name);
+	if (!sd->subscription) {
+		msglog(LDMSD_LDEBUG, PNAME ": subscribing to stream '%s'\n",
+			sd->stream_name);
+		sd->subscription = ldmsd_stream_subscribe(sd->stream_name,
+			stream_cb, sd);
+		/* stream dispatch to stream_cb now holds a reference to sd. */
+	}
+	return 0;
+}
+
+static int add_stream(const char *stream)
+{
+	if (!stream)
+		return EINVAL;
+	stream_data_t old = NULL;
+	stream_data_t sd = NULL;
+	LIST_FOREACH(sd, &data_list, entry) {
+		pthread_mutex_lock(&sd->write_lock);
+		if ( 0 == strcmp(stream, sd->stream_name)) {
+			sd->ws = WS_REOPEN;
+			old = sd;
+			pthread_mutex_unlock(&sd->write_lock);
+			break;
+		}
+		pthread_mutex_unlock(&sd->write_lock);
+	}
+	if (!old) {
+		sd = stream_data_create(stream);
+		if (!sd)
+			return ENOMEM;
+		LIST_INSERT_HEAD(&data_list, sd, entry);
+	}
+	return 0;
+}
+
+/**
+ * \brief Configuration
+ */
+static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct attr_value_list *avl)
+{
+	char* s;
+	int rc;
+
+	if (!self || !avl)
+		return EINVAL;
+	pthread_mutex_lock(&cfg_lock);
+	if (closing) {
+		pthread_mutex_unlock(&cfg_lock);
+		return EINVAL;
+	}
+
+	int i, size = avl->count;
+	for (i = 0; i < size; i++) {
+		if (strcmp("stream", av_name(avl, i)) == 0) {
+			const char *sn = av_value_at_idx(avl, i);
+			rc = add_stream(sn);
+			if (rc) {
+				msglog(LDMSD_LERROR, PNAME ": failed to add"
+					" stream %s.\n", sn);
+				goto out;
+			}
+		}
+	}
+	if (LIST_FIRST(&data_list) == NULL) {
+		msglog(LDMSD_LERROR, PNAME ": missing 'stream=...' in config\n");
+		rc = EINVAL;
+		goto out;
+	}
+
+
+	s = av_value(avl, "debug");
+	if (s) {
+		debug = 1;
+	}
+
+	s = av_value(avl, "path");
+	if (!s) {
+		msglog(LDMSD_LERROR, PNAME ": missing path in config\n");
+		rc = EINVAL;
+		goto out;
+	} else {
+		root_path = strdup(s);
+	}
+
+
+	s = av_value(avl, "container");
+	if (!s){
+		msglog(LDMSD_LERROR, PNAME ": missing container in config\n");
+		rc = EINVAL;
+		goto out;
+	} else {
+		container = strdup(s);
+	}
+	if (!container || !root_path) {
+		rc = ENOMEM;
+		msglog(LDMSD_LERROR, PNAME ": out of memory in config.\n");
+		goto out;
+	}
+
+	stream_data_t sd = NULL;
+	LIST_FOREACH(sd, &data_list, entry) {
+		pthread_mutex_lock(&sd->write_lock);
+		if (sd->ws == WS_REOPEN) {
+			reset_paths(sd);
+		}
+		if (sd->ws == WS_NEW) {
+			rc = set_paths(sd);
+			if (rc) {
+				msglog(LDMSD_LERROR, PNAME ": config: problem '%s'\n",
+					STRERROR(rc));
+			}
+		}
+		pthread_mutex_unlock(&sd->write_lock);
+	}
+
+out:
+	pthread_mutex_unlock(&cfg_lock);
+
+	return rc;
+}
+
+static void stream_data_close( stream_data_t sd )
+{
+	if (!sd)
+		return;
+	pthread_mutex_lock(&sd->write_lock);
+	if (sd->streamfile) {
+		fclose(sd->streamfile);
+		sd->streamfile = NULL;
+	}
+	if (sd->offsetfile) {
+		fclose(sd->offsetfile);
+		sd->offsetfile = NULL;
+	}
+	free(sd->streamfile_name);
+	sd->streamfile_name = NULL;
+	free(sd->offsetfile_name);
+	sd->offsetfile_name = NULL;
+	free(sd->stream_name);
+	sd->stream_name = NULL;
+	ldmsd_stream_close(sd->subscription);
+	/* sd reference is no longer hiding inside cb handler */
+	sd->subscription = NULL;
+	sd->ws = WS_CLOSED;
+	pthread_mutex_unlock(&sd->write_lock);
+	pthread_mutex_destroy(&sd->write_lock);
+}
+
+static void term(struct ldmsd_plugin *self)
+{
+	pthread_mutex_lock(&cfg_lock);
+	closing = 1;
+	stream_data_t sd = LIST_FIRST(&data_list);
+	while (sd) {
+		stream_data_close(sd);
+		LIST_REMOVE(sd, entry);
+		free(sd);
+		sd = LIST_FIRST(&data_list);
+	}
+	pthread_mutex_unlock(&cfg_lock);
+	free(root_path);
+	root_path = NULL;
+	free(container);
+	container = NULL;
+
+	return;
+}
+
+static const char *usage(struct ldmsd_plugin *self)
+{
+	return  "    config name=blob_stream_writer path=<path> container=<container> stream=<stream> \n"
+		"         - Set the root path for the storage of csvs and some default parameters\n"
+		"         - path       The path to the root of the csv directory\n"
+		"         - container  The directory under the path\n"
+		"         - stream     The stream name which will also be the file name\n"
+		"                      The stream argument may be repeated.\n"
+		;
+}
+
+static ldms_set_t get_set(struct ldmsd_sampler *self)
+{
+	return NULL;
+}
+
+static int sample(struct ldmsd_sampler *self)
+{
+	return 0;
+}
+
+static struct ldmsd_sampler blob_stream_writer = {
+	.base = {
+			.name = "blob_stream_writer",
+			.type = LDMSD_PLUGIN_SAMPLER,
+			.term = term,
+			.config = config,
+			.usage = usage,
+	},
+	.get_set = get_set,
+	.sample = sample
+};
+
+struct ldmsd_plugin *get_plugin(ldmsd_msg_log_f pf)
+{
+	msglog = pf;
+	LIST_INIT(&data_list);
+	return &blob_stream_writer.base;
+}
+
+static void __attribute__ ((constructor)) blob_stream_writer_init();
+static void blob_stream_writer_init()
+{
+	pthread_mutex_init(&cfg_lock, NULL);
+}
+
+static void __attribute__ ((destructor)) blob_stream_writer_fini(void);
+static void blob_stream_writer_fini()
+{
+	pthread_mutex_destroy(&cfg_lock);
+}


### PR DESCRIPTION
This plugin subscribes to any number of streams and creates a message-indexed
dump of each stream. There is no parsing of the messages, so this is fast.
Converting blobs to any particular database format is left to other tools.
Test/demo script and man page included