### PR TITLE
Add linux_proc_sampler and related doc derived from app_sampler.

### DIFF
--- a/ldms/scripts/examples/app_sampler
+++ b/ldms/scripts/examples/app_sampler
@@ -1,0 +1,20 @@
+export plugname=app_sampler
+export dsname=$(ldms_dstat_schema_name mmalloc=1 io=1 fd=1 auto-schema=1)
+export dstat_schema=$dsname
+portbase=61060
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --retry=1 -D 15 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+VGARGS="--leak-check=full --track-origins=yes --trace-children=yes"
+vgon
+LDMSD 1
+vgoff
+LDMSD 2
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1 -v
+MESSAGE ldms_ls on host 2:
+SLEEP 1
+LDMS_LS 2 -l
+SLEEP 5
+LDMS_LS 2 -v
+KILL_LDMSD 1 2
+file_created $STOREDIR/node/$testname
+file_created $STOREDIR/node/$dsname

--- a/ldms/scripts/examples/app_sampler.1
+++ b/ldms/scripts/examples/app_sampler.1
@@ -1,0 +1,7 @@
+load name=${testname}
+config name=${testname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i}
+start name=${testname} interval=1000000 offset=0
+
+load name=dstat
+config name=dstat producer=localhost${i} instance=localhost${i}/${dstat_schema} component_id=${i} mmalloc=1 io=1 fd=1 auto-schema=1)
+start name=dstat interval=1000000 offset=0

--- a/ldms/scripts/examples/app_sampler.2
+++ b/ldms/scripts/examples/app_sampler.2
@@ -1,0 +1,22 @@
+load name=blob_stream_writer plugin=blob_stream_writer
+config name=blob_stream_writer path=${STOREDIR} container=blobs stream=slurm
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_subscribe regex=.* stream=slurm
+prdcr_start name=localhost1
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+strgp_add name=store_dstat plugin=store_csv schema=${dstat_schema} container=node
+strgp_prdcr_add name=store_dstat regex=.*
+strgp_start name=store_dstat
+
+strgp_add name=store_${testname} plugin=store_csv schema=app_sampler container=node
+strgp_prdcr_add name=store_${testname} regex=.*
+strgp_start name=store_${testname}
+

--- a/ldms/scripts/examples/linux_proc_sampler
+++ b/ldms/scripts/examples/linux_proc_sampler
@@ -1,0 +1,29 @@
+export plugname=linux_proc_sampler
+export dsname=$(ldms_dstat_schema_name mmalloc=1 io=1 fd=1 stat=1 auto-schema=1)
+export dstat_schema=$dsname
+export LDMSD_LOG_LEVEL=ERROR
+export LDMSD_LOG_TIME_SEC=1
+export LDMSD_EXTRA="-m 128m"
+portbase=61060
+rm -f $LOGDIR/json*.log
+# valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.txt ${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --retry=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --retry=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+# uncomment next one to test duplicate handling
+#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --retry=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+VGARGS="--leak-check=full --track-origins=yes --trace-children=yes"
+# VGARGS="--tool=drd "
+#vgon
+LDMSD 1
+vgoff
+LDMSD 2 3
+SLEEP 2
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1 -v
+MESSAGE ldms_ls on host 2:
+SLEEP 1
+LDMS_LS 2 -v
+SLEEP 30
+LDMS_LS 2 -v
+KILL_LDMSD 1 2 3
+file_created $STOREDIR/node/$testname
+file_created $STOREDIR/node/$dsname

--- a/ldms/scripts/examples/linux_proc_sampler
+++ b/ldms/scripts/examples/linux_proc_sampler
@@ -5,6 +5,19 @@ export LDMSD_LOG_LEVEL=ERROR
 export LDMSD_LOG_TIME_SEC=1
 export LDMSD_EXTRA="-m 128m"
 portbase=61060
+cat << EOF > $LDMSD_RUN/metrics.input
+   { "stream" : "slurm",
+         "metrics" : [
+            "stat_pid" ,
+            "stat_state",
+            "stat_rss",
+            "stat_utime",
+            "stat_stime",
+	    "io_read_b",
+	    "io_write_b"
+         ]
+       }
+EOF
 rm -f $LOGDIR/json*.log
 # valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.txt ${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --retry=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
 ${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --retry=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &

--- a/ldms/scripts/examples/linux_proc_sampler.1
+++ b/ldms/scripts/examples/linux_proc_sampler.1
@@ -1,5 +1,5 @@
 load name=${testname}
-config name=${testname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} perm=0644
+config name=${testname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} perm=0644 cfg_file=${LDMSD_RUN}/metrics.input
 start name=${testname} interval=1000000 offset=0
 
 load name=dstat

--- a/ldms/scripts/examples/linux_proc_sampler.1
+++ b/ldms/scripts/examples/linux_proc_sampler.1
@@ -1,0 +1,7 @@
+load name=${testname}
+config name=${testname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} perm=0644
+start name=${testname} interval=1000000 offset=0
+
+load name=dstat
+config name=dstat producer=localhost${i} instance=localhost${i}/${dstat_schema} component_id=${i} mmalloc=1 io=1 fd=1 auto-schema=1 stat=1) perm=777
+start name=dstat interval=1000000 offset=0

--- a/ldms/scripts/examples/linux_proc_sampler.2
+++ b/ldms/scripts/examples/linux_proc_sampler.2
@@ -1,0 +1,22 @@
+load name=blob_stream_writer plugin=blob_stream_writer
+config name=blob_stream_writer path=${STOREDIR} container=blobs stream=slurm types=1
+
+load name=dstat
+config name=dstat producer=localhost${i} instance=localhost${i}/${dstat_schema} component_id=${i} mmalloc=1 io=1 fd=1 auto-schema=1 stat=1) perm=777
+start name=dstat interval=1000000 offset=0
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_subscribe regex=.* stream=slurm
+prdcr_start name=localhost1
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+strgp_add name=store_${testname} plugin=store_csv schema=linux_proc_sampler container=node
+strgp_prdcr_add name=store_${testname} regex=.*
+strgp_start name=store_${testname}
+

--- a/ldms/scripts/examples/linux_proc_sampler.3
+++ b/ldms/scripts/examples/linux_proc_sampler.3
@@ -1,0 +1,14 @@
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=2000000
+prdcr_start name=localhost2
+
+updtr_add name=allhosts interval=1000000 offset=200000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+strgp_add name=store_dstat plugin=store_csv schema=${dstat_schema} container=node
+strgp_prdcr_add name=store_dstat regex=.*
+strgp_start name=store_dstat
+

--- a/ldms/src/sampler/app_sampler/Makefile.am
+++ b/ldms/src/sampler/app_sampler/Makefile.am
@@ -1,7 +1,19 @@
 pkglib_LTLIBRARIES = libapp_sampler.la
+dist_man7_MANS =
+
+COMMON_LIBS= -lsampler_base -lldms -lovis_util -lcoll \
+	    @LDFLAGS_GETTIME@ ../../ldmsd/libldmsd_stream.la
 
 libapp_sampler_la_SOURCES = app_sampler.c
 libapp_sampler_la_CFLAGS  = @OVIS_INCLUDE_ABS@
-libapp_sampler_la_LIBADD  = -lsampler_base -lldms -lovis_util -lcoll \
-			    @LDFLAGS_GETTIME@ ../../ldmsd/libldmsd_stream.la
+libapp_sampler_la_LIBADD  =  $(COMMON_LIBS)
 libapp_sampler_la_LDFLAGS = @OVIS_LIB_ABS@
+
+pkglib_LTLIBRARIES += liblinux_proc_sampler.la
+
+EXTRA_DIST=get_stat_field.c
+dist_man7_MANS += Plugin_linux_proc_sampler.man
+liblinux_proc_sampler_la_SOURCES = linux_proc_sampler.c
+liblinux_proc_sampler_la_CFLAGS  = @OVIS_INCLUDE_ABS@
+liblinux_proc_sampler_la_LIBADD  = $(COMMON_LIBS)
+liblinux_proc_sampler_la_LDFLAGS = @OVIS_LIB_ABS@

--- a/ldms/src/sampler/app_sampler/Plugin_linux_proc_sampler.man
+++ b/ldms/src/sampler/app_sampler/Plugin_linux_proc_sampler.man
@@ -1,0 +1,139 @@
+.\" Manpage for Plugin_linux_proc_sampler Plugin_linux_proc
+.\" Contact ovis-help@ca.sandia.gov to correct errors or typos.
+.TH man 7 "15 Jul 2021" "v4" "LDMS Plugin linux_proc man page"
+
+.SH NAME
+Plugin_linux_proc_sampler - man page for the LDMS linux_proc_sampler plugin
+
+.SH SYNOPSIS
+Within ldmsd_controller or a configuration file:
+.br
+config name=linux_proc_sampler [common attributes] [stream=STREAM] [metrics=METRICS] [cfg_file=FILE] [instance_prefix=PREFIX] [exe_suffix=1]
+
+.SH DESCRIPTION
+With LDMS (Lightweight Distributed Metric Service), plugins for the ldmsd (ldms daemon) are configured via ldmsd_controller or a configuration file. The linux_proc_sampler plugin provides data from /proc/, creating a different set for each process identified in the named stream. The stream can come from the ldms-netlink-notifier daemon or the spank plugin slurm_notifier.
+
+.SH CONFIGURATION ATTRIBUTE SYNTAX
+The linux_proc_sampler plugin uses the sampler_base base class. This man page covers only the configuration attributes, or those with default values, specific to the this plugin; see ldms_sampler_base.man for the attributes of the base class.
+
+.TP
+.BR config
+name=<plugin_name> [other options]
+.br
+configuration line
+.RS
+.TP
+name=<plugin_name>
+.br
+This MUST be linux_proc_sampler.
+.TP
+instance_prefix=PREFIX
+.br
+Prepend PREFIX to the set instance names. Typically a cluster name when needed to disambiguate producer names that appear in multiple clusters.  (default: no prefix).
+.TP
+exe_suffix=1
+.br
+If present, set instance names are appended with the full path of the executable. This is most likely
+useful for debugging configuration of the notifier up-stream using ldms_ls. (default: no such suffix)
+.TP
+stream
+.br
+The name of the `ldmsd_stream` to listen for SLURM job events.  (default: slurm).
+.TP
+metrics
+.br
+The comma-separated list of metrics to monitor.  The default is (empty), which is equivalent to monitor ALL metrics.
+.TP
+cfg_file The alternative config file in JSON format. The file is expected to have an object that contains the following attributes: { "stream": "STREAM_NAME", "metrics": [ comma-separated-quoted-strings ] }.  If the `cfg_file` is given, the stream, metrics, instance_prefix and exe_suffix options are ignored.
+.RE
+
+.SH INPUT STREAM FORMAT
+
+The named ldmsd stream should deliver messages with a JSON format which includes the following.
+Messages which do not contain event, data, job_id, and some form of PID will be ignored. Extra
+fields will be ignored.
+.nf
+{ "event" = "$e",
+  "data" : {
+	"job_id" : INT,
+	"task_pid" : INT,
+	"os_pid" : INT,
+	"parent_pid" : INT,
+	"is_thread" : INT,
+	"exe" : STRING,
+	"start" : STRING,
+	"start_tick" : STRING
+  }
+}
+.fi
+where $e is one of task_init_priv or task_exit.
+The data fields other than job_id are all optional, but at least one of os_pid and task_pid must
+contain the PID of a process to be monitored. If present and > 0, task_pid should be the value taken
+from SLURM_TASK_PID or an equivalent value from another resource management environment.
+The value of start, if provided, should be approximately the epoch time ("%lu.%06lu") when the
+PID to be monitored started.
+
+
+.SH EXAMPLES
+.PP
+Within ldmsd_controller or a configuration file:
+.nf
+load name=linux_proc_sampler
+config name=linux_proc_sampler producer=vm1_1 instance=vm1_1/linux_proc_sampler metrics=stat_comm,stat_pid,stat_cutime
+start name=linux_proc_sampler interval=1000000
+.fi
+.PP
+An example metrics configuration file is:
+.nf
+{
+  "stream": "slurm",
+  "instance_prefix" : "cluster2",
+  "metrics": [
+    "stat_state",
+    "stat_rss",
+    "stat_utime",
+    "stat_stime",
+    "stat_cutime",
+    "stat_cstime",
+    "stat_num_threads",
+    "stat_comm",
+    "n_open_files",
+    "io_read_b",
+    "io_write_b",
+    "status_vmdata",
+    "status_rssfile",
+    "status_vmswap",
+    "status_hugetlbpages",
+    "status_voluntary_ctxt_switches",
+    "status_nonvoluntary_ctxt_switches",
+    "syscall",
+    "cmdline"
+  ]
+}
+.fi
+.PP
+Obtaining the currenly supported optional metrics list:
+.nf
+ldms-plugins.sh linux_proc_sampler
+.fi
+
+.SH FILES
+Data is obtained from (depending on configuration) the following files in /proc/[PID]/:
+.nf
+cmdline
+exe
+statm
+stat
+status
+fd
+io
+oom_score
+oom_score_adj
+root
+syscall
+timerslack_ns
+wchan
+.fi
+
+.SH SEE ALSO
+ldmsd(8), ldms_quickstart(7), ldmsd_controller(8), ldms_sampler_base(7), proc(5)

--- a/ldms/src/sampler/app_sampler/Plugin_linux_proc_sampler.man
+++ b/ldms/src/sampler/app_sampler/Plugin_linux_proc_sampler.man
@@ -89,6 +89,7 @@ An example metrics configuration file is:
   "stream": "slurm",
   "instance_prefix" : "cluster2",
   "metrics": [
+    "stat_pid",
     "stat_state",
     "stat_rss",
     "stat_utime",

--- a/ldms/src/sampler/app_sampler/README.txt
+++ b/ldms/src/sampler/app_sampler/README.txt
@@ -1,0 +1,47 @@
+There are two samplers here.
+
+Both samplers use the same code to control what user-selectable metrics are
+included in a metric set.
+
+The differences are:
+
+app_sampler.c:
+
+Subscribes to a spank plugin generated stream identifying processes
+spawned directly by slurm.
+The sampler produces set instances named as $producer/$job_id/$task_rank.
+Within a job, task_rank may get reused across multiple processes if there
+are multiple srun commands. Child processes of those spawned by slurm will inherit
+the environment variable SLURM_TASK_RANK.
+
+
+linux_proc_sampler.c (with a bit of code from forkstat in get_stat_field.c):
+
+Subscribes to a netlink-notifier daemon generated stream identifying
+all the processes the kernel announces that are not filtered out by
+matching criteria in the notifier configuration.
+
+For non-slurm processes, the sampler produces set instances named as
+	 $producer/$job_id/$start_time/$pid
+where job_id will be 0 for any process not enclosed in a slurm environment.
+PID may get recycled but the combination $start_time/$pid will not.
+
+For slurm provoked processes, the sampler produces set instances named as
+	 $producer/$job_id/$start_time/rank/$task_rank
+
+Notes!:
+
+There may be a race between the netlink-notifier and the spank notifier if both
+are present to inform ldmsd of interesting pids. These can be publishing
+messages to separate streams,
+in which case there is no race at the sampler, or to the same stream.
+
+If linux_proc_sampler sees messages from both notifiers on the same stream,
+it will switch to the slurm set instance naming when the slurm message
+is seen after the non-slurm message. If the non-slurm message is seen
+after the slurm message, the slurm-derived set will be retained. Fields not
+provided by the spank notifier (start_tick, etc) are derived
+when needed.
+
+It is redundant but safe to run both samplers at the same time
+subscribing to the same stream.

--- a/ldms/src/sampler/app_sampler/get_stat_field.c
+++ b/ldms/src/sampler/app_sampler/get_stat_field.c
@@ -1,0 +1,162 @@
+
+/*
+ * Copyright (C) 2014-2018 Canonical Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Written by Colin Ian King <colin.king@canonical.com>
+ *
+ * Some of this code originally derived from eventstat and powerstat
+ * also by the same author.
+ *
+ */
+
+/*
+ *  get_proc_self_stat_field()
+ *      find nth field of /proc/$PID/stat data. This works around
+ *      the problem that the comm field can contain spaces and
+ *      multiple ) so sscanf on this field won't work.  The returned
+ *      pointer is the start of the Nth field and it is up to the
+ *      caller to determine the end of the field
+ */
+static const char *get_proc_self_stat_field(const char *buf, const int num)
+{
+	const char *ptr = buf, *comm_end;
+	int n;
+
+	if (num < 1 || !buf || !*buf)
+		return NULL;
+	if (num == 1)
+		return buf;
+	if (num == 2)
+		return strstr(buf, "(");
+
+	comm_end = NULL;
+	for (ptr = buf; *ptr; ptr++) {
+		if (*ptr == ')')
+			comm_end = ptr;
+	}
+	if (!comm_end)
+		return NULL;
+	comm_end++;
+	n = num - 2;
+
+	ptr = comm_end;
+	while (*ptr) {
+		while (*ptr && *ptr == ' ')
+			ptr++;
+		n--;
+		if (n <= 0)
+			break;
+		while (*ptr && *ptr != ' ')
+			ptr++;
+	}
+
+	return ptr;
+}
+
+static int get_timeval_from_tick(uint64_t starttime, struct timeval * const tv)
+{
+	/* from proc_info_get_timeval convert tick since boot to clock */
+	double uptime_secs = 0, secs = 0;
+	long jiffies;
+	struct timeval now = {.tv_sec = 0, .tv_usec = 0};
+
+	errno = 0;
+	jiffies = sysconf(_SC_CLK_TCK);
+	if (errno)
+		return 1;
+	secs = uptime_secs - ((double)starttime / (double)jiffies);
+	if (secs < 0.0)
+		return 1;
+
+	if (gettimeofday(&now, NULL) < 0)
+		return 1;
+
+	secs = ( (double)now.tv_sec + ((double)now.tv_usec / 1000000.0) ) - secs;
+	tv->tv_sec = secs;
+	tv->tv_usec = (suseconds_t)secs % 1000000;
+	return 0;
+}
+
+void proc_exe_buf(const pid_t pid, char *buffer, size_t buflen)
+{
+	ssize_t ret;
+	char path[32];
+	snprintf(path, sizeof(path), "/proc/%d/exe", pid);
+	ret = readlink(path, buffer, buflen - 1);
+	if (ret < 0)
+		sprintf(buffer,"(nullexe)");
+	else
+		buffer[ret] = '\0';
+}
+
+
+#define GOT_TGID                (0x01)
+#define GOT_PPID                (0x02)
+#define GOT_ALL                 (GOT_TGID | GOT_PPID)
+
+
+/*
+ *  get_parent_pid()
+ *      get parent pid and set is_thread to true if process
+ *      not forked but a newly created thread
+ */
+static pid_t get_parent_pid(const pid_t pid, bool * const is_thread)
+{
+	FILE *fp;
+	pid_t tgid = 0, ppid = 0;
+	unsigned int got = 0;
+	char path[PATH_MAX];
+	char buffer[4096];
+
+	*is_thread = false;
+	(void)snprintf(path, sizeof(path), "/proc/%u/status", pid);
+	fp = fopen(path, "r");
+	if (!fp)
+		return 0;
+
+	while (((got & GOT_ALL) != GOT_ALL) &&
+		(fgets(buffer, sizeof(buffer), fp) != NULL)) {
+		if (!strncmp(buffer, "Tgid:", 5)) {
+			if (sscanf(buffer + 5, "%u", &tgid) == 1) {
+				got |= GOT_TGID;
+			} else {
+				tgid = 0;
+			}
+		}
+		if (!strncmp(buffer, "PPid:", 5)) {
+			if (sscanf(buffer + 5, "%u", &ppid) == 1)
+				got |= GOT_PPID;
+			else
+				ppid = 0;
+		}
+	}
+	(void)fclose(fp);
+
+	if ((got & GOT_ALL) == GOT_ALL) {
+		/*  TGID and PID are not the same if it is a thread */
+		if (tgid != pid) {
+			/* In this case, the parent is the TGID */
+			ppid = tgid;
+			*is_thread = true;
+		}
+	} else {
+		ppid = 0;
+	}
+
+	return ppid;
+}
+

--- a/ldms/src/sampler/app_sampler/linux_proc_sampler.c
+++ b/ldms/src/sampler/app_sampler/linux_proc_sampler.c
@@ -1439,7 +1439,7 @@ int __handle_cfg_file(linux_proc_sampler_inst_t inst, char *val)
 			INST_LOG(inst, LDMSD_LERROR, "Error: `instance_prefix` must be a string.");
 			goto out;
 		}
-		inst->instance_prefix = strdup(ent->value.str_->str);
+		inst->instance_prefix = strdup(json_value_cstr(ent));
 		if (!inst->instance_prefix) {
 			rc = ENOMEM;
 			INST_LOG(inst, LDMSD_LERROR, "Out of memory while configuring.");
@@ -1457,7 +1457,7 @@ int __handle_cfg_file(linux_proc_sampler_inst_t inst, char *val)
 			INST_LOG(inst, LDMSD_LERROR, "Error: `stream` must be a string.");
 			goto out;
 		}
-		inst->stream_name = strdup(ent->value.str_->str);
+		inst->stream_name = strdup(json_value_cstr(ent));
 		if (!inst->stream_name) {
 			rc = ENOMEM;
 			INST_LOG(inst, LDMSD_LERROR, "Out of memory while configuring.");
@@ -1474,10 +1474,10 @@ int __handle_cfg_file(linux_proc_sampler_inst_t inst, char *val)
 					 "Error: metric must be a string.");
 				goto out;
 			}
-			minfo = find_metric_info_by_name(json_value_str_str(ent));
+			minfo = find_metric_info_by_name(json_value_cstr(ent));
 			if (!minfo) {
 				rc = ENOENT;
-				missing_metric(inst, json_value_str_str(ent));
+				missing_metric(inst, json_value_cstr(ent));
 				goto out;
 			}
 			inst->metric_idx[minfo->code] = -1;
@@ -1520,11 +1520,11 @@ uint64_t get_field_value_u64(linux_proc_sampler_inst_t inst, json_entity_t src, 
 	uint64_t u64;
 	switch (et) {
 	case JSON_STRING_VALUE:
-		if (sscanf(json_value_str_str(e),"%" SCNu64, &u64) == 1) {
+		if (sscanf(json_value_cstr(e),"%" SCNu64, &u64) == 1) {
 			return u64;
 		} else {
 			INST_LOG(inst, LDMSD_LDEBUG, "unconvertible to uint64_t: %s from %s.\n",
-				json_value_str_str(e), name);
+				json_value_cstr(e), name);
 			errno = EINVAL;
 			return 0;
 		}
@@ -1663,7 +1663,7 @@ int __handle_task_init(linux_proc_sampler_inst_t inst, json_entity_t data)
 			tv.tv_sec, tv.tv_usec);
 		start_string = start_string_buf;
 	} else {
-		start_string = json_value_str_str(start);
+		start_string = json_value_cstr(start);
 	}
 	const char *exe_string;
 	char exe_buf[CMDLINE_SZ];
@@ -1671,7 +1671,7 @@ int __handle_task_init(linux_proc_sampler_inst_t inst, json_entity_t data)
 		proc_exe_buf(pid, exe_buf, sizeof(exe_buf));
 		exe_string = exe_buf;
 	} else {
-		exe_string = json_value_str_str(exe);
+		exe_string = json_value_cstr(exe);
 	}
 	int64_t task_rank_val = -1;
 	task_rank = get_field(inst, data, JSON_INT_VALUE, "task_global_id");
@@ -1895,7 +1895,7 @@ static int __stream_cb(ldmsd_stream_client_t c, void *ctxt,
 		rc = ENOENT;
 		goto err;
 	}
-	event_name = json_value_str_str(event);
+	event_name = json_value_cstr(event);
 	data = json_value_find(entity, "data");
 	if (!data) {
 		INST_LOG(inst, LDMSD_LERROR,


### PR DESCRIPTION
This new sampler consumes pids from a stream compatible with it or the app_sampler and supplied by slurm_notifier or netlink-notifier pending in #758.
It has been tested on CTS-1 hardware/toss-3 and centos.
It provides reference tests for app_sampler and linux_proc_sampler driven by ldms-static-test.sh and man page.
It is partially derived (with attribution) from forkstat.

It is disabled by default; configure with '--enable-app-sampler' to test; changing the default to enabled for app_sampler and this would be a good thing but is separable.
It will not pass a build bot test until #761 is merged for json_value_str_str. 