### PR TITLE
fix lingering references to share/doc/ovis-ldms-VERSION

### DIFF
--- a/ldms/scripts/ldms-static-test.sh.in
+++ b/ldms/scripts/ldms-static-test.sh.in
@@ -20,7 +20,7 @@ fi
 export pkglibdir=${ovis_ldms_pkglibdir}
 export PACKAGE_TARNAME=ovis-ldms
 export docdir=${ovis_ldms_datarootdir}/doc/${PACKAGE_TARNAME}
-export exdir=${ovis_ldms_datarootdir}/doc/${PACKAGE_TARNAME}-@VERSION@
+export exdir=$docdir
 
 if test -z "$ZAP_LIBPATH"; then
 	ZAP_LIBPATH=$ovis_ldms_plugins

--- a/ldms/scripts/pll-ldms-static-test.sh.in
+++ b/ldms/scripts/pll-ldms-static-test.sh.in
@@ -26,7 +26,7 @@ fi
 export pkglibdir=${ovis_ldms_pkglibdir}
 export PACKAGE_TARNAME=ovis-ldms
 export docdir=${ovis_ldms_datarootdir}/doc/${PACKAGE_TARNAME}
-export exdir=${ovis_ldms_datarootdir}/doc/${PACKAGE_TARNAME}-@VERSION@
+export exdir=$docdir
 
 if test -z "$ZAP_LIBPATH"; then
 	ZAP_LIBPATH=$ovis_ldms_plugins


### PR DESCRIPTION
this fixes two test drivers that reference share/doc/ovis-ldms that were overlooked in fixing the build files to install under ovis-ldms instead of ovis-ldms-version