### PR TITLE
Demote ENOENT message to LINFO on update callback

### DIFF
--- a/ldms/src/ldmsd/ldmsd_updtr.c
+++ b/ldms/src/ldmsd/ldmsd_updtr.c
@@ -550,11 +550,16 @@ void __ldmsd_prdset_lookup_cb(ldms_t xprt, enum ldms_lookup_status status,
 					"It is likely that there are multiple "
 					"producers providing a set with the same instance name.\n",
 					prd_set->prdcr->obj.name, prd_set->inst_name);
+		} else if (status == ENOENT) {
+			ldmsd_log(LDMSD_LINFO,
+				  	"prdcr %s: disappeared set in lookup callback of set '%s'\n",
+					prd_set->prdcr->obj.name,
+					prd_set->inst_name);
 		} else {
 			ldmsd_log(LDMSD_LERROR,
-				  	"prdcr %s: Error %d in lookup callback of set '%s'\n",
-					prd_set->prdcr->obj.name,
-					status, prd_set->inst_name);
+				  	"prdcr %s: Error %d(%s) in lookup callback of set '%s'\n",
+					prd_set->prdcr->obj.name, status,
+					STRERROR(status), prd_set->inst_name);
 		}
 		prd_set->state = LDMSD_PRDCR_SET_STATE_START;
 		goto out;

--- a/ldms/src/ldmsd/ldmsd_updtr.c
+++ b/ldms/src/ldmsd/ldmsd_updtr.c
@@ -550,10 +550,11 @@ void __ldmsd_prdset_lookup_cb(ldms_t xprt, enum ldms_lookup_status status,
 					"It is likely that there are multiple "
 					"producers providing a set with the same instance name.\n",
 					prd_set->prdcr->obj.name, prd_set->inst_name);
-		} else if (status == ENOENT) {
+		} else if (status == ENOENT || status == EREMOTEIO) {
 			ldmsd_log(LDMSD_LINFO,
-				  	"prdcr %s: disappeared set in lookup callback of set '%s'\n",
+				  	"prdcr %s: disappeared (%s) set in lookup callback of set '%s'\n",
 					prd_set->prdcr->obj.name,
+					STRERROR(status),
 					prd_set->inst_name);
 		} else {
 			ldmsd_log(LDMSD_LERROR,

--- a/ldms/src/ldmsd/ldmsd_updtr.c
+++ b/ldms/src/ldmsd/ldmsd_updtr.c
@@ -550,9 +550,17 @@ void __ldmsd_prdset_lookup_cb(ldms_t xprt, enum ldms_lookup_status status,
 					"It is likely that there are multiple "
 					"producers providing a set with the same instance name.\n",
 					prd_set->prdcr->obj.name, prd_set->inst_name);
-		} else if (status == ENOENT || status == EREMOTEIO) {
+		} else if (status == ENOENT ) {
+			prd_set->state = LDMSD_PRDCR_SET_STATE_DELETED;
 			ldmsd_log(LDMSD_LINFO,
 				  	"prdcr %s: disappeared (%s) set in lookup callback of set '%s'\n",
+					prd_set->prdcr->obj.name,
+					STRERROR(status),
+					prd_set->inst_name);
+			goto out;
+		} else if (status == EREMOTEIO) {
+			ldmsd_log(LDMSD_LINFO,
+				  	"prdcr %s: unfound (%s) set in lookup callback of set '%s'\n",
 					prd_set->prdcr->obj.name,
 					STRERROR(status),
 					prd_set->inst_name);


### PR DESCRIPTION
Samplers removing set instances (and this propagating upstream)
is now a routine event (lustre mount points, app_sampler processes).
This demotes that event to an info from an error, leaving the other
non-specific messages as LERROR.