### PR TITLE
store_csv: Add time_format option

### DIFF
--- a/ldms/man/Plugin_store_csv.man
+++ b/ldms/man/Plugin_store_csv.man
@@ -42,7 +42,7 @@ take on the value configured in the default config line or opt_file.
 .SH STORE_CSV CONFIGURATION ATTRIBUTE SYNTAX
 .TP
 .BR config
-name=<plugin_name> path=<path> [ altheader=<0/!0> typeheader=<typeformat> ietfcsv=<0/1> buffer=<0/1/N> buffertype=<3/4> rolltype=<rolltype> rollover=<rollover> userdata=<0/!0>] [rename_template=<metapath> [rename_uid=<int-uid> [rename_gid=<int-gid] rename_perm=<octal-mode>]] [create_uid=<int-uid>] [create_gid=<int-gid] [create_perm=<octal-mode>] [opt_file=filename] [ietfcsv=<0/1>] [typeheader=<0/1/2>]
+name=<plugin_name> path=<path> [ altheader=<0/!0> typeheader=<typeformat> time_format=<0/1> ietfcsv=<0/1> buffer=<0/1/N> buffertype=<3/4> rolltype=<rolltype> rollover=<rollover> userdata=<0/!0>] [rename_template=<metapath> [rename_uid=<int-uid> [rename_gid=<int-gid] rename_perm=<octal-mode>]] [create_uid=<int-uid>] [create_gid=<int-gid] [create_perm=<octal-mode>] [opt_file=filename] [ietfcsv=<0/1>] [typeheader=<0/1/2>]
 .br
 ldmsd_controller configuration line
 .RS
@@ -71,6 +71,17 @@ For example, if the metric file is named meminfo, the kind file is named meminfo
 meminfo.15111111, the kind file is named meminfo.KIND.15111111. The typeformat parameter is 0 (no kind file), 
 1 (ldms kinds with arrays flattend out into scalars), 2 (LDMS kinds with arrays). 
 The typeformat supporting arrays uses the notation <typename>[]<len> for extraction of lengths by scripting tools. The default typeformat is 0.
+.TP
+time_format=<0/1>
+Controls the format of the initial time fields in each line of the CSV files.
+
+A value of 0 means the classic LDMS format where the first field (Time) is <seconds since epoch>.<microseconds>, and the
+second field (Time_usec) is <microseconds> repeated.
+
+A value of 1 chooses an alternate format where the first field (Time_msec) is <milliseconds since epoch>, and the
+second field (Time_usec) is just the additional <microseconds> since the epoch in excess of the milliseconds since
+epoch. In other words, there is no overlap of the values in the first and seconds fields, which is in contrast to the
+repetition employed by format 0.
 .TP
 ietfcsv=<0/1>
 .br

--- a/ldms/src/store/store_csv_common.h
+++ b/ldms/src/store/store_csv_common.h
@@ -77,6 +77,7 @@
 	bool ietfcsv; \
 	int altheader; \
 	int typeheader; \
+	int time_format; \
 	int buffer_type; \
 	int buffer_sz; \
 	char *store_key; /* this is the container/schema */
@@ -225,7 +226,7 @@ void ch_output(FILE *f, const char *name,
  * \param metric_count length of metric_array.
  * \return 0 or errno value.
  */
-int csv_format_header_common(FILE *file, const char *fpath, const struct csv_store_handle_common *sh, int doudata, struct csv_plugin_static *cps, ldms_set_t set, int *metric_array, size_t metric_count);
+int csv_format_header_common(FILE *file, const char *fpath, const struct csv_store_handle_common *sh, int doudata, struct csv_plugin_static *cps, ldms_set_t set, int *metric_array, size_t metric_count, int time_format);
 
 /** Format a metric types line to a file given following the
  * metric_array indices and conventions of csv_format_common.
@@ -242,6 +243,7 @@ int csv_format_header_common(FILE *file, const char *fpath, const struct csv_sto
  * \param set data to manage output
  * \param metric_array list of indices to use from set.
  * \param metric_count length of metric_array.
+ * \param time_format 0 for traditional time format, 1 for alternate milliseconds-since-epoch time format
  * \return 0 or errno value.
  */
 extern int csv_format_types_common(int typeformat, FILE* f, const char *fpath, const struct csv_store_handle_common *sh, int doudata, struct csv_plugin_static *cps, ldms_set_t set, int *metric_array, size_t metric_count);
@@ -265,6 +267,7 @@ void print_csv_store_handle_common(struct csv_store_handle_common *s_handle, str
 	"ietfcsv", \
 	"altheader", \
 	"typeheader", \
+	"time_format", \
 	"buffer", \
 	"buffertype", \
 	"rename_template", \
@@ -281,6 +284,11 @@ void print_csv_store_handle_common(struct csv_store_handle_common *s_handle, str
 #define TH_ARRAY 2
 /** Maximum valid typeheader value */
 #define TH_MAX TH_ARRAY
+
+/* Time field format options */
+#define TF_CLASSIC 0
+#define TF_MILLISEC 1
+#define TF_MAX 1
 
 #define FILE_PROPS_USAGE \
 		"         - rename_template  The template string for closed output renaming.\n" \


### PR DESCRIPTION
The time format used by LDMS in CSV files can be a bit difficult to use in practice. A great many existing tools use milliseconds-since-epoch as an internal or natively understood time format (Kafka, Cassandra, Elasticsearch, etc.). This PR introduces a store_csv option that keeps the current time format as the default, but allows the use of and alternate time format (time_format=1), where:

A value of 1 chooses an alternate format where the first field (Time_msec) is <milliseconds since epoch>, and the
second field (Time_usec) is just the additional <microseconds> since the epoch in excess of the milliseconds since
epoch. In other words, there is no overlap of the values in the first and seconds fields, which is in contrast to the
repetition employed by format 0.