### PR TITLE
Fix log level checking bug

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -321,6 +321,10 @@ void __ldmsd_log(enum ldmsd_loglevel level, const char *fmt, va_list ap)
 	struct tm *tm;
 	time_t t;
 
+	if ((level != LDMSD_LALL) &&
+			(quiet || ((0 <= level) && (level < log_level_thr))))
+		return;
+
 	log_ev = ev_new(log_type);
 	if (!log_ev)
 		return;
@@ -352,10 +356,6 @@ void __ldmsd_log(enum ldmsd_loglevel level, const char *fmt, va_list ap)
 
 void ldmsd_log(enum ldmsd_loglevel level, const char *fmt, ...)
 {
-	if ((level != LDMSD_LALL) &&
-			(quiet || ((0 <= level) && (level < log_level_thr))))
-		return;
-
 	va_list ap;
 	va_start(ap, fmt);
 	__ldmsd_log(level, fmt, ap);


### PR DESCRIPTION
Log level was checked in `ldmsd_log()`. However, the true logging
function was `__ldmsd_log()`, and other convenient logging functions
(e.g. `ldmsd_linfo()`) call `__ldmsd_log()` directly without checking
the log level. This results in convenient functions such as
`ldmsd_linfo()` to be able to log messages even though the log level is
set to be higher (e.g. ERROR). This patch moved the log level checking
into `__ldmsd_log()` to solve the issue.