### PR TITLE
fix compid, producer, log level in lustre dynamic plugins

### DIFF
--- a/ldms/src/sampler/lustre_client/lustre_client.c
+++ b/ldms/src/sampler/lustre_client/lustre_client.c
@@ -177,7 +177,7 @@ static void llites_refresh()
            here. */
         dir = opendir(llite_path);
         if (dir == NULL) {
-                log_fn(LDMSD_LWARNING, SAMP" unable to open llite dir %s\n",
+                log_fn(LDMSD_LDEBUG, SAMP" unable to open llite dir %s\n",
                        llite_path);
                 return;
         }

--- a/ldms/src/sampler/lustre_mdt/Makefile.am
+++ b/ldms/src/sampler/lustre_mdt/Makefile.am
@@ -8,7 +8,8 @@ liblustre_mdt_la_SOURCES = \
 liblustre_mdt_la_LIBADD = \
 	$(top_builddir)/ldms/src/core/libldms.la \
 	$(top_builddir)/lib/src/coll/libcoll.la \
-        $(top_builddir)/ldms/src/sampler/libjobid_helper.la
+	$(top_builddir)/ldms/src/sampler/libldms_compid_helper.la
+
 liblustre_mdt_la_LDFLAGS = \
 	-no-undefined \
         -export-symbols-regex 'get_plugin' \

--- a/ldms/src/sampler/lustre_mdt/Plugin_lustre_mdt.man
+++ b/ldms/src/sampler/lustre_mdt/Plugin_lustre_mdt.man
@@ -31,7 +31,7 @@ This plugin should work with at least Lustre versions 2.8, 2.10, and 2.12.
 
 .TP
 .BR config
-name=<plugin_name>
+name=<plugin_name> [producer=<name>] [component_id=<u64>]
 .br
 configuration line
 .RS
@@ -39,6 +39,15 @@ configuration line
 name=<plugin_name>
 .br
 This MUST be lustre_mdt.
+.TP
+producer=<alternate host name>
+.br
+The default used for producer (if not provided) is the result of gethostname().
+The set instance names will be $producer/$mdt_name.
+.TP
+component_id=<uint64_t>
+.br
+Optional (defaults to 0) number of the host where the sampler is running. All sets on a host will have the same value.
 .RE
 
 .SH BUGS

--- a/ldms/src/sampler/lustre_mdt/lustre_mdt_general.h
+++ b/ldms/src/sampler/lustre_mdt/lustre_mdt_general.h
@@ -9,12 +9,13 @@
 
 #include "ldms.h"
 #include "ldmsd.h"
+#include "comp_id_helper.h"
 
 int mdt_general_schema_is_initialized();
-int mdt_general_schema_init();
+int mdt_general_schema_init(const comp_id_t cid);
 void mdt_general_schema_fini();
 ldms_set_t mdt_general_create(const char *producer_name, const char *fs_name,
-                              const char *mdt_name);
+                              const char *mdt_name, const comp_id_t cid);
 char *mdt_general_osd_path_find(const char *search_path, const char *mdt_name);
 void mdt_general_sample(const char *mdt_name, const char *stats_path,
                         const char *osd_path, ldms_set_t general_metric_set);

--- a/ldms/src/sampler/lustre_ost/Makefile.am
+++ b/ldms/src/sampler/lustre_ost/Makefile.am
@@ -8,7 +8,8 @@ liblustre_ost_la_SOURCES = \
 liblustre_ost_la_LIBADD = \
 	$(top_builddir)/ldms/src/core/libldms.la \
 	$(top_builddir)/lib/src/coll/libcoll.la \
-        $(top_builddir)/ldms/src/sampler/libjobid_helper.la
+	$(top_builddir)/ldms/src/sampler/libldms_compid_helper.la
+
 liblustre_ost_la_LDFLAGS = \
 	-no-undefined \
         -export-symbols-regex 'get_plugin' \

--- a/ldms/src/sampler/lustre_ost/Plugin_lustre_ost.man
+++ b/ldms/src/sampler/lustre_ost/Plugin_lustre_ost.man
@@ -31,7 +31,7 @@ This plugin should work with at least Lustre versions 2.8, 2.10, and 2.12.
 
 .TP
 .BR config
-name=<plugin_name>
+name=<plugin_name> [producer=<name>] [component_id=<u64>]
 .br
 configuration line
 .RS
@@ -39,6 +39,15 @@ configuration line
 name=<plugin_name>
 .br
 This MUST be lustre_ost.
+.TP
+producer=<alternate host name>
+.br
+The default used for producer (if not provided) is the result of gethostname().
+The set instance names will be $producer/$ost_name.
+.TP
+component_id=<uint64_t>
+.br
+Optional (defaults to 0) number of the host where the sampler is running. All sets on a host will have the same value.
 .RE
 
 .SH BUGS

--- a/ldms/src/sampler/lustre_ost/lustre_ost.c
+++ b/ldms/src/sampler/lustre_ost/lustre_ost.c
@@ -22,6 +22,8 @@
 #define OBDFILTER_PATH "/proc/fs/lustre/obdfilter"
 #define OSD_SEARCH_PATH "/proc/fs/lustre"
 
+static struct comp_id_data cid;
+
 ldmsd_msg_log_f log_fn;
 char producer_name[LDMS_PRODUCER_NAME_MAX];
 
@@ -79,7 +81,7 @@ static struct ost_data *ost_create(const char *ost_name, const char *basedir)
                        ost->fs_name);
                 goto out7;
         }
-        ost->general_metric_set = ost_general_create(producer_name, ost->fs_name, ost->name);
+        ost->general_metric_set = ost_general_create(producer_name, ost->fs_name, ost->name, &cid);
         if (ost->general_metric_set == NULL)
                 goto out7;
         ost->osd_path = ost_general_osd_path_find(OSD_SEARCH_PATH, ost->name);
@@ -150,7 +152,7 @@ static void osts_refresh()
 
         dir = opendir(OBDFILTER_PATH);
         if (dir == NULL) {
-                log_fn(LDMSD_LWARNING, SAMP" unable to open obdfilter dir %s\n",
+                log_fn(LDMSD_LDEBUG, SAMP" unable to open obdfilter dir %s\n",
                        OBDFILTER_PATH);
                 return;
         }
@@ -205,6 +207,16 @@ static int config(struct ldmsd_plugin *self,
                   struct attr_value_list *kwl, struct attr_value_list *avl)
 {
         log_fn(LDMSD_LDEBUG, SAMP" config() called\n");
+	char *ival = av_value(avl, "producer");
+	if (ival) {
+		if (strlen(ival) < sizeof(producer_name)) {
+			strncpy(producer_name, ival, sizeof(producer_name));
+		} else {
+                        log_fn(LDMSD_LERROR, SAMP": config: producer name too long.\n");
+                        return EINVAL;
+		}
+	}
+	comp_id_helper_config(avl, &cid);
         return 0;
 }
 
@@ -212,7 +224,7 @@ static int sample(struct ldmsd_sampler *self)
 {
         log_fn(LDMSD_LDEBUG, SAMP" sample() called\n");
         if (ost_general_schema_is_initialized() < 0) {
-                if (ost_general_schema_init() < 0) {
+                if (ost_general_schema_init(&cid) < 0) {
                         log_fn(LDMSD_LERROR, SAMP" general schema create failed\n");
                         return ENOMEM;
                 }

--- a/ldms/src/sampler/lustre_ost/lustre_ost_general.h
+++ b/ldms/src/sampler/lustre_ost/lustre_ost_general.h
@@ -9,12 +9,13 @@
 
 #include "ldms.h"
 #include "ldmsd.h"
+#include "comp_id_helper.h"
 
 int ost_general_schema_is_initialized();
-int ost_general_schema_init();
+int ost_general_schema_init(const comp_id_t cid);
 void ost_general_schema_fini();
 ldms_set_t ost_general_create(const char *producer_name, const char *fs_name,
-                              const char *ost_name);
+                              const char *ost_name, const comp_id_t cid);
 char *ost_general_osd_path_find(const char *search_path, const char *ost_name);
 void ost_general_sample(const char *ost_name, const char *stats_path,
                         const char *osd_path, ldms_set_t general_metric_set);


### PR DESCRIPTION
reduced log level to 'debug' for checks of the top directory
that will be missing when each lustre service is off (an expected condition
in some deployments).

added component_id and producer option processing from attributes
for consistency with other plugins and updated man pages.

for mdt,ost which do not run on compute nodes, leaving out jobid metric.