### PR TITLE
Make ldmsd_controller receive a single config command at the cmd-line

### DIFF
--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1609,6 +1609,8 @@ if __name__ == "__main__":
         parser.add_argument('--script',
                             help = "Execute the script and send the output \
                             commands to the connected ldmsd")
+        parser.add_argument('--cmd',
+                            help = "Command to be sent to an LDMSD")
         parser.add_argument('-a', '--auth',
                             help = "Authentication method.")
         parser.add_argument('-A', '--auth-arg', action = 'append',
@@ -1639,11 +1641,13 @@ if __name__ == "__main__":
                                    auth = args.auth,
                                    auth_opt = auth_opt)
 
-        if args.source is not None or args.script is not None:
+        if args.source is not None or args.script is not None or args.cmd is not None:
             if args.source is not None:
                 cmdParser.do_source(args.source)
             if args.script is not None:
                 cmdParser.do_script(args.script)
+            if args.cmd is not None:
+                cmdParser.onecmd(args.cmd)
             cmdParser.do_quit(None)
         else:
             if sys.stdin.isatty() is False:


### PR DESCRIPTION
With the patch, users can give a single config command at the command line.
--cmd <cfg> is a new ldmsd_controller's command-line option. For example,

ldmsd_controller -x <xprt> -p <port> -h <host> --cmd 'prdcr_status'
ldmsd_controller -x <xprt> -p <port> -h <host> --cmd 'prdcr_start name=node0001'