### PR TITLE
Change ibmad and dcgm sampler names to match new file name

### DIFF
--- a/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
+++ b/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
@@ -21,7 +21,7 @@
 
 #define _GNU_SOURCE
 
-#define SAMP "dcgm"
+#define SAMP "dcgm_sampler"
 
 static unsigned short default_fields[] = {
         DCGM_FI_DEV_GPU_TEMP,

--- a/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
+++ b/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
@@ -31,7 +31,7 @@
 
 #define _GNU_SOURCE
 
-#define SAMP "ibmad"
+#define SAMP "ibmad_sampler"
 
 /* So far I cannot find a header that defines these for us */
 #define PORT_STATE_ACTIVE 4


### PR DESCRIPTION
The new plugin names for ibmad and dcgm are ibmad_sampler
and dcgm_sampler, respectively. Symlinks to the previous
names still exist for the old names to aid transition.

Unfortunately, the API makes it such that only one of these
name (practically speaking) can have working metric
set hints. This can be addressed in the future in a new
plugin API.

We make the plugins report the same name as the new
plugin file name. The plugins probably aren't in too
wide use yet, so we err on the side of making this
work for future users.