### PR TITLE
Advertise LDMS set delete event to peers

### DIFF
--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -412,6 +412,7 @@ enum ldms_xprt_event_type {
 
 struct ldms_xprt_set_delete_data {
 	ldms_set_t set;		/*! The local set looked up at peer */
+	const char *name;	/*! The name of the set */
 };
 
 typedef struct ldms_xprt_event {

--- a/ldms/src/core/ldms_xprt.h
+++ b/ldms/src/core/ldms_xprt.h
@@ -76,21 +76,6 @@
  */
 typedef void (*ldms_set_delete_cb_t)(ldms_t xprt, int status, ldms_set_t set, void *cb_arg);
 
-/*
- * Notify a remote peers that this set is being deleted
- *
- * A remote peer is a client that has received a copy of this set via ldms_xprt_lookup.
- *
- * set   The set handle
- * cb_fn Pointer to the ldms_del_rem_set_cb function that will
- *       be called when the peer acknolwedges that receiept of
- *       this set delete request.
- * cb_arg void * argument to pass to the callback function
- */
-extern void ldms_xprt_set_delete(ldms_t x, ldms_set_t set,
-				 ldms_set_delete_cb_t cb_fn,
-				 void *cb_arg);
-
 /**
  * If set in the push_flags, the set changes will be automatically
  * pushed by ldms_transaction_end()
@@ -339,6 +324,7 @@ struct ldms_context {
 			ldms_set_t s;
 			ldms_set_delete_cb_t cb;
 			void *cb_arg;
+			int lookup;
 		} set_delete;
 	};
 	struct timespec start;

--- a/ldms/src/ldmsd/ldmsd_prdcr.c
+++ b/ldms/src/ldmsd/ldmsd_prdcr.c
@@ -512,13 +512,11 @@ static int __prdcr_subscribe(ldmsd_prdcr_t prdcr)
 	return rc;
 }
 
-static void __prdcr_remote_set_delete(ldmsd_prdcr_t prdcr, ldms_set_t set)
+static void __prdcr_remote_set_delete(ldmsd_prdcr_t prdcr, const char *name)
 {
 	const char *state_str = "bad_state";
 	ldmsd_prdcr_set_t prdcr_set;
-	if (!set)
-		return;
-	prdcr_set = ldmsd_prdcr_set_find(prdcr, ldms_set_instance_name_get(set));
+	prdcr_set = ldmsd_prdcr_set_find(prdcr, name);
 	pthread_mutex_lock(&prdcr_set->lock);
 	assert(prdcr_set->ref_count);
 	switch (prdcr_set->state) {
@@ -598,7 +596,7 @@ static void prdcr_connect_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 		ldmsd_recv_msg(x, e->data, e->data_len);
 		break;
 	case LDMS_XPRT_EVENT_SET_DELETE:
-		__prdcr_remote_set_delete(prdcr, e->set_delete.set);
+		__prdcr_remote_set_delete(prdcr, e->set_delete.name);
 		break;
 	case LDMS_XPRT_EVENT_REJECTED:
 		ldmsd_log(LDMSD_LERROR, "Producer %s rejected the "


### PR DESCRIPTION
Previously, LDMS advertised the set delete event only to peers that has
successfully looked up the set. In the case of quick set add-delete, the
peer will only get DIR ADD event but won't get LDMS set delete
notification because the lookup process has not completed in time. This
patch modifies LDMS so that it advertises set delete event to downstream
LDMS peers so that the peer can undo what it has done from DIR ADD
event.