### PR TITLE
Fix zap_ugni disconnection handling while receiving a socket message

### DIFF
--- a/lib/src/zap/ugni/zap_ugni.c
+++ b/lib/src/zap/ugni/zap_ugni.c
@@ -3820,6 +3820,10 @@ static void z_ugni_sock_recv(struct z_ugni_ep *uep)
 			/* Otherwise, read error */
 			goto err;
 		}
+		if (n == 0) {
+			errno = ECOMM;
+			goto err;
+		}
 		uep->sock_off += n;
 	}
 	mlen = ntohl(uep->sock_buff.hdr.msg_len);
@@ -3831,6 +3835,10 @@ static void z_ugni_sock_recv(struct z_ugni_ep *uep)
 			if (errno == EAGAIN) /* this is OK */
 				return;
 			/* Otherwise, read error */
+			goto err;
+		}
+		if (n == 0) {
+			errno = ECOMM;
 			goto err;
 		}
 		uep->sock_off += n;


### PR DESCRIPTION
`z_ugni_sock_recv()` did not handle the case that `read()` returns 0
(peer close) when receiving the first message on socket to setup the
GNI connection.