### PR TITLE
fix build for boost-dependence when not in /usr

### DIFF
--- a/util/sample_init_scripts/genders/src/Makefile.am
+++ b/util/sample_init_scripts/genders/src/Makefile.am
@@ -1,13 +1,14 @@
 
 AM_CFLAGS = \
 "-DLDMS_SRCDIR=\"$(abs_top_srcdir)\"" \
-"-DLDMS_BUILDDIR=\"$(abs_top_builddir)\""
+"-DLDMS_BUILDDIR=\"$(abs_top_builddir)\"" \
+$(BOOST_CPPFLAGS)
 
 if ENABLE_LIBGENDERS
 bin_PROGRAMS = ldmsctl_args3
 ldmsctl_args3_SOURCES = ldmsctl_args3.cxx
 ldmsctl_args3_LDADD = -lgendersplusplus -lboost_program_options -lboost_regex
-ldmsctl_args3_LDFLAGS = $(AM_LDFLAGS) @LIBGENDERS_LIBDIR_FLAG@ @LIBGENDERS_LIB64DIR_FLAG@
+ldmsctl_args3_LDFLAGS = $(AM_LDFLAGS) @LIBGENDERS_LIBDIR_FLAG@ @LIBGENDERS_LIB64DIR_FLAG@ -L$(BOOST_ROOT)/lib
 ldmsctl_args3_CPPFLAGS = $(AM_CFLAGS) @LIBGENDERS_INCDIR_FLAG@
 endif
 


### PR DESCRIPTION
This fixes makefile.am insufficiency when boost is not installed with prefix /usr. Affects only the c++ genders config file processor.