### PR TITLE
Fix `include` ldmsd config command

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -573,6 +573,7 @@ int is_req_id_priority(enum ldmsd_request req_id)
 	case LDMSD_LISTEN_REQ:
 	case LDMSD_AUTH_ADD_REQ:
 	case LDMSD_CMDLINE_OPTIONS_SET_REQ:
+	case LDMSD_INCLUDE_REQ:
 		return 1;
 	default:
 		return 0;


### PR DESCRIPTION
The `include path=FILE` ldmsd config command was supposed to be in the
priority command list so that it is processed in the first scan.