### PR TITLE
Bug fix for ldmsd_listen_new error handling

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -1643,7 +1643,6 @@ ldmsd_listen_t ldmsd_listen_new(char *xprt, char *port, char *host, char *auth)
 				getuid(), getgid(), 0550); /* No one can alter it */
 	free(name);
 	if (!listen) {
-		errno = ENOMEM;
 		return NULL;
 	}
 


### PR DESCRIPTION
Fix error where ldmsd hardcodes error to ENOMEM if
ldmsd_listen_new fails to create listen object