### PR TITLE
Fix udata formatting in ldms_ls

### DIFF
--- a/ldms/src/ldmsd/ldms_ls.c
+++ b/ldms/src/ldmsd/ldms_ls.c
@@ -395,7 +395,7 @@ void metric_printer(ldms_set_t s, int i)
 	       (ldms_metric_flags_get(s, i) & LDMS_MDESC_F_DATA ? 'D' : 'M'),
 	       ldms_metric_type_to_str(type), metname);
 	if (user_data)
-		printf("%#" PRIx64, ldms_metric_user_data_get(s,i));
+		printf("0x%" PRIx64 " ", ldms_metric_user_data_get(s,i));
 
 	value_printer(s, i);
 	if (metunit)


### PR DESCRIPTION
This patch addresses 2 issues with `ldms_ls -lu` print format:
1. Missing a " " after udata print, making the udata output globbed
   together with the metric data.

2. When metric `udata` is 0, the format `"%#"PRIx64` ("%#lx") does not
   print '0x0'. It instead printed just single '0'.

This patch explicitly print the prefix '0x' follows by plain hex print
format without the prefix and a space ( `"0x%" PRIx64 " "` ).