### PR TITLE
Add missing ldmsd_set_deregister() calls, plus other minor fixes

### DIFF
--- a/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
+++ b/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
@@ -241,12 +241,14 @@ static ldms_set_t gpu_metric_set_create(int gpu_id)
         ldms_set_producer_name_set(set, producer_name);
         ldms_metric_set_s32(set, gpu_id_metric_index, gpu_id);
         ldms_set_publish(set);
+        ldmsd_set_register(set, SAMP);
 
         return set;
 }
 
 static void gpu_metric_set_destroy(ldms_set_t set)
 {
+        ldmsd_set_deregister(ldms_set_instance_name_get(set), SAMP);
         ldms_set_unpublish(set);
         ldms_set_delete(set);
 }

--- a/ldms/src/sampler/lustre_client/lustre_client_general.c
+++ b/ldms/src/sampler/lustre_client/lustre_client_general.c
@@ -131,6 +131,7 @@ void llite_general_schema_fini()
 
 void llite_general_destroy(ldms_set_t set)
 {
+        ldmsd_set_deregister(ldms_set_instance_name_get(set), SAMP);
         ldms_set_unpublish(set);
         ldms_set_delete(set);
 }

--- a/ldms/src/sampler/lustre_mdt/lustre_mdt_general.c
+++ b/ldms/src/sampler/lustre_mdt/lustre_mdt_general.c
@@ -187,6 +187,7 @@ static void osd_sample(const char *osd_path, ldms_set_t general_metric_set)
 
 void mdt_general_destroy(ldms_set_t set)
 {
+        ldmsd_set_deregister(ldms_set_instance_name_get(set), SAMP);
         ldms_set_unpublish(set);
         ldms_set_delete(set);
 }

--- a/ldms/src/sampler/lustre_mdt/lustre_mdt_job_stats.c
+++ b/ldms/src/sampler/lustre_mdt/lustre_mdt_job_stats.c
@@ -150,6 +150,7 @@ static void mdt_job_stats_data_destroy(struct mdt_job_stats_data *job_stats)
 {
         log_fn(LDMSD_LDEBUG, SAMP" mdt_job_stats_data_destroy() jobid=%s\n",
                job_stats->jobid);
+        ldmsd_set_deregister(ldms_set_instance_name_get(job_stats->metric_set), SAMP);
         ldms_set_unpublish(job_stats->metric_set);
         ldms_set_delete(job_stats->metric_set);
         free(job_stats->jobid);

--- a/ldms/src/sampler/lustre_ost/lustre_ost_general.c
+++ b/ldms/src/sampler/lustre_ost/lustre_ost_general.c
@@ -186,6 +186,7 @@ static void osd_sample(const char *osd_path, ldms_set_t general_metric_set)
 
 void ost_general_destroy(ldms_set_t set)
 {
+        ldmsd_set_deregister(ldms_set_instance_name_get(set), SAMP);
         ldms_set_unpublish(set);
         ldms_set_delete(set);
 }

--- a/ldms/src/sampler/lustre_ost/lustre_ost_job_stats.c
+++ b/ldms/src/sampler/lustre_ost/lustre_ost_job_stats.c
@@ -143,6 +143,7 @@ static void ost_job_stats_data_destroy(struct ost_job_stats_data *job_stats)
 {
         log_fn(LDMSD_LDEBUG, SAMP" ost_job_stats_data_destroy() jobid=%s\n",
                job_stats->jobid);
+        ldmsd_set_deregister(ldms_set_instance_name_get(job_stats->metric_set), SAMP);
         ldms_set_unpublish(job_stats->metric_set);
         ldms_set_delete(job_stats->metric_set);
         free(job_stats->jobid);

--- a/ldms/src/sampler/papi/papi_sampler.c
+++ b/ldms/src/sampler/papi/papi_sampler.c
@@ -142,6 +142,7 @@ static void free_job_data(job_data_t jd)
 	job_task_t t;
 
 	if (jd->set) {
+		ldmsd_set_deregister(jd->instance_name, SAMP);
 		ldms_set_unpublish(jd->set);
 		ldms_set_delete(jd->set);
 	}

--- a/ldms/src/sampler/slurm/slurm_sampler.c
+++ b/ldms/src/sampler/slurm/slurm_sampler.c
@@ -980,8 +980,11 @@ static void term(struct ldmsd_plugin *self)
 	if (job_schema)
 		ldms_schema_delete(job_schema);
 	job_schema = NULL;
-	if (job_set)
+	if (job_set) {
+		ldmsd_set_deregister(ldms_set_instance_name_get(job_set), "slurm_sampler");
+		ldms_set_unpublish(job_set);
 		ldms_set_delete(job_set);
+	}
 	job_set = NULL;
 }
 


### PR DESCRIPTION
Add missing ldmsd_set_deregister() calls to several samplers, as mentioned in issue #860.

Additionally, add the missing ldms_set_unpublish() call to the slurm_sampler and add both ldmsd_set_register() and ldmsd_set_unregister() calls to the dcgm_sampler.