### PR TITLE
fix bugs in  auth arg  and instance name handling for genders-based configuration

### DIFF
--- a/util/sample_init_scripts/genders/man/ldms-attributes.man
+++ b/util/sample_init_scripts/genders/man/ldms-attributes.man
@@ -32,6 +32,9 @@ ldmsd_producer=PROD     Defines the producer name reported in ldms data
 ldmsd_port=P            Defines the port number for the data server.
 ldmsd_xprt=X            Defines protocol for data server connections.
                         Typically, one of sock, rdma, ugni.
+ldmsd_auth=X            Defines authentication for data server connections.
+                        Typically, munge or ovis. 'none' is insecure.
+                        Defaults to munge.
 ldmsd_use_unix_socket=V If the value of V is "yes", a unix socket for
                         daemon control will be opened.
 ldmsd_sockpath          Defines the full filename of the unix socket.

--- a/util/sample_init_scripts/genders/man/ldmsd-genders.man
+++ b/util/sample_init_scripts/genders/man/ldmsd-genders.man
@@ -81,6 +81,7 @@ If VERBOSE is defined as "-v", additional messages will be logged from the init 
 
 .B LDMS_AUTH_TYPE=type
 
+If set, overrides the gender ldmsd_auth, defining the authentication plugin default set on the command line.
 This variable defines the type of authentication to use. The supported types are 'ovis' (the v3 secretword file) and 'munge'. See ldms_authentication(7) for details.
 
 .B LDMS_AUTH_FILE=filename

--- a/util/sample_init_scripts/genders/src/ldmsctl_args3.cxx
+++ b/util/sample_init_scripts/genders/src/ldmsctl_args3.cxx
@@ -92,6 +92,7 @@ public:
 	string retry;	// ldmsaggd_conn_retry
 	string host;	// ldms[agg]d_host
 	string xprt;	// ldms[agg]d_xprt
+	string auth;	// ldms[agg]d_auth
 	string port;	// ldms[agg]d_port
 	string interval;// ldms[aggd]_interval_default
 	string offset; 	// ldms[aggd]_offset_default
@@ -323,6 +324,7 @@ public:
 		string ports = "ldmsd_port";
 		string hosts = "ldmsd_host";
 		string xprts = "ldmsd_xprt";
+		string auths = "ldmsd_auth";
 		string producer = prefix + "_producer";
 		string retry = prefix + "_conn_retry";
 		string intervals = prefix + "_interval_default";
@@ -355,6 +357,9 @@ public:
 			t.producer = host;
 		} else {
 			gender_substitute(host, t.producer);
+		}
+		if (! has_property(host, auths, t.auth, true) ) {
+			t.auth = "munge";
 		}
 		if (! has_property(host, xprts, t.xprt, true) ) {
 			t.xprt = "sock";
@@ -503,6 +508,7 @@ private:
 				oss << " host=" << t.host;
 				oss << " type=active";
 				oss << " xprt=" << t.xprt;
+				oss << " auth=" << t.auth;
 				oss << " port=" << t.port;
 				oss << " interval=" << t.retry;
 				oss << endl;
@@ -610,6 +616,7 @@ public:
 						oss << " host=" << t.host;
 						oss << " type=active";
 						oss << " xprt=" << t.xprt;
+						oss << " auth=" << t.auth;
 						oss << " port=" << t.port;
 						oss << " interval=" << t.retry;
 						oss << endl;
@@ -633,7 +640,7 @@ public:
 			oss << "updtr_prdcr_add name=all_" << hostname;
 			oss << " regex=" << ".*";
 			oss << endl;
-			oss << "updtr_start name=all_" << hostname;
+			oss << "updtr_start auto_interval=true name=all_" << hostname;
 			adds.push_back(oss.str());
 		}
 	}

--- a/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ldms-functions.in
+++ b/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ldms-functions.in
@@ -105,7 +105,7 @@ check_auth_option () {
 			if ! test -f $LDMS_AUTH_FILE; then
 				echoq "LDMS_AUTH_FILE $LDMS_AUTH_FILE not found"
 			fi
-			LDMS_AUTH_ARGS="conf=$LDMS_AUTH_FILE"
+			LDMS_AUTH_ARGS="-A conf=$LDMS_AUTH_FILE"
 		fi
 		;;
 	xmunge)
@@ -119,7 +119,7 @@ check_auth_option () {
 			if ! test -S $LDMS_AUTH_FILE; then
 				echoq "LDMS_AUTH_FILE $LDMS_AUTH_FILE is not a socket as needed by munge"
 			fi
-			LDMS_AUTH_ARGS="socket=$LDMS_AUTH_FILE"
+			LDMS_AUTH_ARGS="-A socket=$LDMS_AUTH_FILE"
 
 		fi
 		;;
@@ -667,6 +667,9 @@ start_ldmsd_plugins () {
 			else
 				instance=${producer}/${pi}
 			fi
+			if echo "$extraconfig" |grep instance=; then
+				instance=$(echo $extraconfig|sed -e 's/.*instance=//g' -e  's/ .*//g')
+			fi > /dev/null
 		fi
 
 		# plugin options from per-plugin plain text file

--- a/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ldms-functions.in
+++ b/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ldms-functions.in
@@ -92,6 +92,12 @@ check_log_option () {
 
 # check consistency of auth variables.
 check_auth_option () {
+	if test -z "$LDMS_AUTH_TYPE"; then
+		LDMS_AUTH_TYPE=$($NODEATTR $NODEATTRFILE -v $host ldmsd_auth 2>/dev/null)
+		if test -z $LDMS_AUTH_TYPE; then
+			LDMS_AUTH_TYPE=munge
+		fi
+	fi
 	LDMS_AUTH_ARGS=""
 	case x$LDMS_AUTH_TYPE in
 	xovis)
@@ -182,7 +188,7 @@ check_genders_file() {
 	renamed="ldmsaggd_stores:ldmsd_store_plugins ldmsd_metric_sets:ldmsd_metric_plugins ldmsaggd_store_csv:ldmsd_store_csv ldmsaggd_conn_thds:ldmsd_event_thds"
 	# common typos in prefixes here
 	prefixtypo="ldmsd_schema_:ldmsd_schemas_ ldmsd_exclude_schema_:ldmsd_exclude_schemas_ ldms_:ldmsd_ ldmsd_metric_plugin$:ldmsd_metric_plugins"
-	commatypo="chkmeminfo clock cray_power_sampler dstat fptrans lnet_stats job_info jobid meminfo perfevent procdiskstats procinterrupts procnetdev procnfs procsensors procstat sampler_atasmart sysclassib vmstat store_csvdbg lustre2_client lustre2_mds lustre2_oss store_csv store_rabbitv3 store_flatfile store_sos"
+	commatypo="chkmeminfo clock cray_power_sampler dstat fptrans lnet_stats job_info jobid meminfo perfevent procdiskstats procinterrupts procnetdev procnfs procsensors procstat sampler_atasmart sysclassib vmstat store_csvdbg lustre2_client lustre2_mds lustre2_oss store_csv store_rabbitv3 store_flatfile store_sos lustre_client linux_proc_sampler"
 	attrtypo="scheme:schema"
 	n=0
 	v=""


### PR DESCRIPTION
-A must be included in the command line when an auth_ovis conf or auth_munge socket option is included in the configuration and the default instance name must be overridden if instance is included in the user-defined configuration. 