### PR TITLE
update build to support rocm 4.5 rdc device headers on gcc4-gcc8

### DIFF
--- a/ldms/src/sampler/rdc_sampler/Makefile.am
+++ b/ldms/src/sampler/rdc_sampler/Makefile.am
@@ -7,6 +7,14 @@ dist_man7_MANS =
 dist_man1_MANS =
 EXTRA_DIST =
 
+BUILT_SOURCES=rdc.h
+# at least for rocm 4.3 and 4.5, the rdc header is broken wrt gcc4 - gcc8
+# this patches it to a local copy.
+RDC_INC=$(subst -I,,$(RDC_CFLAGS))
+rdc.h: $(RDC_INC)/rdc/rdc.h
+	mkdir -p rdc
+	sed -e 's/^const uint32_t MAX_TEST_CASES =  RDC_DIAG_TEST_LAST - RDC_DIAG_TEST_FIRST + 1;/#define MAX_TEST_CASES (RDC_DIAG_TEST_LAST - RDC_DIAG_TEST_FIRST + 1)/' $(RDC_INC)/rdc/rdc.h > rdc/rdc.h
+
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
 COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \


### PR DESCRIPTION
working on reporting the issue upstream. With this patch, the sampler builds and works.