### PR TITLE
update csv test to include milli format

### DIFF
--- a/ldms/scripts/examples/conf_csv.1
+++ b/ldms/scripts/examples/conf_csv.1
@@ -32,7 +32,7 @@ strgp_start name=store_csv_procstat
 # and then remove it when the C api changes, or we can enforce instance=container/schema
 # internally until the store C api changes to pass the strgp name as instance name.
 config name=store_csv path=${STOREDIR} altheader=1 container=bigiron schema=vmstat
-config name=store_csv path=${STOREDIR} altheader=1 container=bigiron schema=clock
+config name=store_csv path=${STOREDIR} altheader=1 container=bigiron schema=clock time_format=1
 config name=store_csv path=${STOREDIR} altheader=1 container=bigiron schema=job_info
 
 strgp_add name=store_csv_vmstat plugin=store_csv schema=vmstat container=bigiron

--- a/ldms/scripts/examples/conf_csv.2
+++ b/ldms/scripts/examples/conf_csv.2
@@ -1,12 +1,12 @@
 load name=meminfo
 config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} job_set=localhost${i}/job_info
-start name=meminfo interval=1000000 offset=0
+start name=meminfo interval=1000000 offset=5000
 load name=vmstat
 config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} job_set=localhost${i}/job_info
-start name=vmstat interval=1000000 offset=0
+start name=vmstat interval=1000000 offset=5000
 load name=clock
 config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} job_set=localhost${i}/job_info
-start name=clock interval=1000000 offset=0
+start name=clock interval=1000000 offset=5000
 load name=procstat
 config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} job_set=localhost${i}/job_info
-start name=procstat interval=1000000 offset=0
+start name=procstat interval=1000000 offset=5000

--- a/ldms/scripts/examples/conf_csv.3
+++ b/ldms/scripts/examples/conf_csv.3
@@ -1,12 +1,12 @@
 load name=meminfo
 config name=meminfo producer=localhost${i} instance=localhost${i}/meminfo schema=meminfo component_id=${i} job_set=localhost${i}/job_info
-start name=meminfo interval=1000000 offset=0
+start name=meminfo interval=1000000 offset=20000
 load name=vmstat
 config name=vmstat producer=localhost${i} instance=localhost${i}/vmstat schema=vmstat component_id=${i} job_set=localhost${i}/job_info
-start name=vmstat interval=1000000 offset=0
+start name=vmstat interval=1000000 offset=20000
 load name=clock
 config name=clock producer=localhost${i} instance=localhost${i}/clock schema=clock component_id=${i} job_set=localhost${i}/job_info
-start name=clock interval=1000000 offset=0
+start name=clock interval=1000000 offset=20000
 load name=procstat
 config name=procstat producer=localhost${i} instance=localhost${i}/procstat schema=procstat component_id=${i} job_set=localhost${i}/job_info
-start name=procstat interval=1000000 offset=0
+start name=procstat interval=1000000 offset=20000


### PR DESCRIPTION
This adds enabling the milli format on some of the existing csv tests and shifts the test sampling offsets so that millis other than 0 are visible.

OVIS-4 with recent changes from @morrone works correctly with this test.