### PR TITLE
Fix ldms_xprt_sockaddr() calls to not assume ipv4 addresses

### DIFF
--- a/.github/workflows/4.3.3-compat-test.yaml
+++ b/.github/workflows/4.3.3-compat-test.yaml
@@ -42,7 +42,7 @@ jobs:
         set -e
         mkdir -p build
         pushd build
-        ../configure --prefix=/opt/ovis-4 --enable-etc
+        ../configure --prefix=/opt/ovis-4 --enable-etc --enable-munge
         make
         make install
     - name: test preparation
@@ -207,6 +207,111 @@ jobs:
         # ldms_ls to agg-4
         echo -n "ldms_ls ... "
         D1=$(./ldms_ls.sh -x sock -p 10002)
+        [[ -z "${D1}" ]] && echo "dir(agg-4) is empty (good)" || error "ERROR: dir(agg-4) is not empty"
+        kill ${AGG_433_PID}
+        kill ${AGG_4_PID}
+        kill ${LIST_SAMP_4_PID}
+        echo "DONE!"
+    - name: compatibility test with munge
+      if: ${{ success() }} # all previous steps are good
+      run: |
+        error() {
+          echo "ERROR:" $@
+          exit -1
+        }
+        ps_state() {
+          _PID=$1
+          if [[ -d /proc/${_PID} ]]; then
+            _STATE=$(cat /proc/${_PID}/stat | cut -f 3 -d ' ')
+            [[ ${_STATE} = "Z" ]] && echo "zombie" || echo "alive"
+          else
+            echo "dead"
+          fi
+        }
+        ps_check() {
+          local _NAME=$1
+          local _PID=$2
+          echo -n "Checking $_NAME ($_PID) ..."
+          local _S=$(ps_state $_PID)
+          echo "$_S"
+          [[ "$_S" = "alive" ]] || error "process $_NAME ($_PID) is not alive"
+        }
+        sudo -u munge munged
+        cd /test
+        # samp
+        echo "starting samp-4.3.3 w/munge"
+        ./ldmsd-4.3.3.sh -c samp-4.3.3.conf -l logs/samp-4.3.3.log -v INFO -x sock:10000 -a munge
+        # agg1
+        echo "starting agg-4.3.3 w/munge"
+        ./ldmsd-4.3.3.sh -c agg-4.3.3.conf -l logs/agg-4.3.3.log -v INFO -x sock:10001 -a munge
+        sleep 10
+        # agg2
+        echo "starting agg-4 w/munge"
+        ./ldmsd-4.sh -c agg-4.conf -l logs/agg-4.log -v INFO -x sock:10002 -a munge
+        sleep 10
+        # check that they're running
+        SAMP_433_PID=$(pgrep -f samp-4.3.3.conf)
+        AGG_433_PID=$(pgrep -f agg-4.3.3.conf)
+        AGG_4_PID=$(pgrep -f agg-4.conf)
+        echo "--- ldmsd's ---"
+        pgrep -a ldmsd
+        echo "---------------"
+        [[ -n "${SAMP_433_PID}" ]] || error "samp-4.3.3 is not running"
+        [[ -n "${AGG_433_PID}" ]] || error "agg-4.3.3 is not running"
+        [[ -n "${AGG_4_PID}" ]] || error "agg-4 is not running"
+        # ldms_ls-4 to agg-4.3.3
+        echo -n "ldms_ls agg-4.3.3 -a munge ... "
+        D0=$( ./ldms_ls.sh -x sock -p 10001 -a munge )
+        echo "result: ${D0}"
+        # ldms_ls-4 to agg-4
+        echo -n "ldms_ls agg-4 -a munge ... "
+        D1=$( ./ldms_ls.sh -x sock -p 10002 -a munge )
+        echo "result: ${D1}"
+        [[ "${D0}" = "ovis-4.3.3/meminfo" ]] || error "unexpected `ldms_ls agg-4.3.3` result"
+        [[ "${D1}" = "ovis-4.3.3/meminfo" ]] || error "unexpected `ldms_ls agg-4` result"
+        # ldms_ls-4.3.3 to agg-4
+        echo -n "ldms_ls(4.3.3) agg-4 -a munge ... "
+        D2=$( ./ldms_ls-4.3.3.sh -x sock -p 10002 -a munge )
+        echo "result: ${D2}"
+        [[ "${D2}" = "ovis-4.3.3/meminfo" ]] || error "unexpected `ldms_ls(4.3.3) agg-4` result"
+        # ldms_ls-4 to agg-4.3.3 -l
+        echo -n "ldms_ls -l agg-4.3.3 -a munge ... "
+        D0=$( ./ldms_ls.sh -l -x sock -p 10001 -a munge | grep MemTotal )
+        echo "${D0}"
+        [[ -n "${D0}" ]] || error "cannot get MemTotal from ldms_ls -l"
+        # ldms_ls-4 to agg-4 -l
+        echo -n "ldms_ls -l agg-4 -a munge ... "
+        D1=$( ./ldms_ls.sh -l -x sock -p 10002 -a munge | grep MemTotal )
+        echo "${D1}"
+        [[ -n "${D1}" ]] || error "cannot get MemTotal from ldms_ls -l"
+        # ldms_ls-4.3.3 to agg-4 -l
+        echo -n "ldms_ls-4.3.3 -l agg-4 -a munge ... "
+        D2=$( ./ldms_ls-4.3.3.sh -l -x sock -p 10002 -a munge | grep MemTotal )
+        echo "${D2}"
+        [[ -n "${D2}" ]] || error "cannot get MemTotal from ldms_ls -l"
+        # check if they're the same
+        [[ "${D0}" == "${D1}" ]] || error "agg-4.3.3 MemTotal != agg-4 MemTotal"
+        [[ "${D1}" == "${D2}" ]] || error "ldms_ls-4 MemTotal != ldms_ls-4.3.3 MemTotal"
+        # kill samp-4.3.3 so that the set disappeared from agg-4.3.3
+        echo "Killing samp-4.3.3"
+        kill ${SAMP_433_PID}
+        sleep 4
+        echo "--- ldmsd's ---"
+        pgrep -a ldmsd
+        echo "---------------"
+        echo "--- ldmsd's ---"
+        ps ax | grep ldmsd
+        echo "---------------"
+        # ldms_ls to agg-4.3.3
+        echo -n "ldms_ls agg-4.3.3 -a munge ... "
+        D0=$(./ldms_ls.sh -x sock -p 10001 -a munge )
+        [[ -z "${D0}" ]] && echo "dir(agg-4.3.3) is empty (good)" || error "ERROR: dir(agg-4.3.3) is not empty"
+        # check aggregators
+        ps_check agg-4.3.3 ${AGG_433_PID}
+        ps_check agg-4 ${AGG_4_PID}
+        # ldms_ls to agg-4
+        echo -n "ldms_ls agg-4 -a munge ... "
+        D1=$(./ldms_ls.sh -x sock -p 10002 -a munge )
         [[ -z "${D1}" ]] && echo "dir(agg-4) is empty (good)" || error "ERROR: dir(agg-4) is not empty"
         echo "DONE!"
     - name: enum compatibility check

--- a/ldms/src/auth/ldms_auth_munge.c
+++ b/ldms/src/auth/ldms_auth_munge.c
@@ -86,8 +86,8 @@ struct ldms_auth_munge {
 	struct ldms_auth base;
 	munge_ctx_t mctx;
 	char *local_cred;
-	struct sockaddr_in lsin;
-	struct sockaddr_in rsin;
+	struct sockaddr_storage lsin;
+	struct sockaddr_storage rsin;
 	socklen_t sin_len;
 };
 

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2748,9 +2748,9 @@ static void ldms_zap_cb(zap_ep_t zep, zap_event_t ev)
 		(void)clock_gettime(CLOCK_REALTIME, &x->stats.connected);
 		__sync_fetch_and_add(&xprt_connect_count, 1);
 		/* initialize/cache addr since connected */
-		struct sockaddr l, r;
-		socklen_t len;
-		ldms_xprt_sockaddr(x, &l, &r, &len);
+		struct sockaddr_storage l, r;
+		socklen_t len = sizeof(l);
+		ldms_xprt_sockaddr(x, (struct sockaddr *)&l, (struct sockaddr *)&r, &len);
 		/* actively connected -- expecting conn_msg */
 		if (0 != __ldms_conn_msg_verify(x, ev->data, ev->data_len,
 					   rej_msg, sizeof(rej_msg))) {

--- a/ldms/src/core/ldms_xprt.h
+++ b/ldms/src/core/ldms_xprt.h
@@ -397,11 +397,6 @@ struct ldms_xprt {
 	struct rbt set_coll;
 
 	LIST_ENTRY(ldms_xprt) xprt_link;
-
-	/* for addr caching */
-	socklen_t sa_len;
-	struct sockaddr_storage local_sa;
-	struct sockaddr_storage remote_sa;
 };
 
 void __ldms_xprt_term(struct ldms_xprt *x);


### PR DESCRIPTION
Also add compatibility test with munge authentication in github actions since the patch touches `ldms_auth_munge.c`