### PR TITLE
Fix SIGABRT due to invalid heap access

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -2642,6 +2642,8 @@ ldms_mval_t ldms_list_first(ldms_set_t s, ldms_mval_t lh, enum ldms_value_type *
 	ldms_mval_t le;
 	if (!lh->v_lh.head)
 		return NULL;
+	if (!s->heap)
+		return NULL;
 	le = ldms_heap_ptr(s->heap, lh->v_lh.head);
 	if (typ)
 		*typ = le->v_le.type;

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2273,7 +2273,10 @@ static void __handle_update_data(ldms_t x, struct ldms_context *ctxt,
 		}
 		if (set->meta->heap_sz) {
 			base = ((void*)set->data) + set->data->size - set->meta->heap_sz;
-			set->heap = ldms_heap_get(&set->heap_inst, &set->data->heap, base);
+			if (ldms_set_is_consistent(set))
+				set->heap = ldms_heap_get(&set->heap_inst, &set->data->heap, base);
+			else
+				set->heap = NULL;
 		}
 		ctxt->update.cb(x, set, flags, ctxt->update.cb_arg);
 		prev_data = data;


### PR DESCRIPTION
When the set update completed with "inconsistent" state, the heap is in
an invalid state and should not be accessed.

In particular, consider the case of `SAMP -> AGG_L1 -> ldms_ls`. SAMP
has a sampler that uses `LDMS_V_LIST`. AGG_L1 has finished looking up
the set from SAMP, and is in the middle of updating it. At this point,
the metadata on AGG_L1 has been populated, but the data+heap parts are
still uninitialized. In the mean time, `ldms_ls` lookup + update the set
and get SIGABRT from `ldms_heap_get()` due to bad heap signature because
of the uninitialized data+heap part on the AGG_L1 that `ldms_ls` copied
the data from.

This patch:
- adds set consistency check before getting the heap in the LDMS set
  update path.
- adds heap pointer check in the `ldms_list_first()` list/heap access.