### PR TITLE
Update workflows to use the current runs-on and containers

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -8,10 +8,13 @@ on:
 jobs:
   build:
     name: Create Release
+    # Make sure that test-make-dist.yaml has the same "runs-on" and
+    # "container" as used here.
     runs-on: ubuntu-20.04
+    container:
+        image: ovishpc/ovis-ubuntu-build
 
     steps:
-    - run: sudo apt install gettext
     - uses: actions/checkout@v2
     # actions/checkout@v2 breaks annotated tags by converting them into
     # lightweight tags, so we need to force fetch the tag again

--- a/.github/workflows/test-make-dist.yaml
+++ b/.github/workflows/test-make-dist.yaml
@@ -8,11 +8,13 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-18.04
+    # Make sure that create-release.yaml has the same "runs-on" and
+    # "container" as used here.
+    runs-on: ubuntu-20.04
+    container:
+        image: ovishpc/ovis-ubuntu-build
 
     steps:
-    - run: sudo apt install gettext
     - uses: actions/checkout@v2
     - name: autogen
       run: sh autogen.sh


### PR DESCRIPTION
Update the create-release.yaml and test-make-dist.yaml workflows
to use the same runs-on (Ubuntu-20.04) and container
(ovishpc/ovis-ubuntu-build) as used elsewhere. Keeping these two
files in sync should help to avoid surprise problems at release
time.