### PR TITLE
Make __destroy_set_no_lock() only reset contexts related to the set

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -760,23 +760,22 @@ static void __destroy_set_no_lock(void *v)
 		 */
 		pthread_mutex_lock(&x->lock);
 		TAILQ_FOREACH(ctxt, &x->ctxt_list, link) {
-			ctxt = TAILQ_FIRST(&x->ctxt_list);
 			switch (ctxt->type) {
 			case LDMS_CONTEXT_LOOKUP_READ:
-				if (ctxt->lu_read.s)
+				if (ctxt->lu_read.s == set)
 					ctxt->lu_read.s = NULL;
 				break;
 			case LDMS_CONTEXT_UPDATE:
 			case LDMS_CONTEXT_UPDATE_META:
-				if (ctxt->update.s)
+				if (ctxt->update.s == set)
 					ctxt->update.s = NULL;
 				break;
 			case LDMS_CONTEXT_REQ_NOTIFY:
-				if (ctxt->req_notify.s)
+				if (ctxt->req_notify.s == set)
 					ctxt->req_notify.s = NULL;
 				break;
 			case LDMS_CONTEXT_SET_DELETE:
-				if (ctxt->set_delete.s)
+				if (ctxt->set_delete.s == set)
 					ctxt->set_delete.s = NULL;
 				break;
 			default:


### PR DESCRIPTION
The commit fbf21b7 made __destroy_set_no_lock() to reset the set handle
in all transport contexts in the transport's list to NULL, including the
contexts that point to other sets. It breaks the link between the
transport and the other sets. A result is that the transport won't put
back the other sets' references when destroying corresponding contexts.