### PR TITLE
fix validations of interval/offset on updtr_start and uninit count leading to arbitrarily large calloc

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -6811,7 +6811,7 @@ static int cmd_line_arg_set_handler(ldmsd_req_ctxt_t reqc)
 	int rc = 0;
 	int argc;
 	char **argv = NULL;
-	int count;
+	int count = 0;
 
 	dummy = NULL;
 	s = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_STRING);

--- a/ldms/src/ldmsd/ldmsd_updtr.c
+++ b/ldms/src/ldmsd/ldmsd_updtr.c
@@ -1139,6 +1139,14 @@ int ldmsd_updtr_start(const char *updtr_name, const char *interval_str,
 		offset_us = strtol(offset_str, NULL, 0)
 					- updtr_sched_offset_skew_get();
 
+	if (interval_us < labs(offset_us) * 2) {
+		ldmsd_log(LDMSD_LERROR, "%s: The absolute value of the offset"
+			" value must not be larger than the half of "
+			"the update interval. (i=%ld, o=%ld)\n", "ldmsd_updtr_start",
+			interval_us, offset_us);
+		rc = EINVAL;
+		goto err;
+	}
 	/* Initialize the default task */
 	updtr_task_init(&updtr->default_task, updtr, 1, interval_us, offset_us);
 	ldmsd_updtr_unlock(updtr);


### PR DESCRIPTION
fixes ldmsd_request.c uninit variable that can lead to allocation failure and incomplete input validation that can lead to updtr start failure. The commits are split by topic.

in the updtr case, user can specify an invalid offset while defaulting the interval, so the half-range validation is needed in two places.