### PR TITLE
add conditional checks to autogen.sh enabling pre-commit hook

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -13,3 +13,9 @@ else
 	echo "this script for regenerating the ovis ldmsd. Cannot find ldms/."
 	exit 1
 fi
+
+if test -f .git/hooks/pre-commit.sample; then
+	if ! test -f .git/hooks/pre-commit; then
+		cp .git/hooks/pre-commit.sample .git/hooks/pre-commit
+	fi
+fi


### PR DESCRIPTION
Does nothing if there is already a pre-commit hook installed.
Enables the pre-commit.sample hook otherwise when git is present.
This makes our normal workflow (clone; ./autogen.sh) support
automatic trailing whitespace warnings at local commit instead
of at PR time.