### PR TITLE
Add AUTH attribute to ID_NAME_MAP dict

### DIFF
--- a/ldms/python/ldmsd/ldmsd_request.py
+++ b/ldms/python/ldmsd/ldmsd_request.py
@@ -183,6 +183,7 @@ class LDMSD_Req_Attr(object):
                    GID : 'gid',
                    STREAM : 'stream',
                    RESET : 'reset',
+                   AUTH : 'auth',
                    LAST : 'TERMINATING'
         }
 


### PR DESCRIPTION
Fix bug where creation of a python LDMSD_Req_Attr object with "AUTH" attribute will fail