### PR TITLE
Fix ldms update never completed bug

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2203,15 +2203,23 @@ static void __handle_update_data(ldms_t x, struct ldms_context *ctxt,
 		goto cleanup;
 	}
 	n = __le32_to_cpu(set->meta->array_card);
-	/* update current index from the update */
+
 	data = __ldms_set_array_get(set, ctxt->update.idx_from);
+	prev_data = __ldms_set_array_get(set, set->curr_idx);
+
+	if (__ldms_data_ts_cmp(prev_data, data) >= 0) {
+		/* special case, no new data */
+		ctxt->update.cb(x, set, flags, ctxt->update.cb_arg);
+		goto cleanup;
+	}
+
+	/* update current index from the update */
 	upd_curr_idx = __le32_to_cpu(data->curr_idx);
 	for (i = 0; i < n; i++) {
 		data = __ldms_set_array_get(set, i);
 		data->curr_idx = upd_curr_idx;
 	}
 
-	prev_data = __ldms_set_array_get(set, set->curr_idx);
 	for (i = ctxt->update.idx_from;i <= ctxt->update.idx_to; i++) {
 		data = __ldms_set_array_get(set, i);
 		if (data != prev_data &&


### PR DESCRIPTION
When the ldms consumer (e.g. ldms_ls or agg) updated the looked-up set
before the producer (e.g. sampler) sampled a new data since previous
update, the consumer side won't get update complete callback at all.
What happened was that the zap_read completion was delivered but the
logic in ldms xprt detected that the data was old and didn't call update
complete. This patch modified the code to call the update callback in
the case of receiving the old data.