### PR TITLE
Fix ldmsd name issues & terminate ldmsd if no listening xprt

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -2339,6 +2339,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* Process configuration files */
+	int has_config_file = 0;
 	opterr = 0;
 	optind = 0;
 	while ((op = getopt_long(argc, argv, short_opts, long_opts, &op_idx)) != -1) {
@@ -2346,6 +2347,7 @@ int main(int argc, char *argv[])
 		int lln = -1;
 		switch (op) {
 		case 'c':
+			has_config_file = 1;
 			dup_arg = strdup(optarg);
 			ret = process_config_file(dup_arg, &lln, 1);
 			free(dup_arg);
@@ -2379,6 +2381,15 @@ int main(int argc, char *argv[])
 		}
 		ldmsd_linfo("Enabling in-band config\n");
 		ldmsd_inband_cfg_mask_add(0777);
+	}
+
+	/* Check for at least a listening port */
+	struct ldmsd_listen *_listen;
+	_listen = (ldmsd_listen_t) ldmsd_cfgobj_first(LDMSD_CFGOBJ_LISTEN);
+	if (!_listen && !has_config_file) {
+		ldmsd_log(LDMSD_LCRITICAL,
+			"No config files nor listening ports are given ... exiting\n");
+		cleanup(101, "no config files nor listening ports");
 	}
 
 	/* Keep the process alive */

--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -2388,7 +2388,8 @@ int main(int argc, char *argv[])
 	_listen = (ldmsd_listen_t) ldmsd_cfgobj_first(LDMSD_CFGOBJ_LISTEN);
 	if (!_listen && !has_config_file) {
 		ldmsd_log(LDMSD_LCRITICAL,
-			"No config files nor listening ports are given ... exiting\n");
+			"A config file (-c) or listening port (-x) is required."
+			" Specify at least one of these. ... exiting\n");
 		cleanup(101, "no config files nor listening ports");
 	}
 

--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -2208,16 +2208,6 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	if (myname[0] == '\0') {
-		struct ldmsd_listen *listen;
-		ret = gethostname(myhostname, sizeof(myhostname));
-		if (ret)
-			myhostname[0] = '\0';
-		listen = (ldmsd_listen_t)ldmsd_cfgobj_first(LDMSD_CFGOBJ_LISTEN);
-		snprintf(myname, sizeof(myname), "%s:%d",
-				myhostname, listen->port_no);
-	}
-
 	if (!foreground) {
 		/* Create pidfile for daemon that usually goes away on exit. */
 		/* user arg, then env, then default to get pidfile name */

--- a/ldms/src/ldmsd/ldmsd_failover.c
+++ b/ldms/src/ldmsd/ldmsd_failover.c
@@ -1614,6 +1614,15 @@ int failover_config_handler(ldmsd_req_ctxt_t req)
 	peer_name = __req_attr_gets(req, LDMSD_ATTR_PEER_NAME);
 	timeout_factor = __req_attr_gets(req, LDMSD_ATTR_TIMEOUT_FACTOR);
 
+	/* Check for at least a listening port */
+	struct ldmsd_listen *_listen;
+	_listen = (ldmsd_listen_t) ldmsd_cfgobj_first(LDMSD_CFGOBJ_LISTEN);
+	if (!_listen) {
+		rc = EINVAL;
+		errmsg = "ldmsd_failover requires at least one listening port";
+		goto out;
+	}
+
 	__failover_lock(f);
 	if (f->state != FAILOVER_STATE_STOP) {
 		rc = EBUSY;

--- a/ldms/src/ldmsd/ldmsd_failover.c
+++ b/ldms/src/ldmsd/ldmsd_failover.c
@@ -1591,6 +1591,7 @@ int failover_config_handler(ldmsd_req_ctxt_t req)
 	char *auto_switch;
 	char *interval;
 	char *peer_name;
+	const char *myname;
 	char *timeout_factor;
 	const char *errmsg = NULL;
 	ldmsd_failover_t f;
@@ -1617,6 +1618,13 @@ int failover_config_handler(ldmsd_req_ctxt_t req)
 	if (f->state != FAILOVER_STATE_STOP) {
 		rc = EBUSY;
 		errmsg = "cannot reconfigure due to busy failover service";
+		goto out;
+	}
+	myname = ldmsd_myname_get();
+	if (!myname || !*myname) {
+		rc = EINVAL;
+		errmsg = "`-n <NAME>` command line option is required to "
+			 "use failover";
 		goto out;
 	}
 	if (host) {
@@ -1653,6 +1661,10 @@ int failover_config_handler(ldmsd_req_ctxt_t req)
 			rc = ENAMETOOLONG;
 			errmsg = "";
 		}
+	} else {
+		rc = EINVAL;
+		errmsg = "failover_config: peer_name attribute is required";
+		goto out;
 	}
 	if (auto_switch) {
 		f->auto_switch = atoi(auto_switch);

--- a/ldms/test/failover-simple/agg1.sh
+++ b/ldms/test/failover-simple/agg1.sh
@@ -9,7 +9,7 @@ updtr_add name=updtr interval=1000000 offset=500000
 updtr_prdcr_add name=updtr regex=.*
 updtr_start name=updtr
 failover_config host=localhost xprt=sock port=11002 interval=2000000 \
-                timeout_factor=5
+                timeout_factor=5 peer_name=agg2
 failover_start
 EOF
-gdb --args ldmsd -F -c $CFG -x sock:11001 -v INFO | tee agg1.log
+gdb --args ldmsd -F -n agg1 -c $CFG -x sock:11001 -v INFO | tee agg1.log

--- a/ldms/test/failover-simple/agg2.sh
+++ b/ldms/test/failover-simple/agg2.sh
@@ -3,7 +3,7 @@ mkdir -p cfg
 CFG=cfg/agg2.cfg
 cat > $CFG <<EOF
 failover_config host=localhost xprt=sock port=11001 interval=2000000 \
-                timeout_factor=5
+                timeout_factor=5 peer_name=agg1
 failover_start
 EOF
-gdb --args ldmsd -F -c $CFG -x sock:11002 -v INFO | tee agg2.log
+gdb --args ldmsd -F -n agg2 -c $CFG -x sock:11002 -v INFO | tee agg2.log


### PR DESCRIPTION
- Enforce `-n <OUR_NAME>` and `failover_config peer_name=<PEER_NAME>`
- Terminate LDMSD if there is no listening transport