### PR TITLE
add lustre_mdc (client side metadata perf) sampler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -862,6 +862,7 @@ ldms/src/sampler/llnl/Makefile
 ldms/src/sampler/lustre_client/Makefile
 ldms/src/sampler/lustre_mdt/Makefile
 ldms/src/sampler/lustre_ost/Makefile
+ldms/src/sampler/lustre_mdc/Makefile
 ldms/src/sampler/shm/Makefile
 ldms/src/sampler/shm/shm_util/Makefile
 ldms/src/sampler/shm/mpi_profiler/Makefile

--- a/ldms/scripts/examples/.canned
+++ b/ldms/scripts/examples/.canned
@@ -38,6 +38,7 @@ clock.job
 meminfo.job
 procstat.job
 lustre2_client
+lustre_mdc
 dstat.job
 many
 conf_csv

--- a/ldms/scripts/examples/lustre_mdc
+++ b/ldms/scripts/examples/lustre_mdc
@@ -1,0 +1,18 @@
+export plugname=lustre_mdc
+#VGARGS="--tool=drd --gen-suppressions=all --suppressions=ldms/scripts/examples/sampler.drd.supp --trace-mutex=yes --trace-cond=yes"
+#VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=all"
+#vgon
+portbase=61060
+LDMSD -s 2000000 1 2 3
+#vgoff
+SLEEP 2
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1 -v
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2 -v
+MESSAGE ldms_ls on host 3:
+LDMS_LS 3 -vl
+SLEEP 5
+KILL_LDMSD 1 2 3
+file_created $STOREDIR/node/${testname}_ops
+file_created $STOREDIR/node/${testname}_ops_timing

--- a/ldms/scripts/examples/lustre_mdc.1
+++ b/ldms/scripts/examples/lustre_mdc.1
@@ -1,0 +1,3 @@
+load name=${testname}
+config name=${testname} producer=localhost${i} component_id=${i}
+start name=${testname} interval=1000000 offset=0

--- a/ldms/scripts/examples/lustre_mdc.2
+++ b/ldms/scripts/examples/lustre_mdc.2
@@ -1,0 +1,3 @@
+load name=${testname}
+config name=${testname} producer=localhost${i} component_id=${i} mdc_timing=0 uid=1 gid=1 perm=777
+start name=${testname} interval=1000000 offset=0

--- a/ldms/scripts/examples/lustre_mdc.3
+++ b/ldms/scripts/examples/lustre_mdc.3
@@ -1,0 +1,20 @@
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_start name=localhost1
+
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=2000000
+prdcr_start name=localhost2
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+strgp_add name=store_${testname}_ops plugin=store_csv schema=${testname}_ops container=node
+strgp_prdcr_add name=store_${testname}_ops regex=.*
+strgp_start name=store_${testname}_ops
+
+strgp_add name=store_${testname}_all plugin=store_csv schema=${testname}_ops_timing container=node
+strgp_prdcr_add name=store_${testname}_all regex=.*
+strgp_start name=store_${testname}_all

--- a/ldms/src/sampler/Makefile.am
+++ b/ldms/src/sampler/Makefile.am
@@ -35,6 +35,7 @@ endif
 SUBDIRS += lustre_client
 SUBDIRS += lustre_mdt
 SUBDIRS += lustre_ost
+SUBDIRS += lustre_mdc
 
 if HAVE_DCGM
 SUBDIRS += dcgm_sampler

--- a/ldms/src/sampler/lustre_mdc/Makefile.am
+++ b/ldms/src/sampler/lustre_mdc/Makefile.am
@@ -1,0 +1,24 @@
+liblustre_mdc_la_SOURCES = \
+	lustre_mdc.c \
+	lustre_mdc_general.c \
+	lustre_mdc.h \
+	lustre_mdc_general.h
+
+liblustre_mdc_la_LIBADD = \
+	$(top_builddir)/ldms/src/core/libldms.la \
+	$(top_builddir)/lib/src/coll/libcoll.la \
+	$(top_builddir)/ldms/src/sampler/libsampler_base.la \
+	$(top_builddir)/ldms/src/sampler/libldms_compid_helper.la \
+	$(top_builddir)/ldms/src/sampler/libjobid_helper.la
+
+liblustre_mdc_la_LDFLAGS = \
+	-no-undefined \
+	-export-symbols-regex 'get_plugin' \
+	-version-info 1:0:0
+liblustre_mdc_la_CFLAGS = $(AM_CFLAGS)
+liblustre_mdc_la_CPPFLAGS = \
+	@OVIS_INCLUDE_ABS@
+
+pkglib_LTLIBRARIES = liblustre_mdc.la
+
+dist_man7_MANS = Plugin_lustre_mdc.man

--- a/ldms/src/sampler/lustre_mdc/NOTES
+++ b/ldms/src/sampler/lustre_mdc/NOTES
@@ -1,0 +1,76 @@
+Read data is found in (for lustre 2.12)
+
+FILE (operation counts)
+
+/proc/fs/lustre/mdc/*/md_stats
+snapshot_time             1653661756.400269074 secs.nsecs
+close                     3485 samples [reqs]
+create                    4694 samples [reqs]
+getattr                   34 samples [reqs]
+intent_lock               990613 samples [reqs]
+rename                    13906 samples [reqs]
+setattr                   12082 samples [reqs]
+read_page                 6102 samples [reqs]
+unlink                    3 samples [reqs]
+intent_getattr_async      23075 samples [reqs]
+revalidate_lock           79295 samples [reqs]
+
+and these values are defined in kernel code:
+
+lustre/lustre/obdclass/lprocfs_status.c
+lustre/lustre/include/obd_class.h
+mps_stats[], enum mps_stat_idx
+most recently (2.12 lustre) seen to be:
+	[LPROC_MD_CLOSE]		= "close",
+	[LPROC_MD_CREATE]		= "create",
+	[LPROC_MD_ENQUEUE]		= "enqueue",
+	[LPROC_MD_GETATTR]		= "getattr",
+	[LPROC_MD_INTENT_LOCK]		= "intent_lock",
+	[LPROC_MD_LINK]			= "link",
+	[LPROC_MD_RENAME]		= "rename",
+	[LPROC_MD_SETATTR]		= "setattr",
+	[LPROC_MD_FSYNC]		= "fsync",
+	[LPROC_MD_READ_PAGE]		= "read_page",
+	[LPROC_MD_UNLINK]		= "unlink",
+	[LPROC_MD_SETXATTR]		= "setxattr",
+	[LPROC_MD_GETXATTR]		= "getxattr",
+	[LPROC_MD_INTENT_GETATTR_ASYNC]	= "intent_getattr_async",
+	[LPROC_MD_REVALIDATE_LOCK]	= "revalidate_lock",
+
+Where values of 0 may be omitted from the dump file in /proc.
+
+and in:
+FILE (operation timing)
+/sys/kernel/debug/lustre/mdc/*/stats
+
+snapshot_time             1653661841.175727462 secs.nsecs
+req_waittime              568454 samples [usec] 78 890906 342452119 1647791995921
+req_active                568454 samples [reqs] 1 13 670364 1107000
+ldlm_glimpse_enqueue      15 samples [reqs] 1 1 15 15
+ldlm_ibits_enqueue        124765 samples [reqs] 1 1 124765 124765
+mds_getattr               34 samples [usec] 115 577 7380 1978142
+mds_getattr_lock          3 samples [usec] 759 836 2382 1894346
+mds_close                 3485 samples [usec] 118 2645 1776310 992011638
+mds_readpage              97 samples [usec] 1224 29713 345324 4116029462
+mds_connect               1 samples [usec] 916 916 916 839056
+mds_get_root              1 samples [usec] 365 365 365 133225
+mds_statfs                370308 samples [usec] 179 3213 242293389 171142540723
+ldlm_cancel               14851 samples [usec] 88 5228 5434823 3284658567
+obd_ping                  27318 samples [usec] 172 10251 18467610 14396646894
+seq_query                 1 samples [usec] 483 483 483 233289
+fld_query                 1 samples [usec] 293 293 293 85849
+
+Where values of 0 may be omitted.
+
+format: {name of statistic} {count of events} samples [{units}] {minimum value} {maximum value} {sum of values} {sum of value squared}
+which may be reduced by any number of trailing field omissions.
+
+Naming of files referencing the same device across proc, sys is like:
+
+/proc
+xxxxxxx-MDT0000-mdc-ffff99967cc54000  yyyyyyyy-MDT0000-mdc-ffff99a62a682800
+xxxxxxx-MDT0001-mdc-ffff99967cc54000  yyyyyyyy-MDT0001-mdc-ffff99a62a682800
+
+/sys
+xxxxxxx-MDT0000-mdc-ffff99967cc54000  yyyyyyyy-MDT0000-mdc-ffff99a62a682800
+xxxxxxx-MDT0001-mdc-ffff99967cc54000  yyyyyyyy-MDT0001-mdc-ffff99a62a682800

--- a/ldms/src/sampler/lustre_mdc/Plugin_lustre_mdc.man
+++ b/ldms/src/sampler/lustre_mdc/Plugin_lustre_mdc.man
@@ -1,0 +1,128 @@
+.TH man 7 "1 May 2019" "LDMS Plugin" "Plugin for LDMS"
+
+.SH NAME
+Plugin_lustre_mdc - man page for the LDMS lustre_mdc plugin
+
+.SH SYNOPSIS
+Within ldmsd_controller or a configuration file:
+.br
+config name=lustre_mdc
+
+.SH DESCRIPTION
+With LDMS (Lightweight Distributed Metric Service), plugins for the ldmsd (ldms daemon) are configured via ldmsd_controller
+or a configuration file.
+
+The lustre_mdc plugin provides schema lustre_mdc for daemons with read access to
+the lustre files in /proc/fs/lustre/mdc/*/md_stats and  /sys/kernel/debug/lustre/mdc/*/stats.
+The metric sets will have instance names combining the producer name and the mdc name.
+
+This plugin will work with Lustre versions 2.12 and others which share these file locations and formats.
+
+.SH CONFIGURATION ATTRIBUTE SYNTAX
+
+.TP
+.BR config
+name=<plugin_name> [producer=<name>] [component_id=<u64>]
+.br
+configuration line
+.RS
+.TP
+name=<plugin_name>
+.br
+This MUST be lustre_mdc.
+.TP
+producer=<alternate host name>
+.br
+The default used for producer (if not provided) is the result of gethostname().
+The set instance names will be <producer>/<mdc_name>
+.TP
+component_id=<uint64_t>
+.br
+Optional (defaults to 0) number of the host where the sampler is running. All sets on a host will have the same value.
+.TP
+job_set=<job information set name>
+.br
+Optional (defaults to "job_info"). Typically should be set to <hostname>/jobid or <hostname>/job_info depending on choice of job sampling plugin.
+.TP
+mdc_timing=0
+.br
+Optionally exclude timing data from /sys/kernel/debug/lustre/mdc/*/stats. If given,
+the sampler may be run by unprivileged users. If /sys/kernel/debug/ cannot be opened
+by the user, it is a configuration error unless mdc_timing=0 is given.
+.RE
+
+.SH SCHEMA
+The default schema name is lustre_mdc_ops_timing with all the data described in DATA REPORTED below included. If mdc_timing=0 is given, only the operation counts from md_stats are reported and the default schema name changes to lustre_mdc_ops.
+
+.SH DATA REPORTED
+
+Operation counts from /proc/fs/lustre/mdc/*/md_stats.
+See also kernel source lustre/lustre/obdclass/lprocfs_status.c and
+lustre/lustre/include/obd_class.h: mps_stats[]:
+        "close",
+        "create",
+        "enqueue",
+        "getattr",
+        "intent_lock",
+        "link",
+        "rename",
+        "setattr",
+        "fsync",
+        "read_page",
+        "unlink",
+        "setxattr",
+        "getxattr",
+        "intent_getattr_async",
+        "revalidate_lock",
+
+Client operation timing statistics (all but .count are in microseconds) for the following list of fields in /sys/kernel/debug/lustre/mdc/*/stats:
+     "req_waittime",
+     "mds_getattr",
+     "mds_getattr_lock",
+     "mds_close",
+     "mds_readpage",
+     "mds_connect",
+     "mds_get_root",
+     "mds_statfs",
+     "ldlm_cancel",
+     "obd_ping",
+     "seq_query",
+     "fld_query"
+
+and statistics:
+     "__count" the number of events observed,
+     "__min" the minimum event duration observed,
+     "__max" the maximum duration observed,
+     "__sum" the sum of all durations observed,
+     "__sumsqs" the sum of squares of all durations observed
+
+.SH NOTES
+The counters and file locations supported by this plugin are those present in Lustre 2.12.
+The fields labeled [reqs] are omitted. Data names not listed here are simply ignored.
+
+The minimum sample interval recommended for this sampler is 5-10 seconds, as the data volume may
+be substantial and the resolving shorter bursts of metadata activity is generally unnecessary.
+
+The average and sample standard deviation can be computed from sum and sumsqs, but
+once these counters roll over on a high up-time client, they may be less useful.
+
+The lustre utility equivalent of this plugin is to inspect the output of
+  lctl get_param -R mdc.*.stats
+  lctl get_param -R mdc.*.md_stats
+
+specifying instance=xxx as an option will be ignored.
+
+.SH BUGS
+No known bugs.
+
+.SH EXAMPLES
+.PP
+Within ldmsd_controller or a configuration file:
+.nf
+load name=lustre_mdc
+config name=lustre_mdc
+start name=lustre_mdc interval=1000000
+.fi
+
+.SH SEE ALSO
+ldmsd(8), ldms_quickstart(7), ldmsd_controller(8), ldms_sampler_base(7), lctl(8).

--- a/ldms/src/sampler/lustre_mdc/lustre_mdc.c
+++ b/ldms/src/sampler/lustre_mdc/lustre_mdc.c
@@ -1,0 +1,312 @@
+/* -*- c-basic-offset: 8 -*- */
+/* Copyright 2021 Lawrence Livermore National Security, LLC
+ * See the top-level COPYING file for details.
+ * Copyright 2022 NTESS.
+ *
+ * SPDX-License-Identifier: (GPL-2.0 OR BSD-3-Clause)
+ */
+#include <limits.h>
+#include <string.h>
+#include <dirent.h>
+#include <coll/rbt.h>
+#include <sys/queue.h>
+#include <unistd.h>
+#include "ldms.h"
+#include "ldmsd.h"
+#include "config.h"
+#include "lustre_mdc.h"
+#include "lustre_mdc_general.h"
+#include "jobid_helper.h"
+
+#define _GNU_SOURCE
+
+#define MDC_PATH "/proc/fs/lustre/mdc"
+#define TIMING_SEARCH_PATH "/sys/kernel/debug/lustre/mdc/"
+#define PERM_CHECK_PATH "/sys/kernel/debug"
+
+static struct comp_id_data cid;
+
+ldmsd_msg_log_f log_fn;
+char producer_name[LDMS_PRODUCER_NAME_MAX];
+
+/* red-black tree root for mdcs */
+static struct rbt mdc_tree;
+
+static struct base_auth auth;
+static int mdc_timing = 1; /* 0 means do not, -1 means cannot */
+
+struct mdc_data {
+	char *fs_name;
+	char *name;
+	char *path;
+	char *md_stats_path; /* operations: /proc/fs/lustre/mdc/ * /md_stats */
+	char *timing__stats_path; /* timings: /sys/kernel/debug/lustre/mdc/ * /stats */
+	ldms_set_t general_metric_set;
+	struct rbn mdc_tree_node;
+};
+
+static int string_comparator(void *a, const void *b)
+{
+	return strcmp((char *)a, (char *)b);
+}
+
+static struct mdc_data *mdc_create(const char *mdc_name, const char *basedir)
+{
+	struct mdc_data *mdc;
+	char path_tmp[PATH_MAX];
+	char *state;
+
+	log_fn(LDMSD_LDEBUG, SAMP" mdc_create() %s from %s\n",
+	       mdc_name, basedir);
+	mdc = calloc(1, sizeof(*mdc));
+	if (mdc == NULL)
+		goto out1;
+	mdc->name = strdup(mdc_name);
+	if (mdc->name == NULL)
+		goto out2;
+	snprintf(path_tmp, PATH_MAX, "%s/%s", basedir, mdc_name);
+	mdc->path = strdup(path_tmp);
+	if (mdc->path == NULL)
+		goto out3;
+	snprintf(path_tmp, PATH_MAX, "%s/md_stats", mdc->path);
+	mdc->md_stats_path = strdup(path_tmp);
+	if (mdc->md_stats_path == NULL)
+		goto out4;
+	snprintf(path_tmp, PATH_MAX, "%s/%s/stats", TIMING_SEARCH_PATH,
+		mdc_name );
+	mdc->timing__stats_path = strdup(path_tmp);
+	if (mdc->timing__stats_path == NULL)
+		goto out5;
+	mdc->fs_name = strdup(mdc_name);
+	if (mdc->fs_name == NULL)
+		goto out6;
+	if (strtok_r(mdc->fs_name, "-", &state) == NULL) {
+		log_fn(LDMSD_LWARNING, SAMP
+			": unable to parse filesystem name from \"%s\"\n",
+		       mdc->fs_name);
+		goto out7;
+	}
+	mdc->general_metric_set = mdc_general_create(producer_name,
+							mdc->fs_name,
+							mdc->name, &cid,
+							&auth);
+	if (mdc->general_metric_set == NULL)
+		goto out7;
+	rbn_init(&mdc->mdc_tree_node, mdc->name);
+
+	return mdc;
+out7:
+	free(mdc->fs_name);
+out6:
+	free(mdc->timing__stats_path);
+out5:
+	free(mdc->md_stats_path);
+out4:
+	free(mdc->path);
+out3:
+	free(mdc->name);
+out2:
+	free(mdc);
+out1:
+	return NULL;
+}
+
+static void mdc_destroy(struct mdc_data *mdc)
+{
+	log_fn(LDMSD_LDEBUG, SAMP" mdc_destroy() %s\n", mdc->name);
+	mdc_general_destroy(mdc->general_metric_set);
+	free(mdc->timing__stats_path);
+	free(mdc->fs_name);
+	free(mdc->md_stats_path);
+	free(mdc->path);
+	free(mdc->name);
+	free(mdc);
+}
+
+static void mdcs_destroy()
+{
+	struct rbn *rbn;
+	struct mdc_data *mdc;
+
+	while (!rbt_empty(&mdc_tree)) {
+		rbn = rbt_min(&mdc_tree);
+		mdc = container_of(rbn, struct mdc_data,
+				   mdc_tree_node);
+		rbt_del(&mdc_tree, rbn);
+		mdc_destroy(mdc);
+	}
+}
+
+static int dir_once_log;
+/* List subdirectories in MDC_PATH to get list of
+   MDC names.  Create mdc_data structures for any MDCS any that we
+   have not seen, and delete any that we no longer see. */
+static int mdcs_refresh()
+{
+	struct dirent *dirent;
+	DIR *dir;
+	struct rbt new_mdc_tree;
+	int err = 0;
+
+	rbt_init(&new_mdc_tree, string_comparator);
+
+	/* Make sure we have mdc_data objects in the new_mdc_tree for
+	   each currently existing directory.  We can find the objects
+	   cached in the global mdc_tree (in which case we move them
+	   from mdc_tree to new_mdc_tree), or they can be newly allocated
+	   here. */
+
+	dir = opendir(MDC_PATH);
+	if (dir == NULL) {
+		if (!dir_once_log) {
+			log_fn(LDMSD_LDEBUG, SAMP" unable to open mdc dir %s\n",
+			       MDC_PATH); /* expected if lustre all unmounted */
+			dir_once_log = 1;
+		}
+		return 0;
+	}
+	dir_once_log = 0;
+	while ((dirent = readdir(dir)) != NULL) {
+		struct rbn *rbn;
+		struct mdc_data *mdc;
+
+		if (dirent->d_type != DT_DIR ||
+		    strcmp(dirent->d_name, ".") == 0 ||
+		    strcmp(dirent->d_name, "..") == 0)
+			continue;
+		rbn = rbt_find(&mdc_tree, dirent->d_name);
+		errno = 0;
+		if (rbn) {
+			mdc = container_of(rbn, struct mdc_data,
+					   mdc_tree_node);
+			rbt_del(&mdc_tree, &mdc->mdc_tree_node);
+		} else {
+			mdc = mdc_create(dirent->d_name, MDC_PATH);
+		}
+		if (mdc == NULL) {
+			err = errno;
+			continue;
+		}
+		rbt_ins(&new_mdc_tree, &mdc->mdc_tree_node);
+	}
+	closedir(dir);
+
+	/* destroy any mdcs remaining in the global mdc_tree since we
+	   did not see their associated directories this time around */
+	mdcs_destroy();
+
+	/* copy the new_mdc_tree into place over the global mdc_tree */
+	memcpy(&mdc_tree, &new_mdc_tree, sizeof(struct rbt));
+
+	return err;
+}
+
+static void mdcs_sample()
+{
+	struct rbn *rbn;
+
+	/* walk tree of known MDCs */
+	RBT_FOREACH(rbn, &mdc_tree) {
+		struct mdc_data *mdc;
+		mdc = container_of(rbn, struct mdc_data, mdc_tree_node);
+		mdc_general_sample(mdc->name, mdc->md_stats_path,
+				mdc->timing__stats_path,
+				mdc->general_metric_set, mdc_timing);
+	}
+}
+
+static int config(struct ldmsd_plugin *self,
+		  struct attr_value_list *kwl, struct attr_value_list *avl)
+{
+	log_fn(LDMSD_LDEBUG, SAMP" config() called\n");
+	char *ival = av_value(avl, "producer");
+	if (ival) {
+		if (strlen(ival) < sizeof(producer_name)) {
+			strncpy(producer_name, ival, sizeof(producer_name));
+		} else {
+			log_fn(LDMSD_LERROR, SAMP": config: producer name too long.\n");
+			return EINVAL;
+		}
+	}
+	ival = av_value(avl, "mdc_timing");
+	if (ival && ival[0] == '0')
+		mdc_timing = 0;
+	(void)base_auth_parse(avl, &auth, log_fn);
+	int je = jobid_helper_config(avl);
+	if (je) {
+		log_fn(LDMSD_LERROR, SAMP": job_set name too long\n");
+		return ENAMETOOLONG;
+	}
+	comp_id_helper_config(avl, &cid);
+	if (mdc_timing) {
+		DIR *dchk = opendir(PERM_CHECK_PATH);
+		if (!dchk) {
+			log_fn(LDMSD_LERROR, SAMP": cannot open %s (%s)\n",
+				PERM_CHECK_PATH, STRERROR(errno));
+			log_fn(LDMSD_LERROR, SAMP": use mdc_timing=0 or "
+				"run ldmsd with more privileges\n");
+			mdc_timing = -1;
+			return EPERM;
+		} else {
+			closedir(dchk);
+		}
+	}
+	return 0;
+}
+
+static int sample(struct ldmsd_sampler *self)
+{
+	if (mdc_timing < 0)
+		return EPERM;
+	if (mdc_general_schema_is_initialized() < 0) {
+		if (mdc_general_schema_init(&cid, mdc_timing) < 0) {
+			log_fn(LDMSD_LERROR, SAMP" general schema create failed\n");
+			return ENOMEM;
+		}
+	}
+
+	int err = mdcs_refresh(); /* running out of set memory is an error */
+	mdcs_sample();
+
+	return err;
+}
+
+static void term(struct ldmsd_plugin *self)
+{
+	log_fn(LDMSD_LDEBUG, SAMP" term() called\n");
+	mdcs_destroy();
+	mdc_general_schema_fini();
+}
+
+static ldms_set_t get_set(struct ldmsd_sampler *self)
+{
+	return NULL;
+}
+
+static const char *usage(struct ldmsd_plugin *self)
+{
+	log_fn(LDMSD_LDEBUG, SAMP" usage() called\n");
+	return  "config name=" SAMP;
+}
+
+static struct ldmsd_sampler mdc_plugin = {
+	.base = {
+		.name = SAMP,
+		.type = LDMSD_PLUGIN_SAMPLER,
+		.term = term,
+		.config = config,
+		.usage = usage,
+	},
+	.get_set = get_set,
+	.sample = sample,
+};
+
+struct ldmsd_plugin *get_plugin(ldmsd_msg_log_f pf)
+{
+	log_fn = pf;
+	log_fn(LDMSD_LDEBUG, SAMP" get_plugin() called ("PACKAGE_STRING")\n");
+	rbt_init(&mdc_tree, string_comparator);
+	gethostname(producer_name, sizeof(producer_name));
+
+	return &mdc_plugin.base;
+}

--- a/ldms/src/sampler/lustre_mdc/lustre_mdc.h
+++ b/ldms/src/sampler/lustre_mdc/lustre_mdc.h
@@ -1,0 +1,18 @@
+/* -*- c-basic-offset: 8 -*- */
+/* Copyright 2021 Lawrence Livermore National Security, LLC
+ * See the top-level COPYING file for details.
+ * Copyright 2022 NTESS.
+ *
+ * SPDX-License-Identifier: (GPL-2.0 OR BSD-3-Clause)
+ */
+#ifndef __LUSTRE_MDC_H
+#define __LUSTRE_MDC_H
+
+#include "ldms.h"
+#include "ldmsd.h"
+
+#define SAMP "lustre_mdc"
+
+extern ldmsd_msg_log_f log_fn;
+
+#endif /* __LUSTRE_MDC_H */

--- a/ldms/src/sampler/lustre_mdc/lustre_mdc_general.c
+++ b/ldms/src/sampler/lustre_mdc/lustre_mdc_general.c
@@ -1,0 +1,322 @@
+/* -*- c-basic-offset: 8 -*- */
+/* Copyright 2021 Lawrence Livermore National Security, LLC
+ * See the top-level COPYING file for details.
+ * Copyright 2022 NTESS.
+ *
+ * SPDX-License-Identifier: (GPL-2.0 OR BSD-3-Clause)
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <dirent.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "ldms.h"
+#include "ldmsd.h"
+#include "lustre_mdc.h"
+#include "lustre_mdc_general.h"
+#include "jobid_helper.h"
+
+static ldms_schema_t mdc_general_schema;
+
+#define MAXNAMESIZE 64
+
+static char *mdc_md_stats_uint64_t_entries[] = {
+	"close",
+	"create",
+	"enqueue",
+	"getattr",
+	"intent_lock",
+	"link",
+	"rename",
+	"setattr",
+	"fsync",
+	"read_page",
+	"unlink",
+	"setxattr",
+	"getxattr",
+	"intent_getattr_async",
+	"revalidate_lock",
+	NULL
+};
+
+static char *md_timing_fields[] = { /* count, min_usec, max_usec, tot_usec, tot(usec^2) */
+	"req_waittime",
+	"mds_getattr",
+	"mds_getattr_lock",
+	"mds_close",
+	"mds_readpage",
+	"mds_connect",
+	"mds_get_root",
+	"mds_statfs",
+	"ldlm_cancel",
+	"obd_ping",
+	"seq_query",
+	"fld_query",
+	NULL
+};
+
+
+int mdc_general_schema_is_initialized()
+{
+	if (mdc_general_schema)
+		return 0;
+	else
+		return -1;
+}
+
+int mdc_general_schema_init(comp_id_t cid, int mdc_timing)
+{
+	ldms_schema_t sch;
+	int rc;
+	int i;
+	char str1[MAXNAMESIZE+1];
+
+	log_fn(LDMSD_LDEBUG, SAMP" mdc_general_schema_init()\n");
+	const char *sn;
+	if (mdc_timing > 0)
+		sn = "lustre_mdc_ops_timing";
+	else
+		sn = "lustre_mdc_ops";
+	sch = ldms_schema_new(sn);
+	if (sch == NULL)
+		goto err1;
+	const char *field;
+	field = "component_id";
+	rc = comp_id_helper_schema_add(sch, cid);
+	if (rc) {
+		rc = -rc;
+		goto err2;
+	}
+	field = "job data";
+	rc = jobid_helper_schema_add(sch);
+	if (rc <0) {
+		goto err2;
+	}
+	field = "fs_name";
+	rc = ldms_schema_meta_array_add(sch, field, LDMS_V_CHAR_ARRAY, MAXNAMESIZE);
+	if (rc < 0)
+		goto err2;
+	field = "mdc";
+	rc = ldms_schema_meta_array_add(sch, field, LDMS_V_CHAR_ARRAY, MAXNAMESIZE);
+	if (rc < 0)
+		goto err2;
+	/* add mdc md_stats entries */
+	for (i = 0; mdc_md_stats_uint64_t_entries[i] != NULL; i++) {
+		field = mdc_md_stats_uint64_t_entries[i];
+		rc = ldms_schema_metric_add(sch, field, LDMS_V_U64);
+		if (rc < 0)
+			goto err2;
+	}
+	/* add mdc stats timing entries. the order here is assumed and matched
+	 * in sampling. */
+
+	if (!mdc_timing)
+		goto timing0;
+
+	for (i = 0; md_timing_fields[i] != NULL; i++) {
+		sprintf(str1, "%s__count", md_timing_fields[i]);
+		rc = ldms_schema_metric_add(sch, str1, LDMS_V_U64);
+		if (rc < 0)
+			goto err3;
+		sprintf(str1, "%s__min", md_timing_fields[i]);
+		rc = ldms_schema_metric_add(sch, str1, LDMS_V_U64);
+		if (rc < 0)
+			goto err3;
+		sprintf(str1, "%s__max", md_timing_fields[i]);
+		rc = ldms_schema_metric_add(sch, str1, LDMS_V_U64);
+		if (rc < 0)
+			goto err3;
+		sprintf(str1, "%s__sum", md_timing_fields[i]);
+		rc = ldms_schema_metric_add(sch, str1, LDMS_V_U64);
+		if (rc < 0)
+			goto err3;
+		sprintf(str1, "%s__sumsqs", md_timing_fields[i]);
+		rc = ldms_schema_metric_add(sch, str1, LDMS_V_U64);
+		if (rc < 0)
+			goto err3;
+	}
+
+timing0:
+	mdc_general_schema = sch;
+	return 0;
+err3:
+	log_fn(LDMSD_LERROR, SAMP ": lustre_mdc_general schema creation failed to add %s. (%s)\n",
+		str1, STRERROR(-rc));
+	goto out;
+err2:
+	log_fn(LDMSD_LERROR, SAMP ": lustre_mdc_general schema creation failed to add %s. (%s)\n",
+		field, STRERROR(-rc));
+out:
+	ldms_schema_delete(sch);
+err1:
+	log_fn(LDMSD_LERROR, SAMP" lustre_mdc_general schema creation failed\n");
+	return -1;
+}
+
+void mdc_general_schema_fini()
+{
+	log_fn(LDMSD_LDEBUG, SAMP" mdc_general_schema_fini()\n");
+	if (mdc_general_schema != NULL) {
+		ldms_schema_delete(mdc_general_schema);
+		mdc_general_schema = NULL;
+	}
+}
+
+void mdc_general_destroy(ldms_set_t set)
+{
+	ldmsd_set_deregister(ldms_set_instance_name_get(set), SAMP);
+	ldms_set_unpublish(set);
+	ldms_set_delete(set);
+}
+
+
+/* must be schema created by mdc_general_schema_create() */
+ldms_set_t mdc_general_create(const char *producer_name,
+				const char *fs_name,
+				const char *mdc_name,
+				const comp_id_t cid,
+				const struct base_auth *auth)
+{
+	ldms_set_t set;
+	int index;
+	char instance_name[LDMS_PRODUCER_NAME_MAX + MAXNAMESIZE];
+
+	log_fn(LDMSD_LDEBUG, SAMP" mdc_general_create()\n");
+	snprintf(instance_name, sizeof(instance_name), "%s/%s",
+		 producer_name, mdc_name);
+	set = ldms_set_new(instance_name, mdc_general_schema);
+	if (!set) {
+		errno = ENOMEM;
+		return NULL;
+	}
+	ldms_set_producer_name_set(set, producer_name);
+	base_auth_set(auth, set);
+	index = ldms_metric_by_name(set, "fs_name");
+	ldms_metric_array_set_str(set, index, fs_name);
+	index = ldms_metric_by_name(set, "mdc");
+	ldms_metric_array_set_str(set, index, mdc_name);
+	comp_id_helper_metric_update(set, cid);
+	ldms_set_publish(set);
+	ldmsd_set_register(set, SAMP);
+	return set;
+}
+
+static int mdc_ops_sample(const char *path,
+			   ldms_set_t general_metric_set)
+{
+	FILE *sf;
+	char buf[512];
+	char str1[MAXNAMESIZE+1];
+	int ec = 0;
+
+	sf = fopen(path, "r");
+	if (sf == NULL) {
+		return ENOENT;
+	}
+
+	/* The first line should always be "snapshot_time"
+	   we will ignore it because it always contains the time that we read
+	   from the file, not any information about when the stats last
+	   changed */
+	if (fgets(buf, sizeof(buf), sf) == NULL) {
+		ec = ENOMSG;
+		goto out1;
+	}
+	if (strncmp("snapshot_time", buf, sizeof("snapshot_time")-1) != 0) {
+		ec = ENOMSG;
+		goto out1;
+	}
+
+	while (fgets(buf, sizeof(buf), sf)) {
+		uint64_t val1 = 0, val2 = 0, val3 = 0, val4 = 0, val5 = 0;
+		int rc;
+		int index;
+
+		rc = sscanf(buf, "%64s %lu samples [%*[^]]] %lu %lu %lu %lu",
+			    str1, &val1, &val2, &val3, &val4, &val5);
+		if (rc == 2) {
+			index = ldms_metric_by_name(general_metric_set, str1);
+			if (index > 1) {
+				ldms_metric_set_u64(general_metric_set, index, val1);
+			}
+			continue;
+		}
+	}
+out1:
+	fclose(sf);
+	return ec;
+}
+
+static int mdc_timing_sample(const char *path,
+				ldms_set_t general_metric_set)
+{
+	FILE *sf;
+	char buf[512];
+	char str1[MAXNAMESIZE+1];
+	char str2[2*MAXNAMESIZE+1];
+	int ec = 0;
+	sf = fopen(path, "r");
+	if (sf == NULL) {
+		return ENOENT;
+	}
+
+	/* The first line should always be "snapshot_time"
+	   we will ignore it because it always contains the time that we read
+	   from the file, not any information about when the stats last
+	   changed */
+	if (fgets(buf, sizeof(buf), sf) == NULL) {
+		ec = ENOMSG;
+		goto out1;
+	}
+	if (strncmp("snapshot_time", buf, sizeof("snapshot_time")-1) != 0) {
+		ec = ENOMSG;
+		goto out1;
+	}
+	while (fgets(buf, sizeof(buf), sf)) {
+		uint64_t valmin = 0, valmax = 0, valsum = 0, valsumsqs = 0,
+			valcount = 0;
+		int rc;
+		int index;
+
+		rc = sscanf(buf, "%64s %lu samples [%*[^]]] %lu %lu %lu %lu",
+				str1, &valcount, &valmin, &valmax, &valsum,
+				&valsumsqs);
+		if (rc == 6) {
+			sprintf(str2, "%s__count", str1);
+			index = ldms_metric_by_name(general_metric_set, str2);
+			if (index < 1) {
+				continue;
+			}
+			ldms_metric_set_u64(general_metric_set, index, valcount);
+			ldms_metric_set_u64(general_metric_set, index+1, valmin);
+			ldms_metric_set_u64(general_metric_set, index+2, valmax);
+			ldms_metric_set_u64(general_metric_set, index+3, valsum);
+			ldms_metric_set_u64(general_metric_set, index+4, valsumsqs);
+		}
+	}
+out1:
+	fclose(sf);
+	return ec;
+}
+
+void mdc_general_sample(const char *mdc_name, const char *md_stats_path,
+			const char *stats_path, ldms_set_t general_metric_set,
+			const int mdc_timing)
+{
+	ldms_transaction_begin(general_metric_set);
+	jobid_helper_metric_update(general_metric_set);
+	int ec1, ec2 = 0;
+	ec1 = mdc_ops_sample(md_stats_path, general_metric_set);
+	if (!ec1) {
+		if (mdc_timing)
+			ec2 = mdc_timing_sample(stats_path, general_metric_set);
+	} else {
+		log_fn(LDMSD_LDEBUG, SAMP": mdc_md_stats_sample %s fail (%s)\n",
+			md_stats_path, STRERROR(ec1));
+	}
+	if (ec2)
+		log_fn(LDMSD_LDEBUG, SAMP": mdc_timing_sample %s fail (%s)\n",
+			stats_path, STRERROR(ec2));
+	ldms_transaction_end(general_metric_set);
+}

--- a/ldms/src/sampler/lustre_mdc/lustre_mdc_general.h
+++ b/ldms/src/sampler/lustre_mdc/lustre_mdc_general.h
@@ -1,0 +1,27 @@
+/* -*- c-basic-offset: 8 -*- */
+/* Copyright 2021 Lawrence Livermore National Security, LLC
+ * See the top-level COPYING file for details.
+ * Copyright 2022 NTESS.
+ *
+ * SPDX-License-Identifier: (GPL-2.0 OR BSD-3-Clause)
+ */
+#ifndef __LUSTRE_MDC_GENERAL_H
+#define __LUSTRE_MDC_GENERAL_H
+
+#include "ldms.h"
+#include "ldmsd.h"
+#include "comp_id_helper.h"
+#include "sampler_base.h"
+
+int mdc_general_schema_is_initialized();
+int mdc_general_schema_init(const comp_id_t cid, int mdc_timing);
+void mdc_general_schema_fini();
+ldms_set_t mdc_general_create(const char *producer_name, const char *fs_name,
+				const char *mdc_name, const comp_id_t cid,
+				const struct base_auth *auth);
+void mdc_general_sample(const char *mdc_name, const char *md_stats_path,
+			const char *stats_path, ldms_set_t general_metric_set,
+			const int mdc_timing);
+void mdc_general_destroy(ldms_set_t set);
+
+#endif /* __LUSTRE_MDC_GENERAL_H */


### PR DESCRIPTION
Includes jobid and set perm support, basic test script.
The sampler can run without root access if timing data is excluded.
The mdc timing stats can be suppressed optionally.