### PR TITLE
Support LDMSD cmd-line options in configuration files

### DIFF
--- a/ldms/examples/cmdline-opts/agg_cmdline_opts.conf
+++ b/ldms/examples/cmdline-opts/agg_cmdline_opts.conf
@@ -1,0 +1,22 @@
+# Set the default authentication
+option default_auth=munge
+
+# Set the log path and the loglevel to ERROR
+option log_file=/var/log/agg.log log_level=ERROR
+
+# Set various command-line options
+#   Set total set memory to 2GB
+#   Set the number of LDMSD workers to 16
+option set_memory=2gb worker_threads=16
+
+# Add a listen endpoint that uses the default authentication
+listen xprt=sock port=411
+
+# Additional authentication
+auth_add name=ovis plugin=ovis conf=/opt/ovis/etc/.ldmsauth.conf
+
+prdcr_add name=samplerd type=active xprt=sock port=411 host=nid00001 auth=ovis interval=1000000
+prdcr_start name=samplerd
+updtr_add name=all interval=1000000 offset=100000
+updtr_prdcr_add name=all regex=.*
+updtr_start name=all

--- a/ldms/examples/cmdline-opts/agg_cmdline_opts.conf
+++ b/ldms/examples/cmdline-opts/agg_cmdline_opts.conf
@@ -1,21 +1,21 @@
 # Set the default authentication
-option default_auth=munge
+option --default_auth munge
 
 # Set the log path and the loglevel to ERROR
-option log_file=/var/log/agg.log log_level=ERROR
+option --log_file /var/log/agg.log --log_level=ERROR
 
 # Set various command-line options
 #   Set total set memory to 2GB
 #   Set the number of LDMSD workers to 16
-option set_memory=2gb worker_threads=16
+option -m 2GB -P 16
 
 # Add a listen endpoint that uses the default authentication
-listen xprt=sock port=411
+listen xprt=sock port=10002
 
 # Additional authentication
 auth_add name=ovis plugin=ovis conf=/opt/ovis/etc/.ldmsauth.conf
 
-prdcr_add name=samplerd type=active xprt=sock port=411 host=nid00001 auth=ovis interval=1000000
+prdcr_add name=samplerd type=active xprt=sock port=10001 host=localhost auth=ovis interval=1000000
 prdcr_start name=samplerd
 updtr_add name=all interval=1000000 offset=100000
 updtr_prdcr_add name=all regex=.*

--- a/ldms/examples/cmdline-opts/sampler_cmdline_opts.conf
+++ b/ldms/examples/cmdline-opts/sampler_cmdline_opts.conf
@@ -1,0 +1,34 @@
+# Set the default authentication
+option default_auth=ovis default_auth_args=conf=/opt/ovis/etc/.ldmsauth.conf
+
+# Set the log path and the loglevel to ERROR
+option log_file=/var/log/ldmsd.log log_level=ERROR
+
+# Set various command-line options
+#   Set total set memory to 2GB
+#   Set the number of LDMSD workers to 16
+option set_memory=2gb worker_threads=16
+
+# Add additional authentication domains
+auth_add name=alt_ovis plugin=ovis conf=/opt/ovis/etc/.ldmsauth2.conf
+
+# Add a authentication domain that does not do any authentication
+auth_add name=none # If 'plugin' is given, 'name' is used.
+
+# Add a listen endpoint that uses the default authentication
+listen xprt=sock port=411
+
+# Add another listen endpoint that uses the alt_ovis
+listen xprt=sock port=412 auth=alt_ovis
+
+# Add another listen endpoint that uses 'none' auth
+listen xprt=sock port=413 auth=none
+
+# Set environment variables
+env SAMPLE_INTERVAL=1000000
+env SAMPLE_OFFSET=0
+
+# Other configurations
+load name=meminfo
+config name=meminfo producer=compute1 instance=compute1/meminfo
+start name=meminfo interval=${SAMPLE_INTERVAL} offset=${SAMPLE_OFFSET}

--- a/ldms/examples/cmdline-opts/sampler_cmdline_opts.conf
+++ b/ldms/examples/cmdline-opts/sampler_cmdline_opts.conf
@@ -1,13 +1,13 @@
 # Set the default authentication
-option default_auth=ovis default_auth_args=conf=/opt/ovis/etc/.ldmsauth.conf
+option -a ovis -A conf=/opt/ovis/etc/.ldmsauth.conf
 
 # Set the log path and the loglevel to ERROR
-option log_file=/var/log/ldmsd.log log_level=ERROR
+option -l /var/log/ldmsd.log -v ERROR
 
 # Set various command-line options
 #   Set total set memory to 2GB
 #   Set the number of LDMSD workers to 16
-option set_memory=2gb worker_threads=16
+option --set_memory 2gb --worker_threads 16
 
 # Add additional authentication domains
 auth_add name=alt_ovis plugin=ovis conf=/opt/ovis/etc/.ldmsauth2.conf
@@ -16,13 +16,13 @@ auth_add name=alt_ovis plugin=ovis conf=/opt/ovis/etc/.ldmsauth2.conf
 auth_add name=none # If 'plugin' is given, 'name' is used.
 
 # Add a listen endpoint that uses the default authentication
-listen xprt=sock port=411
+listen xprt=sock port=10001
 
 # Add another listen endpoint that uses the alt_ovis
-listen xprt=sock port=412 auth=alt_ovis
+listen xprt=sock port=10002 auth=alt_ovis
 
 # Add another listen endpoint that uses 'none' auth
-listen xprt=sock port=413 auth=none
+listen xprt=sock port=10003 auth=none
 
 # Set environment variables
 env SAMPLE_INTERVAL=1000000

--- a/ldms/man/ldmsd.man
+++ b/ldms/man/ldmsd.man
@@ -86,7 +86,7 @@ General/Configuration Options:
 .BR -F
 Run in foreground mode; don't daemonize the program. Default is false.
 .TP
-.BI -B " version-file-mode [0, 1, 2]"
+.BI "-B, --banner" " version-file-mode [0, 1, 2]"
 When run in daemon mode, controls the existence of the banner file.
 Mode 0 suppresses the version file. Mode 1 deletes it at daemon exit. Mode >= 2 leaves it in place for debugging after daemon exit. Default mode is 1.
 The banner contains the software and protocol versions information, which is also logged at the INFO level. The banner file name is always the pidfile name with .version appended.
@@ -105,7 +105,7 @@ deferred configuration objects will be started. Please also note that while
 failover service is in use, prdcr, updtr, and strgp cannot be altered (start,
 stop, or reconfigure) over in-band configuration.
 .TP
-.BI -m " MEMORY_SIZE"
+.BI "-m, --set_memory" " MEMORY_SIZE"
 .br
 MEMORY_SIZE is the maximum size of pre-allocated memory for metric sets.
 The given size must be less than 1 petabytes.
@@ -113,11 +113,11 @@ For example, 20M or 20mb are 20 megabytes. The default is adequate for most ldms
 For aggregating ldmsd, a rough estimate of preallocated memory needed is (Number of nodes aggregated) x (Number of metric sets per node) x 4k.
 Data sets containing arrays may require more. The estimate can be checked by enabling DEBUG logging and examining the mm_stat bytes_used+holes value at ldmsd exit.
 .TP
-.BI -n " NAME"
+.BI "-n, --daemon_name" " NAME"
 .br
 The name of the daemon. By default, it is "\fIHOSTNAME:PORT\fR". The failover feature uses the daemon name to verify the buddy name, and the producer name of kernel metric sets is the daemon name.
 .TP
-.BI -r " pid_file"
+.BI "-r, --pid_file" " pid_file"
 The path to the pid file and prefix of the .version banner file for daemon mode.
 .TP
 .BR -V
@@ -142,7 +142,7 @@ The listening transports can also be specified in the configuration file using
 \fBlisten\fR command, e.g. `listen xprt=sock port=1234 host=node1-ib`. Please see
 \fBldmsd_controller\fR(8) section \fBLISTEN COMMAND SYNTAX\fR for more details.
 .TP
-.BI -a " AUTH"
+.BI "-a, --default_auth" " AUTH"
 Specify the default LDMS Authentication method for the LDMS connections in this
 daemon (when the connections do not specify authentication method/domain).
 Please see \fBldms_authentication\fR(7) for more information. If this option is
@@ -150,7 +150,7 @@ not given, the default is "none" (no authentication). Also see
 \fBldmsd_controller\fR(8) section \fBAUTHENTICATION COMMAND SYNTAX\fR for how to
 define an authentication domain.
 .TP
-.BI -A " NAME" = VALUE
+.BI "-A, --default_auth_args" " NAME" = VALUE
 Passing the \fINAME\fR=\fIVALUE\fR option to the LDMS Authentication plugin.
 This command line option can be given multiple times. Please see
 \fBldms_authentication\fR(7) for more information, and consult the plugin manual
@@ -160,13 +160,13 @@ page for plugin-specific options.
 .SS
 Log Verbosity Options:
 .TP
-.BI -l " LOGFILE"
+.BI "-l, --log_file" " LOGFILE"
 .br
 LOGFILE is the path to the log file for status messages. Default is stdout unless given.
 The syslog facility is used if LOGFILE is exactly "syslog".
 Silence can be obtained by specifying /dev/null for the log file or using command line redirection as illustrated below.
 .TP
-.BI -v " LOG_LEVEL"
+.BI "-v, --log_level" " LOG_LEVEL"
 .br
 LOG_LEVEL can be one of DEBUG, INFO, ERROR, CRITICAL or QUIET.
 The default level is ERROR. QUIET produces only user-requested output.
@@ -178,15 +178,15 @@ Truncate the log file if it already exists.
 .SS
 Kernel Metric Options:
 .TP
-.BR -k
+.BR "-k, --publish_kernel"
 Publish kernel metrics.
 .TP
-.BI -s " SETFILE"
+.BI "-s, --kernel_set_file" " SETFILE"
 Text file containing kernel metric sets to publish. Default: /proc/sys/kldms/set_list
 
 .SS Thread Options:
 .TP
-.BI -P " THR_COUNT"
+.BI "-P, --worker_threads" " THR_COUNT"
 .br
 THR_COUNT is the number of event threads to start.
 
@@ -194,45 +194,31 @@ THR_COUNT is the number of event threads to start.
 .PP
 Users can use the 'option' command to specify some command-line options in a configuration file.
 .RS
-option ATTR=VALUE ...
+option <COMMAND-LINE OPTIONS>
 
 .SS Command-line options supported by the 'option' command and the corresponding attributes
 .TP
-.BI -a
-default_auth=<auth_method>
+.BI -a, --default_auth
 .TP
-.BI -A
-default_auth_args=<attribute-value pairs>
+.BI -A, --default_auth_args
 .TP
-.BI -B
-banner=<mode>
+.BI -B, --banner
 .TP
-.BI -H
-host_name=<name>
+.BI -k, --publish_kernel
 .TP
-.BI -k
-publish_kernel=<true|false>
+.BI -l, --log_file
+log_file=<pat
+.BI -m, --sett_memory
 .TP
-.BI -l
-log_file=<path>
+.BI -n, --daemon_name
 .TP
-.BI -m
-set_memory=<size>
+.BI -P, --worker_threads
 .TP
-.BI -n
-daemon_name=<name>
+.BI -r, --pid_file
 .TP
-.BI -P
-worker_threads=<num_threads>
+.BI -s, --kernel_set_path
 .TP
-.BI -r
-pid_file=<path>
-.TP
-.BI -s
-kernel_set_path=<path>
-.TP
-.BI -v
-log_level=<level>
+.BI -v, --log_level
 
 .SS Specifying the listen endpoints in configuraton files
 .TP
@@ -243,9 +229,9 @@ listen xprt=sock port=411
 > cat ldmsd.conf
 .nf
   # cmd-line options
-  option log_file=/opt/ovis/var/ldmsd.log
-  option set_memory=2GB worker_threads=16
-  option default_auth=munge
+  option --log_file /opt/ovis/var/ldmsd.log --log_level ERROR
+  option -m 2GB -P 16
+  option -a munge
   listen xprt=ugni port=411
   # meminfo
   load name=meminfo

--- a/ldms/man/ldmsd.man
+++ b/ldms/man/ldmsd.man
@@ -170,6 +170,9 @@ Silence can be obtained by specifying /dev/null for the log file or using comman
 LOG_LEVEL can be one of DEBUG, INFO, ERROR, CRITICAL or QUIET.
 The default level is ERROR. QUIET produces only user-requested output.
 (Note: this has changed from the previous release where q designated no (QUIET) logging).
+.TP
+.BR -t
+Truncate the log file if it already exists.
 
 .SS
 Kernel Metric Options:
@@ -179,53 +182,16 @@ Publish kernel metrics.
 .TP
 .BI -s " SETFILE"
 Text file containing kernel metric sets to publish. Default: /proc/sys/kldms/set_list
+.TP
+.BI -H " host_name"
+.br
+The host/producer name for test metric sets
 
 .SS Thread Options:
 .TP
 .BI -P " THR_COUNT"
 .br
 THR_COUNT is the number of event threads to start.
-.TP
-.BI -f " COUNT"
-.br
-COUNT is the number of flush threads.
-.TP
-.BI -D " NUM"
-.br
-NUM is the number of bytes of the dirty threshold used for store rollover.
-
-.SS Test Options:
-.TP
-.BI -H " host_name"
-.br
-The host/producer name for test metric sets
-.TP
-.BI -i " interval"
-.br
-Test metric set sample interval
-.TP
-.BI -t " count"
-.br
-Create set_count instances of set_name.
-.TP
-.BI -T " set_name"
-.br
-Test set prefix
-.TP
-.BR -N
-.br
-Notify registered monitors of the test metric sets.
-
-.SS Obsolete options:
-.TP
-.BI "-q -Z -z -S"
-.br
-These v2 options are no longer supported, and will cause exit with a hint.
-
-.TP
-.BI -p " XPRT" : (NAME|PORT)
-The configuration-only transports have been removed from \fBldmsd\fR v4 to
-leverage the pluggable authentication capability in LDMS transport.
 
 .SH SPECIFYING COMMAND-LINE OPTIONS IN CONFIGURATION FILES
 .PP

--- a/ldms/man/ldmsd.man
+++ b/ldms/man/ldmsd.man
@@ -227,6 +227,68 @@ These v2 options are no longer supported, and will cause exit with a hint.
 The configuration-only transports have been removed from \fBldmsd\fR v4 to
 leverage the pluggable authentication capability in LDMS transport.
 
+.SH SPECIFYING COMMAND-LINE OPTIONS IN CONFIGURATION FILES
+.PP
+Users can use the 'option' command to specify some command-line options in a configuration file.
+.RS
+option ATTR=VALUE ...
+
+.SS Command-line options supported by the 'option' command and the corresponding attributes
+.TP
+.BI -a
+default_auth=<auth_method>
+.TP
+.BI -A
+default_auth_args=<attribute-value pairs>
+.TP
+.BI -B
+banner=<mode>
+.TP
+.BI -H
+host_name=<name>
+.TP
+.BI -k
+publish_kernel=<true|false>
+.TP
+.BI -l
+log_file=<path>
+.TP
+.BI -m
+set_memory=<size>
+.TP
+.BI -n
+daemon_name=<name>
+.TP
+.BI -P
+worker_threads=<num_threads>
+.TP
+.BI -r
+pid_file=<path>
+.TP
+.BI -s
+kernel_set_path=<path>
+.TP
+.BI -v
+log_level=<level>
+
+.SS Specifying the listen endpoints in configuraton files
+.TP
+Users can use the 'listen' command to define the listen endpoints. For example,
+listen xprt=sock port=411
+
+.SS Example
+> cat ldmsd.conf
+.nf
+  # cmd-line options
+  option log_file=/opt/ovis/var/ldmsd.log
+  option set_memory=2GB worker_threads=16
+  option default_auth=munge
+  listen xprt=ugni port=411
+  # meminfo
+  load name=meminfo
+  config name=meminfo producer=nid0001 instance=nid0001/meminfo
+  start name=meminfo interval=1000000 offset=0
+
 .SH RUNNING LDMSD ON CRAY XE/XK/XC SYSTEMS USING APRUN
 .PP
 ldsmd can be run as either a user or as root using the appropriate PTag and cookie.

--- a/ldms/man/ldmsd.man
+++ b/ldms/man/ldmsd.man
@@ -114,7 +114,8 @@ For aggregating ldmsd, a rough estimate of preallocated memory needed is (Number
 Data sets containing arrays may require more. The estimate can be checked by enabling DEBUG logging and examining the mm_stat bytes_used+holes value at ldmsd exit.
 .TP
 .BI -n " NAME"
-The name of the daemon. By default, it is "\fIHOSTNAME:PORT\fR".
+.br
+The name of the daemon. By default, it is "\fIHOSTNAME:PORT\fR". The failover feature uses the daemon name to verify the buddy name, and the producer name of kernel metric sets is the daemon name.
 .TP
 .BI -r " pid_file"
 The path to the pid file and prefix of the .version banner file for daemon mode.
@@ -182,10 +183,6 @@ Publish kernel metrics.
 .TP
 .BI -s " SETFILE"
 Text file containing kernel metric sets to publish. Default: /proc/sys/kldms/set_list
-.TP
-.BI -H " host_name"
-.br
-The host/producer name for test metric sets
 
 .SS Thread Options:
 .TP

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1506,18 +1506,18 @@ class LdmsdCmdParser(cmd.Cmd):
         Specify the command-line options
 
         Parameters:
-            [defulat_auth_args=]    (-A) Arguments of the default authentication method
-            [default_auth=]         (-a) Default authentication method
-            [banner=]               (-B) Banner mode: 0=do banner file, 1=auto-delete at exit, 2=keep the file
-            [host_name=]            (-H) Host/producer name used by the kernel metric sets
-            [publish_kernel=]       (-k) Publish kernel: true or false
-            [log_file=]             (-l) Path to the log file or 'syslog'
-            [set_memory=]           (-m) Set memory, e.g., 2GB, 512mB
-            [daemon_name=]          (-n) Daemon name
-            [worker_threads=]       (-P) Number of worker threads
-            [pid_file=]             (-r) Path to the PID file
-            [kernel_set_path=]      (-s) Path to a text file containing the kernel metric values
-            [log_level=]            (-v) Log level: DEBUG, INFO, ERROR, CRITICAL, QUIET
+            -A, -- defulat_auth_args    Arguments of the default authentication method
+            -a, -- default_auth         Default authentication method
+            -B, --banner                Banner mode: 0=do banner file, 1=auto-delete at exit, 2=keep the file
+            -H, --host_name             Host/producer name used by the kernel metric sets
+            -k, --publish_kernel        Publish kernel: true or false
+            -l, --log_file              Path to the log file or 'syslog'
+            -m, --set_memory            Set memory, e.g., 2GB, 512mB
+            -n, --daemon_name           Daemon name
+            -P, --worker_threads        Number of worker threads
+            -r, --pid_file              Path to the PID file
+            -s, --kernel_set_path       Path to a text file containing the kernel metric values
+            -v, --log_level             Log level: DEBUG, INFO, ERROR, CRITICAL, QUIET
 
         Use 'listen' instead of the -x option.
 
@@ -1526,6 +1526,17 @@ class LdmsdCmdParser(cmd.Cmd):
             -F        Foreground mode
             -u        List named plugins
             -V        Print LDMS version
+
+        You would specify the command-line options as if you specify them at
+        the command line.
+
+        Examples:
+           # Specify a short option
+           option -a ovis
+           # Specify multiple short options
+           option -m 2GB -P 16
+           # Specify multiple long options
+           option --log_file /path/to/logfile --log_level ERROR
         """
         print("Not supported! The 'option' command is only supported in a configuration file.")
 

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1500,6 +1500,35 @@ class LdmsdCmdParser(cmd.Cmd):
     def complete_auth_add(self, text, line, begidx, endidx):
         return self.__complete_attr_list('auth_add', text)
 
+    def do_option(self, arg):
+        """
+        ONLY SUPPORTED IN CONFIGURATION FILES
+        Specify the command-line options
+
+        Parameters:
+            [defulat_auth_args=]    (-A) Arguments of the default authentication method
+            [default_auth=]         (-a) Default authentication method
+            [banner=]               (-B) Banner mode: 0=do banner file, 1=auto-delete at exit, 2=keep the file
+            [host_name=]            (-H) Host/producer name used by the kernel metric sets
+            [publish_kernel=]       (-k) Publish kernel: true or false
+            [log_file=]             (-l) Path to the log file or 'syslog'
+            [set_memory=]           (-m) Set memory, e.g., 2GB, 512mB
+            [daemon_name=]          (-n) Daemon name
+            [worker_threads=]       (-P) Number of worker threads
+            [pid_file=]             (-r) Path to the PID file
+            [kernel_set_path=]      (-s) Path to a text file containing the kernel metric values
+            [log_level=]            (-v) Log level: DEBUG, INFO, ERROR, CRITICAL, QUIET
+
+        Use 'listen' instead of the -x option.
+
+        The following options must specified only at the command line.
+            -c        Path to a configuration file
+            -F        Foreground mode
+            -u        List named plugins
+            -V        Print LDMS version
+        """
+        print("Not supported! The 'option' command is only supported in a configuration file.")
+
     def parseline(self, line):
         """Parse the line into a command name and a string containing
         the arguments.  Returns a tuple containing (command, args, line).

--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -588,53 +588,53 @@ void usage_hint(char *argv[],char *hint)
 {
 	printf("%s: [%s]\n", argv[0], short_opts);
 	printf("  General Options\n");
-	printf("    -F             Foreground mode, don't daemonize the program [false].\n");
-	printf("    -B mode        Daemon mode banner file with pidfile [1].\n"
-	       "                   modes:0-no banner file, 1-banner auto-deleted, 2-banner left.\n");
-	printf("    -u name        List named plugin if available, and where possible\n");
-	printf("                   its usage, then exit. Name all, sampler, and store limit output.\n");
-	printf("    -m memory size Maximum size of pre-allocated memory for metric sets.\n"
-	       "		   The given size must be less than 1 petabytes.\n"
-	       "		   The default value is %s\n"
-	       "		   For example, 20M or 20mb are 20 megabytes.\n"
-	       "		   - The environment variable %s could be set instead of\n"
-	       "		   giving the -m option. If both are given, the -m option\n"
-	       "		   takes precedence over the environment variable.\n",
-	       LDMSD_MEM_SIZE_STR, LDMSD_MEM_SIZE_ENV);
-	printf("    -n NAME        The name of the daemon. By default, it is \"HOSTNAME:PORT\".\n");
-	printf("                   The failover uses the daemon name to verify the buddy name.\n");
-	printf("                   The producer name of kernel metric sets is the daemon name.\n");
-	printf("    -r pid_file    The path to the pid file for daemon mode.\n"
-	       "		   [" LDMSD_PIDFILE_FMT "]\n",basename(argv[0]));
+	printf("    -F                                            Foreground mode, don't daemonize the program [false].\n");
+	printf("    -u name                                       List named plugin if available, and where possible\n");
+	printf("                                                  its usage, then exit. Name all, sampler, and store limit output.\n");
+	printf("    -B MODE,     --banner MODE                    Daemon mode banner file with pidfile [1].\n"
+	       "                                                  modes:0-no banner file, 1-banner auto-deleted, 2-banner left.\n");
+	printf("    -m SIZE,     --set_memory SIZE                Maximum size of pre-allocated memory for metric sets.\n"
+	       "                                                  The given size must be less than 1 petabytes.\n"
+	       "                                                  The default value is %s\n"
+	       "                                                  For example, 20M or 20mb are 20 megabytes.\n"
+	       "                                                  - The environment variable %s could be set instead of\n"
+	       "                                                  giving the -m option. If both are given, the -m option\n"
+	       "                                                  takes precedence over the environment variable.\n",
+	                                                          LDMSD_MEM_SIZE_STR, LDMSD_MEM_SIZE_ENV);
+	printf("    -n NAME,     --daemon_name NAME               The name of the daemon. By default, it is \"HOSTNAME:PORT\".\n");
+	printf("                                                  The failover uses the daemon name to verify the buddy name.\n");
+	printf("                                                  The producer name of kernel metric sets is the daemon name.\n");
+	printf("    -r PATH,     --pid_file PATH                  The path to the pid file for daemon mode.\n"
+	       "                                                  [" LDMSD_PIDFILE_FMT "]\n",basename(argv[0]));
 	printf("  Log Verbosity Options\n");
-	printf("    -l log_file    The path to the log file for status messages.\n"
-	       "		   [" LDMSD_LOGFILE "]\n");
-	printf("    -v level       The available verbosity levels, in order of decreasing verbosity,\n"
-	       "		   are DEBUG, INFO, ERROR, CRITICAL and QUIET.\n"
-	       "		   The default level is ERROR.\n");
-	printf("    -t             Truncate the log file at start if the log file exists.\n");
+	printf("    -l PATH,     --log_file PATH                  The path to the log file for status messages.\n"
+	       "                                                  [" LDMSD_LOGFILE "]\n");
+	printf("    -v LEVEL,    --log_level LEVEL                The available verbosity levels, in order of decreasing verbosity,\n"
+	       "                                                  are DEBUG, INFO, ERROR, CRITICAL and QUIET.\n"
+	       "                                                  The default level is ERROR.\n");
+	printf("    -t,          --log_truncate                   Truncate the log file at start if the log file exists.\n");
 	printf("  Communication Options\n");
 	printf("    -x xprt:port:host\n"
-	       "		   Specifies the transport type to listen on. May be specified\n"
-	       "		   more than once for multiple transports. The transport string\n"
-	       "		   is one of 'rdma', 'sock', 'ugni', or 'fabric'.\n"
-	       "		   A transport specific port number is optionally specified\n"
-	       "		   following a ':', e.g. rdma:50000. Optional host name\n"
-	       "		   or address may be given after the port, e.g. rdma:10000:node1-ib,\n"
-	       "		   to listen to a specific address.\n");
-	printf("    -a AUTH        Transport authentication plugin (default: 'none')\n");
-	printf("    -A KEY=VALUE   Authentication plugin options (repeatable)\n");
+	       "                                                  Specifies the transport type to listen on. May be specified\n"
+	       "                                                  more than once for multiple transports. The transport string\n"
+	       "                                                  is one of 'rdma', 'sock', 'ugni', or 'fabric'.\n"
+	       "                                                  A transport specific port number is optionally specified\n"
+	       "                                                  following a ':', e.g. rdma:50000. Optional host name\n"
+	       "                                                  or address may be given after the port, e.g. rdma:10000:node1-ib,\n"
+	       "                                                  to listen to a specific address.\n");
+	printf("    -a AUTH,      --default_auth AUTH             Transport authentication plugin (default: 'none')\n");
+	printf("    -A KEY=VALUE, --default_auth_args KEY=VALUE   Authentication plugin options (repeatable)\n");
 	printf("  Kernel Metric Options\n");
-	printf("    -k             Publish kernel metrics.\n");
-	printf("    -s setfile     Text file containing kernel metric sets to publish.\n"
-	       "                   [" LDMSD_SETFILE "]\n");
+	printf("    -k,           --publish_kernel                Publish kernel metrics.\n");
+	printf("    -s PATH,      --kernel_set_path PATH          Text file containing kernel metric sets to publish.\n"
+	       "                                                  [" LDMSD_SETFILE "]\n");
 	printf("  Thread Options\n");
-	printf("    -P thr_count   Count of event threads to start.\n");
+	printf("    -P COUNT,     --worker_threads COUNT          Count of event threads to start.\n");
 	printf("  Configuration Options\n");
-	printf("    -c path        The path to configuration file (optional, default: <none>).\n");
-	printf("    -V             Print LDMS version and exit.\n");
+	printf("    -c PATH                                       The path to configuration file (optional, default: <none>).\n");
+	printf("    -V                                            Print LDMS version and exit.\n");
 	printf("  Deprecated options\n");
-	printf("    -H             DEPRECATED.\n");
+	printf("    -H                                            DEPRECATED.\n");
 	if (hint) {
 		printf("\nHINT: %s\n",hint);
 	}

--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -96,7 +96,7 @@
 #define LDMSD_LOGFILE "/var/log/ldmsd.log"
 #define LDMSD_PIDFILE_FMT "/var/run/%s.pid"
 
-const char *short_opts = "B:H:l:S:s:x:I:M:P:m:Fkr:R:p:v:Vz:Z:q:c:u:a:A:n:t";
+const char *short_opts = "B:H:l:s:x:P:m:Fkr:v:Vc:u:a:A:n:t";
 
 struct option long_opts[] = {
 	{ "default_auth_args",     required_argument, 0,  'A' },
@@ -594,12 +594,11 @@ void usage_hint(char *argv[],char *hint)
 {
 	printf("%s: [%s]\n", argv[0], short_opts);
 	printf("  General Options\n");
-	printf("    -F	     Foreground mode, don't daemonize the program [false].\n");
-	printf("    -B mode  Daemon mode banner file with pidfile [1].\n"
-	       "   		modes:0-no banner file, 1-banner auto-deleted, 2-banner left.\n");
-	printf("    -u	name List named plugin if available, and where possible\n");
-	printf("       	its usage, then exit. Name all, sampler, and store limit output.\n");
-	printf("    -u	name List named plugin if available, and where possible their usage, then exit.\n");
+	printf("    -F             Foreground mode, don't daemonize the program [false].\n");
+	printf("    -B mode        Daemon mode banner file with pidfile [1].\n"
+	       "                   modes:0-no banner file, 1-banner auto-deleted, 2-banner left.\n");
+	printf("    -u name        List named plugin if available, and where possible\n");
+	printf("                   its usage, then exit. Name all, sampler, and store limit output.\n");
 	printf("    -m memory size Maximum size of pre-allocated memory for metric sets.\n"
 	       "		   The given size must be less than 1 petabytes.\n"
 	       "		   The default value is %s\n"
@@ -608,7 +607,7 @@ void usage_hint(char *argv[],char *hint)
 	       "		   giving the -m option. If both are given, the -m option\n"
 	       "		   takes precedence over the environment variable.\n",
 	       LDMSD_MEM_SIZE_STR, LDMSD_MEM_SIZE_ENV);
-	printf("    -n NAME        The name of the daemon. By default, it is \"IHOSTNAME:PORT\".");
+	printf("    -n NAME        The name of the daemon. By default, it is \"HOSTNAME:PORT\".\n");
 	printf("    -r pid_file    The path to the pid file for daemon mode.\n"
 	       "		   [" LDMSD_PIDFILE_FMT "]\n",basename(argv[0]));
 	printf("  Log Verbosity Options\n");
@@ -617,6 +616,7 @@ void usage_hint(char *argv[],char *hint)
 	printf("    -v level       The available verbosity levels, in order of decreasing verbosity,\n"
 	       "		   are DEBUG, INFO, ERROR, CRITICAL and QUIET.\n"
 	       "		   The default level is ERROR.\n");
+	printf("    -t             Truncate the log file at start if the log file exists.\n");
 	printf("  Communication Options\n");
 	printf("    -x xprt:port:host\n"
 	       "		   Specifies the transport type to listen on. May be specified\n"
@@ -629,20 +629,15 @@ void usage_hint(char *argv[],char *hint)
 	printf("    -a AUTH        Transport authentication plugin (default: 'none')\n");
 	printf("    -A KEY=VALUE   Authentication plugin options (repeatable)\n");
 	printf("  Kernel Metric Options\n");
-	printf("    -k	     Publish kernel metrics.\n");
+	printf("    -k             Publish kernel metrics.\n");
 	printf("    -s setfile     Text file containing kernel metric sets to publish.\n"
-	       "		   [" LDMSD_SETFILE "]\n");
+	       "                   [" LDMSD_SETFILE "]\n");
 	printf("  Thread Options\n");
 	printf("    -P thr_count   Count of event threads to start.\n");
-	printf("    -f count       The number of flush threads.\n");
-	printf("    -D num         The dirty threshold.\n");
 	printf("  Configuration Options\n");
 	printf("    -c path        The path to configuration file (optional, default: <none>).\n");
-	printf("    -V	     Print LDMS version and exit\n.");
+	printf("    -V             Print LDMS version and exit.\n");
 	printf("    -H host_name   The host/producer name for metric sets.\n");
-	printf("   Deprecated Options\n");
-	printf("    -S     	   DEPRECATED.\n");
-	printf("    -p     	   DEPRECATED.\n");
 	if (hint) {
 		printf("\nHINT: %s\n",hint);
 	}
@@ -2125,18 +2120,6 @@ int main(int argc, char *argv[])
 							ldmsd_version.flags);
 			printf("git-SHA: %s\n", OVIS_GIT_LONG);
 			exit(0);
-		case 'q':
-			usage_hint(argv,"-q becomes -v in LDMS v3. Update your scripts.\n"
-				"This message will disappear in a future release.");
-			break;
-		case 'z':
-			usage_hint(argv,"-z not available in LDMS v3.\n"
-				"This message will disappear in a future release.");
-			break;
-		case 'Z':
-			usage_hint(argv,"-Z not needed in LDMS v3. Remove it.\n"
-				"This message will disappear in a future release.");
-			break;
 		case 'c':
 			/* Handle below */
 			break;

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -1223,7 +1223,7 @@ typedef struct ldmsd_auth {
 
 /* Key (name) of the default auth -- intentionally including SPACE as it is not
  * allowed in user-defined names */
-#define DEFAULT_AUTH "auth_default"
+#define DEFAULT_AUTH "DEFAULT"
 
 ldmsd_auth_t
 ldmsd_auth_new_with_auth(const char *name, const char *plugin,
@@ -1246,4 +1246,13 @@ void ldmsd_timespec_diff(struct timespec *a, struct timespec *b, struct timespec
 
 void ldmsd_log_flush_interval_set(unsigned long interval);
 void ldmsd_flush_log();
+
+struct ldmsd_str_ent {
+	char *str;
+	TAILQ_ENTRY(ldmsd_str_ent) entry;
+};
+TAILQ_HEAD(ldmsd_str_list, ldmsd_str_ent);
+struct ldmsd_str_ent *ldmsd_str_ent_new(char *s);
+void ldmsd_str_ent_free(struct ldmsd_str_ent *ent);
+void ldmsd_str_list_destroy(struct ldmsd_str_list *list);
 #endif

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -5074,7 +5074,7 @@ static int __greeting_path_req_handler(ldmsd_req_ctxt_t reqc)
 	ldmsd_cfg_lock(LDMSD_CFGOBJ_PRDCR);
 	prdcr = ldmsd_prdcr_first();
 	ldmsd_cfg_unlock(LDMSD_CFGOBJ_PRDCR);;
-	char *myself = strdup(ldmsd_myhostname_get());
+	char *myself = strdup(ldmsd_myname_get());
 	if (!myself) {
 		ldmsd_log(LDMSD_LERROR, "Out of memory\n");
 		return ENOMEM;
@@ -5331,7 +5331,7 @@ size_t __set_route_json_get(int is_internal, ldmsd_req_ctxt_t reqc,
 					"\"trans_end_usec\":\"%ld\""
 					"}"
 				"}",
-				ldmsd_myhostname_get(),
+				ldmsd_myname_get(),
 				ldmsd_set_info_origin_enum2str(info->origin_type),
 				info->origin_name,
 				info->interval_us,
@@ -5362,7 +5362,7 @@ size_t __set_route_json_get(int is_internal, ldmsd_req_ctxt_t reqc,
 					"\"last_end_usec\":\"%ld\""
 					"}"
 				"}",
-				ldmsd_myhostname_get(),
+				ldmsd_myname_get(),
 				ldmsd_set_info_origin_enum2str(info->origin_type),
 				info->origin_name,
 				info->prd_set->prdcr->host_name,
@@ -5446,7 +5446,7 @@ static int set_route_handler(ldmsd_req_ctxt_t reqc)
 		/* The set does not exist. */
 		cnt = snprintf(reqc->line_buf, reqc->line_len,
 				"%s: Set '%s' not exist.",
-				ldmsd_myhostname_get(), inst_name);
+				ldmsd_myname_get(), inst_name);
 		(void) ldmsd_send_error_reply(reqc->xprt, reqc->key.msg_no, ENOENT,
 				reqc->line_buf, cnt + 1);
 		goto out;
@@ -5478,7 +5478,7 @@ static int set_route_handler(ldmsd_req_ctxt_t reqc)
 			reqc->errcode = rc;
 			cnt = snprintf(reqc->line_buf, reqc->line_len,
 					"%s: error forwarding set_route_request to "
-					"prdcr '%s'", ldmsd_myhostname_get(),
+					"prdcr '%s'", ldmsd_myname_get(),
 					info->origin_name);
 			ldmsd_send_req_response(reqc, reqc->line_buf);
 			goto err2;

--- a/ldms/src/ldmsd/ldmsd_request.h
+++ b/ldms/src/ldmsd/ldmsd_request.h
@@ -122,6 +122,7 @@ enum ldmsd_request {
 	LDMSD_SET_STATS_REQ,
 	LDMSD_LISTEN_REQ,
 	LDMSD_SET_DEFAULT_AUTHZ_REQ,
+	LDMSD_CMDLINE_OPTIONS_SET_REQ,
 
 	/* failover requests by user */
 	LDMSD_FAILOVER_CONFIG_REQ = 0x700, /* "failover_config" user command */

--- a/ldms/src/ldmsd/ldmsd_request_util.c
+++ b/ldms/src/ldmsd/ldmsd_request_util.c
@@ -85,6 +85,7 @@ const struct req_str_id req_str_id_table[] = {
 	{  "logrotate",          LDMSD_LOGROTATE_REQ  },
 	{  "metric_sets_default_authz", LDMSD_SET_DEFAULT_AUTHZ_REQ  },
 	{  "oneshot",            LDMSD_ONESHOT_REQ  },
+	{  "option",             LDMSD_CMDLINE_OPTIONS_SET_REQ  },
 	{  "plugn_sets",         LDMSD_PLUGN_SETS_REQ  },
 	{  "plugn_status",       LDMSD_PLUGN_STATUS_REQ  },
 	{  "prdcr_add",          LDMSD_PRDCR_ADD_REQ  },
@@ -270,6 +271,7 @@ const char *ldmsd_req_id2str(enum ldmsd_request req_id)
 	case LDMSD_EXIT_DAEMON_REQ       : return "EXIT_DAEMON_REQ";
 	case LDMSD_RECORD_LEN_ADVICE_REQ : return "RECORD_LEN_ADVICE_REQ";
 	case LDMSD_SET_ROUTE_REQ         : return "SET_ROUTE_REQ";
+	case LDMSD_CMDLINE_OPTIONS_SET_REQ : return "CMDLINE_OPTION_SET_REQ";
 
 	/* failover requests by user */
 	case LDMSD_FAILOVER_CONFIG_REQ        : return "FAILOVER_CONFIG_REQ";
@@ -710,6 +712,13 @@ out:
 	return rc;
 }
 
+int __ldmsd_parse_cmdline_req(struct ldmsd_parse_ctxt *ctxt)
+{
+	/* Treat the attribute string as a single STRING attribute value */
+	return add_attr_from_attr_str(NULL, ctxt->av,
+			&ctxt->request, &ctxt->request_sz, ctxt->msglog);
+}
+
 struct ldmsd_req_array *ldmsd_parse_config_str(const char *cfg, uint32_t msg_no,
 					size_t xprt_max_msg, ldmsd_msg_log_f msglog)
 {
@@ -777,6 +786,9 @@ struct ldmsd_req_array *ldmsd_parse_config_str(const char *cfg, uint32_t msg_no,
 		break;
 	case LDMSD_AUTH_ADD_REQ:
 		rc = __ldmsd_parse_auth_add_req(&ctxt);
+		break;
+	case LDMSD_CMDLINE_OPTIONS_SET_REQ:
+		rc = __ldmsd_parse_cmdline_req(&ctxt);
 		break;
 	default:
 		rc = __ldmsd_parse_generic(&ctxt);


### PR DESCRIPTION
To specify a cmd-line option in a configuration file, use the command
'option'. For example,

option l=/var/log/ldmsd.log v=INFO
option m=2gb

A configuration file example is at ldms/examples/cmdline-opts/ldmsd_w_cmdline_opts.conf.