### PR TITLE
Make the 'env' command as a priority command

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -568,6 +568,7 @@ static struct request_handler_entry request_handler[] = {
 int is_req_id_priority(enum ldmsd_request req_id)
 {
 	switch (req_id) {
+	case LDMSD_ENV_REQ:
 	case LDMSD_VERBOSE_REQ:
 	case LDMSD_LISTEN_REQ:
 	case LDMSD_AUTH_ADD_REQ:


### PR DESCRIPTION
Without this change, LDMSD skips any ‘env’ commands preceding the priority
commands (option, listen, auth_add, and verbose) in a configuration file, so
name substitution in the priority commands results in an empty string. The
patch that supports the command-line options in configuration files (commit
001fb2 in PR826) introduced the bug.

Fixes #863