### PR TITLE
Remove circular build dependency

### DIFF
--- a/ldms/scripts/Makefile.am
+++ b/ldms/scripts/Makefile.am
@@ -40,12 +40,6 @@ untestsets += uninstall-slurm
 bin_SCRIPTS += pll-ldms-static-test.sh
 endif
 
-ovis-roll-over.py: ${srcdir}/ovis-roll-over.py
-	cp ${srcdir}/ovis-roll-over.py .
-
-lsdate: ${srcdir}/lsdate
-	cp ${srcdir}/lsdate .
-
 install-data-local: $(testsets)
 
 install-serial:


### PR DESCRIPTION
The build system rightly complains about a circular build dependency:

  make[3]: Circular lsdate <- lsdate dependency dropped.
  make[3]: Circular ovis-roll-over.py <- ovis-roll-over.py dependency dropped.

Remove the manually created lsdate and ovis-roll-over.py targets
in favor of the normal listings in bin_SCRIPTS and EXTRA_DIST.