### PR TITLE
Get rid of the log file lock

### DIFF
--- a/ldms/src/ldmsd/Makefile.am
+++ b/ldms/src/ldmsd/Makefile.am
@@ -26,6 +26,7 @@ LCOLL = $(top_builddir)/lib/src/coll/libcoll.la
 LJSON_UTIL = $(top_builddir)/lib/src/ovis_json/libovis_json.la
 LOVIS_EVENT = $(top_builddir)/lib/src/ovis_event/libovis_event.la
 LOVIS_CTRL = $(top_builddir)/lib/src/ovis_ctrl/libovis_ctrl.la
+LOVIS_EV = $(top_builddir)/lib/src/ovis_ev/libovis_ev.la
 
 AM_CFLAGS += -DPLUGINDIR='"$(pkglibdir)"'
 
@@ -51,10 +52,11 @@ ldmsd_SOURCES = ldmsd.c ldmsd_config.c \
 	ldmsd_request.c \
 	ldmsd_request.h \
 	ldmsd_cfgobj.c ldmsd_prdcr.c ldmsd_updtr.c ldmsd_strgp.c \
-	ldmsd_failover.c ldmsd_group.c ldmsd_auth.c
+	ldmsd_failover.c ldmsd_group.c ldmsd_auth.c \
+	ldmsd_event.c ldmsd_event.h
 ldmsd_LDADD = ../core/libldms.la libldmsd_request.la libldmsd_stream.la \
 	$(LZAP) $(LMMALLOC) $(LOVIS_UTIL) $(LCOLL) $(LJSON_UTIL) \
-	$(LOVIS_EVENT) -lpthread $(LOVIS_CTRL) -lm -ldl
+	$(LOVIS_EVENT) $(LOVIS_EV) -lpthread $(LOVIS_CTRL) -lm -ldl
 ldmsd_CFLAGS = $(AM_CFLAGS)
 ldmsd_LDFLAGS = $(AM_LDFLAGS) -rdynamic -pthread
 

--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -300,7 +300,7 @@ int __log(enum ldmsd_loglevel level, char *msg)
 	}
 
 	fprintf(log_fp, "%s", msg);
-	fflush(log_fp);
+
 	return 0;
 }
 
@@ -311,11 +311,13 @@ int log_actor(ev_worker_t src, ev_worker_t dst, ev_status_t status, ev_t ev)
 	uint8_t is_rotate = EV_DATA(ev, struct log_data)->is_rotate;
 	int rc;
 
-	if (is_rotate)
+	if (is_rotate) {
 		rc = __logrotate();
-	else
+	} else {
 		rc = __log(level, msg);
-
+		if (0 == ev_pending(logger_w))
+			fflush(log_fp);
+	}
 	free(msg);
 	ev_put(ev);
 	return rc;

--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -75,10 +75,12 @@
 #include <time.h>
 #include <coll/rbt.h>
 #include <coll/str_map.h>
+#include "ovis_ev/ev.h"
 #include "ldms.h"
 #include "ldmsd.h"
 #include "ldms_xprt.h"
 #include "ldmsd_request.h"
+#include "ldmsd_event.h"
 #include "config.h"
 #include "kldms_req.h"
 
@@ -114,7 +116,6 @@ int log_truncate = 0;
 char *pidfile;
 char *bannerfile;
 int banner = 1;
-pthread_mutex_t log_lock = PTHREAD_MUTEX_INITIALIZER;
 size_t max_mem_size;
 char *max_mem_sz_str;
 
@@ -223,22 +224,56 @@ int ldmsd_loglevel_to_syslog(enum ldmsd_loglevel level)
 #define LDMSD_LOG_SYSLOG ((FILE*)0x7)
 
 static int log_time_sec = -1;
-void __ldmsd_log(enum ldmsd_loglevel level, const char *fmt, va_list ap)
+int __logrotate()
 {
-	if ((level != LDMSD_LALL) &&
-			(quiet || ((0 <= level) && (level < log_level_thr))))
-		return;
+	int rc;
+	if (!logfile) {
+		ldmsd_log(LDMSD_LERROR, "Received a logrotate command but "
+			"the log messages are printed to the standard out.\n");
+		return EINVAL;
+	}
 	if (log_fp == LDMSD_LOG_SYSLOG) {
-		vsyslog(ldmsd_loglevel_to_syslog(level),fmt,ap);
-		return;
+		/* nothing to do */
+		return 0;
 	}
-	char dtsz[200];
+	struct timeval tv;
+	char ofile_name[PATH_MAX];
+	gettimeofday(&tv, NULL);
+	sprintf(ofile_name, "%s-%ld", logfile, tv.tv_sec);
 
-	pthread_mutex_lock(&log_lock);
+	fflush(log_fp);
+	fclose(log_fp);
+	rename(logfile, ofile_name);
+	log_fp = fopen_perm(logfile, "a", LDMSD_DEFAULT_FILE_PERM);
 	if (!log_fp) {
-		pthread_mutex_unlock(&log_lock);
-		return;
+		printf("%-10s: Failed to rotate the log file. Cannot open a new "
+			"log file\n", "ERROR");
+		fflush(stdout);
+		rc = errno;
+		goto err;
 	}
+	int fd = fileno(log_fp);
+	if (dup2(fd, 1) < 0) {
+		rc = errno;
+		goto err;
+	}
+	if (dup2(fd, 2) < 0) {
+		rc = errno;
+		goto err;
+	}
+	stdout = stderr = log_fp;
+	return 0;
+err:
+	return rc;
+}
+
+int __log(enum ldmsd_loglevel level, char *msg)
+{
+	if (log_fp == LDMSD_LOG_SYSLOG) {
+		syslog(ldmsd_loglevel_to_syslog(level), "%s", msg);
+		return 0;
+	}
+
 	if (log_time_sec == -1) {
 		char * lt = getenv("LDMSD_LOG_TIME_SEC");
 		if (lt)
@@ -252,8 +287,9 @@ void __ldmsd_log(enum ldmsd_loglevel level, const char *fmt, va_list ap)
 		fprintf(log_fp, "%lu.%06lu: ", tv.tv_sec, tv.tv_usec);
 	} else {
 		time_t t;
-		t = time(NULL);
+		char dtsz[200];
 		struct tm tm;
+		t = time(NULL);
 		localtime_r(&t, &tm);
 		if (strftime(dtsz, sizeof(dtsz), "%a %b %d %H:%M:%S %Y", &tm))
 			fprintf(log_fp, "%s: ", dtsz);
@@ -263,13 +299,53 @@ void __ldmsd_log(enum ldmsd_loglevel level, const char *fmt, va_list ap)
 		fprintf(log_fp, "%-10s: ", ldmsd_loglevel_names[level]);
 	}
 
-	vfprintf(log_fp, fmt, ap);
+	fprintf(log_fp, "%s", msg);
 	fflush(log_fp);
-	pthread_mutex_unlock(&log_lock);
+	return 0;
+}
+
+int log_actor(ev_worker_t src, ev_worker_t dst, ev_status_t status, ev_t ev)
+{
+	enum ldmsd_loglevel level = EV_DATA(ev, struct log_data)->level;
+	char *msg = EV_DATA(ev, struct log_data)->msg;
+	uint8_t is_rotate = EV_DATA(ev, struct log_data)->is_rotate;
+	int rc;
+
+	if (is_rotate)
+		rc = __logrotate();
+	else
+		rc = __log(level, msg);
+
+	free(msg);
+	ev_put(ev);
+	return rc;
+}
+
+void __ldmsd_log(enum ldmsd_loglevel level, const char *fmt, va_list ap)
+{
+	ev_t log_ev;
+	char *msg;
+	int rc;
+
+	log_ev = ev_new(log_type);
+	if (!log_ev)
+		return;
+	rc = vasprintf(&msg, fmt, ap);
+	if (rc < 0)
+		return;
+	EV_DATA(log_ev, struct log_data)->msg = msg;
+	EV_DATA(log_ev, struct log_data)->level = level;
+	EV_DATA(log_ev, struct log_data)->is_rotate = 0;
+
+	ev_post(NULL, logger_w, log_ev, NULL);
 }
 
 void ldmsd_log(enum ldmsd_loglevel level, const char *fmt, ...)
 {
+	if ((level != LDMSD_LALL) &&
+			(quiet || ((0 <= level) && (level < log_level_thr))))
+		return;
+
 	va_list ap;
 	va_start(ap, fmt);
 	__ldmsd_log(level, fmt, ap);
@@ -364,8 +440,16 @@ void cleanup(int x, const char *reason)
 		llevel = LDMSD_LCRITICAL;
 	ldmsd_mm_status(LDMSD_LDEBUG,"mmap use at exit");
 	ldmsd_strgp_close();
-	ldmsd_log(llevel, "LDMSD_ LDMS Daemon exiting...status %d, %s\n", x,
-		       (reason && x) ? reason : "");
+
+	if (!quiet && (llevel >= log_level_thr)) {
+		/*
+		 * The logger and the log file may not be created and opened
+		 * at the time the cleanup() function is called.
+		 */
+		printf("LDMSD_ LDMS Daemon exiting...status %d, %s\n", x,
+			       (reason && x) ? reason : "");
+	}
+
 	if (ldms) {
 		/* No need to close the xprt. It has never been connected. */
 		ldms_xprt_put(ldms);
@@ -388,7 +472,9 @@ void cleanup(int x, const char *reason)
 		free(pidfile);
 		pidfile = NULL;
 	}
-	ldmsd_log(llevel, "LDMSD_ cleanup end.\n");
+	if (!quiet && (llevel >= log_level_thr))
+		printf("LDMSD_ cleanup end.\n");
+
 	if (logfile) {
 		free(logfile);
 		logfile = NULL;
@@ -437,52 +523,13 @@ FILE *ldmsd_open_log(const char *progname)
 }
 
 int ldmsd_logrotate() {
-	int rc;
-	if (!logfile) {
-		ldmsd_log(LDMSD_LERROR, "Received a logrotate command but "
-			"the log messages are printed to the standard out.\n");
-		return EINVAL;
-	}
-	if (log_fp == LDMSD_LOG_SYSLOG) {
-		/* nothing to do */
-		return 0;
-	}
-	struct timeval tv;
-	char ofile_name[PATH_MAX];
-	gettimeofday(&tv, NULL);
-	sprintf(ofile_name, "%s-%ld", logfile, tv.tv_sec);
-
-	pthread_mutex_lock(&log_lock);
-	if (!log_fp) {
-		pthread_mutex_unlock(&log_lock);
-		return EINVAL;
-	}
-	fflush(log_fp);
-	fclose(log_fp);
-	rename(logfile, ofile_name);
-	log_fp = fopen_perm(logfile, "a", LDMSD_DEFAULT_FILE_PERM);
-	if (!log_fp) {
-		printf("%-10s: Failed to rotate the log file. Cannot open a new "
-			"log file\n", "ERROR");
-		fflush(stdout);
-		rc = errno;
-		goto err;
-	}
-	int fd = fileno(log_fp);
-	if (dup2(fd, 1) < 0) {
-		rc = errno;
-		goto err;
-	}
-	if (dup2(fd, 2) < 0) {
-		rc = errno;
-		goto err;
-	}
-	stdout = stderr = log_fp;
-	pthread_mutex_unlock(&log_lock);
+	ev_t ev = ev_new(log_type);
+	if (!ev)
+		return ENOMEM;
+	EV_DATA(ev, struct log_data)->is_rotate = 1;
+	EV_DATA(ev, struct log_data)->msg = NULL;
+	ev_post(NULL, logger_w, ev, NULL);
 	return 0;
-err:
-	pthread_mutex_unlock(&log_lock);
-	return rc;
 }
 
 void cleanup_sa(int signal, siginfo_t *info, void *arg)
@@ -1860,6 +1907,7 @@ int main(int argc, char *argv[])
 			usage(argv);
 		}
 	}
+
 	if (list_plugins) {
 		if (plug_name) {
 			if (strcmp(plug_name,"all") == 0) {
@@ -1874,15 +1922,26 @@ int main(int argc, char *argv[])
 		exit(0);
 	}
 
-	if (logfile)
-		log_fp = ldmsd_open_log(argv[0]);
-
 	if (!foreground) {
 		if (daemon(1, 1)) {
 			perror("ldmsd: ");
 			cleanup(8, "daemon failed to start");
 		}
 	}
+
+	ret = ldmsd_ev_init();
+	if (ret) {
+		printf("Memory allocation failure.\n");
+		exit(1);
+	}
+	ret = ldmsd_worker_init();
+	if (ret) {
+		printf("Memory allocation failure.\n");
+		exit(1);
+	}
+
+	if (logfile)
+		log_fp = ldmsd_open_log(argv[0]);
 
 	/* Initialize LDMS */
 	umask(0);

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -1244,4 +1244,6 @@ void ldmsd_timespec_add(struct timespec *a, struct timespec *b, struct timespec 
 int ldmsd_timespec_cmp(struct timespec *a, struct timespec *b);
 void ldmsd_timespec_diff(struct timespec *a, struct timespec *b, struct timespec *result);
 
+void ldmsd_log_flush_interval_set(unsigned long interval);
+void ldmsd_flush_log();
 #endif

--- a/ldms/src/ldmsd/ldmsd_event.c
+++ b/ldms/src/ldmsd/ldmsd_event.c
@@ -1,0 +1,71 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2021 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ * Copyright (c) 2021 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ovis_ev/ev.h"
+#include "ldmsd_event.h"
+
+ev_worker_t logger_w;
+ev_type_t log_type;
+
+extern int log_actor(ev_worker_t src, ev_worker_t dst, ev_status_t status, ev_t ev);
+int ldmsd_worker_init(void)
+{
+	logger_w = ev_worker_new("logger", log_actor);
+	if (!logger_w)
+		return ENOMEM;
+	return 0;
+}
+
+int ldmsd_ev_init(void)
+{
+	log_type = ev_type_new("ldmsd:log", sizeof(struct log_data));
+	if (!log_type)
+		return ENOMEM;
+	return 0;
+}

--- a/ldms/src/ldmsd/ldmsd_event.h
+++ b/ldms/src/ldmsd/ldmsd_event.h
@@ -1,0 +1,74 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2021 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ * Copyright (c) 2021 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __LDMSD_EVENT_H__
+#define __LDMSD_EVENT_H__
+#include "ovis_json/ovis_json.h"
+#include "ovis_ev/ev.h"
+#include "ldmsd_stream.h"
+#include "ldmsd_request.h"
+#include "ldmsd.h"
+
+
+/* Worker */
+extern ev_worker_t logger_w;
+
+/* Event Types and data */
+/* LDMSD log */
+extern ev_type_t log_type;
+
+struct log_data {
+	uint8_t is_rotate;
+	enum ldmsd_loglevel level;
+	char *msg;
+};
+
+int ldmsd_ev_init(void);
+int ldmsd_worker_init(void);
+
+#endif /* __LDMSD_EVENT_H__ */

--- a/ldms/src/ldmsd/ldmsd_event.h
+++ b/ldms/src/ldmsd/ldmsd_event.h
@@ -66,6 +66,8 @@ struct log_data {
 	uint8_t is_rotate;
 	enum ldmsd_loglevel level;
 	char *msg;
+	struct timeval tv;
+	struct tm tm;
 };
 
 int ldmsd_ev_init(void);

--- a/lib/src/ovis_ev/ev.c
+++ b/lib/src/ovis_ev/ev.c
@@ -144,10 +144,13 @@ int ev_post(ev_worker_t src, ev_worker_t dst, ev_t ev, struct timespec *to)
 	if (dst->w_state == EV_WORKER_FLUSHING)
 		goto err;
 	ev_get(&e->e_ev);
-	if (to)
+	if (to) {
 		rbt_ins(&dst->w_event_tree, &e->e_to_rbn);
-	else
+	} else {
+		__sync_fetch_and_add(&dst->w_ev_list_len, 1);
 		TAILQ_INSERT_TAIL(&dst->w_event_list, e, e_entry);
+
+	}
 	rc = (ev_time_cmp(&e->e_to, &dst->w_sem_wait) <= 0);
 	pthread_mutex_unlock(&dst->w_lock);
 	if (rc)
@@ -188,6 +191,7 @@ int ev_cancel(ev_t ev)
 	}
 
 	rbt_del(&e->e_dst->w_event_tree, &e->e_to_rbn);
+	__sync_fetch_and_add(&e->e_dst->w_ev_list_len, 1);
 	TAILQ_INSERT_TAIL(&e->e_dst->w_event_list, e, e_entry);
  out:
 	pthread_mutex_unlock(&e->e_dst->w_lock);

--- a/lib/src/ovis_ev/ev.c
+++ b/lib/src/ovis_ev/ev.c
@@ -116,6 +116,12 @@ int ev_posted(ev_t ev)
 	return e->e_posted;
 }
 
+int ev_canceled(ev_t ev)
+{
+	ev__t e = EV(ev);
+	return (e->e_status == EV_FLUSH);
+}
+
 int ev_post(ev_worker_t src, ev_worker_t dst, ev_t ev, struct timespec *to)
 {
 	ev__t e = EV(ev);
@@ -169,10 +175,9 @@ int ev_cancel(ev_t ev)
 	int rc = EINVAL;
 	struct timespec now;
 
+	if (!e->e_posted && ev_canceled(ev))
+		return 0;
 	pthread_mutex_lock(&e->e_dst->w_lock);
-	if (!e->e_posted)
-		goto out;
-
 	/*
 	 * Set the status to EV_CANCEL so the actor will see that
 	 * status

--- a/lib/src/ovis_ev/ev.h
+++ b/lib/src/ovis_ev/ev.h
@@ -279,4 +279,16 @@ int ev_time_cmp(struct timespec *tsa, const struct timespec *tsb);
  */
 double ev_time_diff(struct timespec *tsa, const struct timespec *tsb);
 
+/**
+ * \brief Return the number of pending events on the worker
+ *
+ * The returned number does not include the event that is
+ * currently handled by the application.
+ *
+ * \param w Worker
+ *
+ * \return A non-negative number. 0 means no pending events.
+ */
+int ev_pending(ev_worker_t w);
+
 #endif

--- a/lib/src/ovis_ev/ev.h
+++ b/lib/src/ovis_ev/ev.h
@@ -254,6 +254,14 @@ int ev_dispatch(ev_worker_t w, ev_type_t t, ev_actor_t fn);
 int ev_posted(ev_t ev);
 
 /**
+ * \brief Returns 1 if the event is canceled
+ *
+ * \retval 1 Event is canceled
+ * \retval 0 Event is not canceled
+ */
+int ev_canceled(ev_t ev);
+
+/**
 * \brief Compare two timespec values
 *
 * Compares two timespace values *tsa and *tsb and returns:

--- a/lib/src/ovis_ev/ev_priv.h
+++ b/lib/src/ovis_ev/ev_priv.h
@@ -48,6 +48,7 @@ struct ev_worker_s {
 	struct rbt w_event_tree;
 	/* A list of events without timeouts */
 	TAILQ_HEAD(w_event_list, ev__s) w_event_list;
+	int w_ev_list_len;
 };
 
 #define EV(_e_) container_of(_e_, struct ev__s, e_ev);


### PR DESCRIPTION
Logging to the log file becomes a performance bottleneck when a burst of
errors occur, especially on aggregators. We use event-driven programming
to get rid of the log file's lock. The ldmsd_log() function publishes an
event to a worker exclusively responsible for printing data to
the log file or the syslog. Thus, there is only one thread that accesses the log file.