### PR TITLE
Add include/exclude/rate options, fix producer and rate computations

### DIFF
--- a/ldms/scripts/examples/.canned
+++ b/ldms/scripts/examples/.canned
@@ -8,6 +8,7 @@ array_example
 blob_writer
 clock
 lnet_stats
+ibmad_sampler
 meminfo
 procdiskstats
 procinterrupts

--- a/ldms/scripts/examples/ibmad_sampler
+++ b/ldms/scripts/examples/ibmad_sampler
@@ -1,0 +1,12 @@
+export plugname=ibmad_sampler
+portbase=61060
+DAEMONS 1 2 3
+LDMSD 3
+SLEEP 1
+LDMSD 1  2
+LDMS_LS 1 -l
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2 -lv
+SLEEP 5
+KILL_LDMSD 1 2 3
+file_created $STOREDIR/node/$testname

--- a/ldms/scripts/examples/ibmad_sampler.1
+++ b/ldms/scripts/examples/ibmad_sampler.1
@@ -1,0 +1,3 @@
+load name=${testname}
+config name=${testname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} exclude=mlx5_0.2,mlx5_0 rate=1
+start name=${testname} interval=1000000 offset=0

--- a/ldms/scripts/examples/ibmad_sampler.2
+++ b/ldms/scripts/examples/ibmad_sampler.2
@@ -1,0 +1,3 @@
+load name=${testname}
+config name=${testname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} include=hfi1_0.1 rate=1
+start name=${testname} interval=1000000 offset=0

--- a/ldms/scripts/examples/ibmad_sampler.3
+++ b/ldms/scripts/examples/ibmad_sampler.3
@@ -1,0 +1,16 @@
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_start name=localhost1
+
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=2000000
+prdcr_start name=localhost2
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+strgp_add name=store_${testname} plugin=store_csv schema=${testname} container=node
+strgp_prdcr_add name=store_${testname} regex=.*
+strgp_start name=store_${testname}

--- a/ldms/src/sampler/ibmad_sampler/Plugin_ibmad_sampler.man
+++ b/ldms/src/sampler/ibmad_sampler/Plugin_ibmad_sampler.man
@@ -12,7 +12,7 @@ config name=ibmad_sampler [ <attr>=<value> ]
 With LDMS (Lightweight Distributed Metric Service), plugins for the ldmsd (ldms daemon) are configured via ldmsd_controller
 or a configuration file. The ibmad_sampler plugin provides a metric set for each infiniband port discovered on the node.
 
-The schema is named "ibmad" by default.
+The schema is named "ibmad_sampler" by default.
 
 NOTE: This plugin will not currently work with virtual IB devices.
 
@@ -31,16 +31,50 @@ This MUST be ibmad_sampler.
 .TP
 schema=<schema_name>
 .br
-The schema name defaults to "ibmad", but it can be renamed at the
+The schema name defaults to "ibmad_sampler", but it can be renamed at the
 user's choice.
+
+.TP
+rate=0
+.br
+Stop the default inclusion of rate values in the set.
 .TP
 job_set=<metric set name>
 .br
 The name of the metric set that contains the job id information (default=job_id)
+.TP
+include=PORTLIST
+.br
+Ignore any devices and ports discovered that are not matched by PORTLIST. See PORTLIST below.
+Cannot be combined with the exclude option.
+.TP
+exclude=PORTLIST
+.br
+Collect all devices and ports discovered and active that are not matched by PORTLIST. See PORTLIST below.
+Cannot be combined with the include option.
 .RE
+
+.SH PORTLIST
+Providing a port list specification will stop the automated
+discovery process at every sample time from requerying devices and ports
+that are not of interest, eliminating
+nuisance log messages from the MAD libraries. Such messages are frequently seen
+on systems using SocketDirect hardware.
+
+The port list is a comma-separated list of CA name and optionally number. E.g.
+"mlx4_0.1,mlx4_1". A device name specified without a port number (.N) matches all
+ports on that device. The maximum port number supported for a single device is 63.
+Including a device or port which does not exist or is not active in the port list
+has no effect on the metric sets reported.
 
 .SH BUGS
 No known bugs.
+
+.SH NOTES
+The rates reported are computed from the last sample taken and the present sample; however
+the last sample may not have been stored downstream and the sample interval size may
+vary due to kernel wakeup variations. Rate values are set to -1 for samples where the
+rate computation is invalid.
 
 .SH EXAMPLES
 .PP
@@ -51,5 +85,17 @@ config name=ibmad_sampler
 start name=ibmad_sampler interval=1000000
 .fi
 
+.nf
+load name=ibmad_sampler
+config name=ibmad_sampler include=hfi1_0.1 rate=0
+start name=ibmad_sampler interval=1000000
+.fi
+
+.nf
+load name=ibmad_sampler
+config name=ibmad_sampler exclude=mlx5_0.2,mlx5_0.3,mlx5_0.4,
+start name=ibmad_sampler interval=1000000
+.fi
+
 .SH SEE ALSO
-ldmsd(8), ldms_quickstart(7), ldmsd_controller(8), ldms_sampler_base(7)
+ldmsd(8), ldms_quickstart(7), ldmsd_controller(8)


### PR DESCRIPTION
Updated man page and added check driver.

The include/exclude options allow admins to indicate ports of interest
and prevent queries at every sample which generate nuisance log messages
from mad libraries.
The rate option allows admins to suppress redundant data when desired.
The producer option is now used to set the producer metadata.
The rate computation now returns -1 when the rate computed is
invalid for any reason; this permits plots of the rate metrics
to work with standard tools which may otherwise detect large
spurious values that mis-scale the plot axis.