### PR TITLE
fix process_dir_reply memory leak

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -1992,6 +1992,7 @@ void ldms_xprt_dir_free(ldms_t t, ldms_dir_t dir)
 		free(dir->set_data[i].inst_name);
 		free(dir->set_data[i].schema_name);
 		free(dir->set_data[i].flags);
+		free(dir->set_data[i].digest_str);
 		free(dir->set_data[i].perm);
 		if (NULL == dir->set_data[i].info)
 			continue;


### PR DESCRIPTION
ldms_ls (and maybe agg?) induces a memory leak in the dir reply json management. 
now freeing the unfreed field set_data[i].digest_str