### PR TITLE
fix multiple -x handling and listener setup messages on ldmsd

### DIFF
--- a/ldms/man/ldmsd.man
+++ b/ldms/man/ldmsd.man
@@ -129,13 +129,15 @@ Display the usage for named plugin. Special names all, sampler, and store match 
 .SS
 Communication Options:
 .TP
-.BI -x " XPRT:PORT:HOST"
+.BI -x " XPRT:PORT[:HOST:AUTH:OPTS]"
 .br
-Specifies the transport type to listen on. May be specified more than once for
+Specifies a new transport to listen on. May be specified more than once for
 multiple transports. The XPRT string is one of 'rdma', 'sock', or 'ugni' (CRAY
 XE/XK/XC). A transport specific port number must be specified following a \':',
-e.g. rdma:10000. An optional host or address may be specified after the port,
-e.g. rdma:10000:node1-ib, to listen to a specific address.
+e.g. rdma:10000. An optional host or IPv4 address may be specified after the
+port, e.g. rdma:10000:node1-ib, to listen to a specific address. If not specified, localhost will be assumed.
+
+The authentication method may be optionally specified with AUTH, and the default method (settable with -a) will be used if it is not. Additional options specific to the authentication method may be optionally passed as OPTS, but only for the first explicit occurence of each method. Default values for the optional fields will be assumed when no space is left between colons. If OPTS requires multiple key=value pairs, they are separated by a colon rather than space.
 
 The listening transports can also be specified in the configuration file using
 \fBlisten\fR command, e.g. `listen xprt=sock port=1234 host=node1-ib`. Please see
@@ -261,9 +263,11 @@ None known.
 .SH EXAMPLES
 .PP
 .nf
-$/tmp/opt/ovis/sbin/ldmsd -x sock:60000 -p unix:/var/run/ldmsd/metric_socket -l /tmp/opt/ovis/logs/1
+$ ldmsd -x sock:60000 -p unix:/var/run/ldmsd/metric_socket -l /tmp/opt/ovis/logs/1
 .br
-$/tmp/opt/ovis/sbin/ldmsd -x sock:60000 -p sock:61000 -p unix:/var/runldmsd/metric_socket
+$ ldmsd -x sock:60000 -p sock:61000 -p unix:/var/runldmsd/metric_socket
+$ ldmsd -x sock:60000 -p sock:61000 -p unix:/var/runldmsd/metric_socket
+$ ldmsd -a munge -x sock:412 -x rdma:411:node-ib0:ovis:conf=/install/ldmsauth.conf -x sock:10411::ovis
 .fi
 
 

--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -578,15 +578,16 @@ void usage_hint(char *argv[],char *hint)
 	       "		   are DEBUG, INFO, ERROR, CRITICAL and QUIET.\n"
 	       "		   The default level is ERROR.\n");
 	printf("  Communication Options\n");
-	printf("    -x xprt:port:host\n"
+	printf("    -x xprt:port:host:auth\n"
 	       "		   Specifies the transport type to listen on. May be specified\n"
 	       "		   more than once for multiple transports. The transport string\n"
 	       "		   is one of 'rdma', 'sock', 'ugni', or 'fabric'.\n"
 	       "		   A transport specific port number is optionally specified\n"
 	       "		   following a ':', e.g. rdma:50000. Optional host name\n"
 	       "		   or address may be given after the port, e.g. rdma:10000:node1-ib,\n"
-	       "		   to listen to a specific address.\n");
-	printf("    -a AUTH        Transport authentication plugin (default: 'none')\n");
+	       "		   to listen to a specific address. Optional authentication method name\n"
+               "                   may be given after host, e.g. sock:::munge.\n");
+	printf("    -a AUTH        Transport authentication plugin when not specifed per listener (default: 'none')\n");
 	printf("    -A KEY=VALUE   Authentication plugin options (repeatable)\n");
 	printf("  Kernel Metric Options\n");
 	printf("    -k	     Publish kernel metrics.\n");
@@ -1677,18 +1678,39 @@ int ldmsd_listen_start(ldmsd_listen_t listen)
 	return rc;
 }
 
-static int __create_default_auth()
+static int __create_auth(const char *n, const char *pname, struct attr_value_list *opt)
 {
 	ldmsd_auth_t auth_dom;
 	int rc = 0;
-	auth_dom = ldmsd_auth_new_with_auth(DEFAULT_AUTH, auth_name, auth_opt,
+	auth_dom = ldmsd_auth_find(n);
+	char *sopt = av_to_string(opt, AV_EXPAND);
+	if (auth_dom) {
+		if (opt && opt->count) {
+			ldmsd_log(LDMSD_LERROR, "Repeated auth method %s"
+				" must not have options given again:%s.\n",
+				n, sopt);
+			free(sopt);
+			return E2BIG;
+		}
+		free(sopt);
+		return 0;
+	}
+	ldmsd_log(LDMSD_LINFO, "Configuring auth method %s with plugin %s "
+		"and options %s\n", n, pname, sopt ? sopt : "(none)");
+	free(sopt);
+	auth_dom = ldmsd_auth_new_with_auth(n, pname, opt,
 					geteuid(), getegid(), 0600);
 	if (!auth_dom) {
-		ldmsd_log(LDMSD_LCRITICAL, "Failed to set the default "
-				"authentication method, errno %d\n", errno);
+		ldmsd_log(LDMSD_LCRITICAL, "Failed to set the %s "
+			"authentication method, errno %d\n", n, errno);
 		rc = errno;
 	}
 	return rc;
+}
+
+static int __create_default_auth()
+{
+	return __create_auth(DEFAULT_AUTH, auth_name, auth_opt);
 }
 
 int main(int argc, char *argv[])
@@ -1853,7 +1875,7 @@ int main(int argc, char *argv[])
 			/* Listening port processing is handled below */
 			port = strchr(optarg, ':');
 			if (!port) {
-				printf("Bad xprt format, expecting XPRT:PORT, "
+				printf("Bad xprt format, expecting at least XPRT:PORT, "
 				       "but got: %s\n", optarg);
 				exit(1);
 			}
@@ -2110,12 +2132,13 @@ int main(int argc, char *argv[])
 				printf("out of memory parsing arguments\n");
 				return ENOMEM;
 			}
-			char *_xprt, *_port, *_host;
+			char *_xprt, *_port, *_host,
+				*_auth = NULL, *x_auth_opts = NULL;
 			_xprt = dup_xtuple;
 			_port = strchr(dup_xtuple, ':');
 			if (!_port) {
-				printf("Bad xprt format, expecting XPRT:PORT, "
-						"but got: %s\n", optarg);
+				printf("Bad xprt format, expecting at least "
+					"XPRT:PORT, but got: %s\n", optarg);
 				free(dup_xtuple);
 				return EINVAL;
 			}
@@ -2126,18 +2149,75 @@ int main(int argc, char *argv[])
 			if (_host) {
 				*_host = '\0';
 				_host++;
+				/* optional `auth` */
+				_auth = strchr(_host, ':');
+				if (_auth) {
+					*_auth = '\0';
+					_auth++;
+					/* optional `x_auth_opts` */
+					x_auth_opts = strchr(_auth, ':');
+					if (x_auth_opts) {
+						*x_auth_opts = '\0';
+						x_auth_opts++;
+					}
+				}
+				if (!strlen(_host)) {
+					_host = NULL;
+				}
+				if (!strlen(_auth)) {
+					_auth = NULL;
+				}
 			}
-			/* Use the default auth domain */
-			ldmsd_listen_t listen = ldmsd_listen_new(_xprt, _port, _host, DEFAULT_AUTH);
+			/* Use the default auth domain unless specified */
+			if (!_auth) {
+				_auth = DEFAULT_AUTH;
+			} else {
+				/* -x xprt:port:host:auth defines an auth
+				 * instance with name=plugin_name */
+				int xosize = 1;
+				if (x_auth_opts) {
+					/* extra : separated fields of
+					 * x=y convert to av list */
+					char *t = x_auth_opts;
+					while (t[0] != '\0') {
+						if (t[0] == ':') {
+							t[0] = ' ';
+							xosize++;
+						}
+						t++;
+					}
+				}
+				struct attr_value_list *xav = av_new(xosize);
+				struct attr_value_list *xkv = av_new(xosize);
+				if (x_auth_opts) {
+					tokenize(x_auth_opts, xkv, xav);
+				}
+				int xrc = __create_auth(_auth, _auth, xav);
+				av_free(xav);
+				av_free(xkv);
+				if (xrc) {
+					ldmsd_log(LDMSD_LERROR, "%s: failed to"
+						" add auth method %s\n",
+						STRERROR(xrc), _auth);
+					cleanup(13, "add auth on command-line "
+						"failed.");
+				}
+			}
+			ldmsd_log(LDMSD_LINFO, "main() Trying to listen on "
+				"%s:%s:%s:%s.\n", _xprt, _port,
+				_host ? _host : "NULL_HOST", _auth);
+			ldmsd_listen_t listen = ldmsd_listen_new(_xprt,
+							_port, _host, _auth );
 			free(dup_xtuple);
 			if (!listen) {
-				printf( "Error %d: failed to add listening "
-					"endpoint: %s:%s\n",
-					errno, optarg, rval);
-				cleanup(errno, "listen failed");
+				ldmsd_log(LDMSD_LERROR, "Error %s: failed to "
+					"add listening endpoint: %s\n",
+					STRERROR(errno), optarg);
+				cleanup(14, "listen failed");
 			}
 			if (myname[0] == '\0')
-				snprintf(myname, sizeof(myname), "%s:%s", myhostname, rval);
+				snprintf(myname, sizeof(myname), "%s:%s",
+					myhostname, rval);
 
 			break;
 		}
@@ -2156,8 +2236,8 @@ int main(int argc, char *argv[])
 			if (ret) {
 				char errstr[128];
 				snprintf(errstr, sizeof(errstr),
-					 "Error %d processing configuration file '%s'",
-					 ret, optarg);
+					"Error %d processing configuration "
+					"file '%s'", ret, optarg);
 				cleanup(ret, errstr);
 			}
 			ldmsd_log(LDMSD_LINFO, "Processing the config file '%s' is done.\n", optarg);


### PR DESCRIPTION
To make -x options handle multiple listeners independently, the optional fields in a listener specification are extended to:
XPRT:PORT[:[host]:[AUTH[:authopts]]]

Without this patch, all -x defined listeners are tied to the -a (default_auth) configuration.
Where the AUTH field is omitted, the default auth method (as possibly redefined with the -a argument) will be used.

Implementation: where AUTH is the name of an authentication plugin specified explicitly with -x, it will cause the equivalent of
```
auth_add name=AUTH plugin=AUTH 
```
with authopts also included if provided.

This enables listeners to be defined in the systemd service file (or elsewhere) such as:
```
ldmsd -x rdma:411:host-ib0:ovis:conf=/file -x sock:412::munge
```
so that a daemon can be started and listening without any input file needed to define listeners and authentications.