### PR TITLE
exclude default /lib and /lib64 from extra lib search path computed by OPTION_WITH

### DIFF
--- a/m4/options.m4
+++ b/m4/options.m4
@@ -110,7 +110,7 @@ AC_ARG_WITH(
 )
 
 case "x$withval" in
-xyes | x/usr | x)
+xyes | x/usr | x/lib | x/lib64 | x)
 	:
 	;;
 *)


### PR DESCRIPTION
Without this change extraneous /lib can appear in search paths before the build's libdir, causing older installations of ldms to get mixed with the build and fail immediately on symbols or crash later.