### PR TITLE
add option to suppress - in output of ldms-sensors-config

### DIFF
--- a/ldms/src/sampler/filesingle/ldms-sensors-config
+++ b/ldms/src/sampler/filesingle/ldms-sensors-config
@@ -9,10 +9,12 @@ import tempfile
 import subprocess
 import argparse
 
-def fixlabel(s):
+def fixlabel(s, nodash=False):
     if s[-2:] == "\\n":
         s = s[:-2]
     s = s.replace(" ", "_")
+    if nodash:
+        s = s.replace("-", "_")
     return s
 
 ignore_types = [
@@ -29,6 +31,8 @@ def main():
             help="Full path to lm_sensor 'sensors' program")
     opts.add_argument("--lscpu", metavar="LSCPU-PATH", default="/usr/bin/lscpu",
             help="Full path to 'lscpu' program")
+    opts.add_argument("--nodash", default=False, action='store_true',
+            help="enable replacing - with _ in names.")
     opts.add_argument("--test-lscpu", metavar="TEST-INPUT", required=False,
             help="path to strace result file for parser testing")
     opts.add_argument("--test-sensors", metavar="TEST-INPUT", required=False,
@@ -54,6 +58,7 @@ def main():
 
     sensorsbin = args.sensors
     lscpubin = args.lscpu
+    nodash = args.nodash
 
     # build and parse sensors trace
     tf = tempfile.mktemp(dir="/tmp", suffix=".trace", prefix="ldms-config-sensors.")
@@ -179,8 +184,8 @@ def main():
     for k,d in devices.iteritems():
         if len(d["items"]) > 0:
             for i in d["items"]:
-                print ".".join([d["group"], d[i]["label"] ]), \
-                        d[i]["inputfile"], "S64 -1"
+                ilbl = fixlabel(".".join([d["group"], d[i]["label"] ]), nodash)
+                print ilbl, d[i]["inputfile"], "S64 -1"
 
     devices = dict()
     # build and parse lscpu trace
@@ -249,7 +254,8 @@ def main():
     for k,d in devices.iteritems():
         if len(d["items"]) > 0:
             for i in d["items"]:
-                ln = ".".join([d["group"], d[i]["label"] ]) + " " + d[i]["inputfile"] + " " + "S64 -1"
+                ilbl = fixlabel(".".join([d["group"], d[i]["label"] ]), nodash)
+                ln = ilbl + " " + d[i]["inputfile"] + " " + "S64 -1"
                 llist.append(ln)
     for i in sorted(llist):
         print i

--- a/ldms/src/sampler/filesingle/ldms-sensors-config.man
+++ b/ldms/src/sampler/filesingle/ldms-sensors-config.man
@@ -24,6 +24,11 @@ sampler. The user should tailor the selection, naming, data storage type, and de
 specify an alternate location of the sensors program. The default is /usr/bin/sensors, and the PATH variable is not used to search for alternatives.
 
 .TP
+--nodash
+.br
+Replace all - characters in metric names with _ characters.
+
+.TP
 --lscpu=<path>
 .br
 specify an alternate location of the lscpu program. The default is /usr/bin/lscpu and the PATH variable is not used to search for alternatives.
@@ -53,6 +58,9 @@ script -c 'strace -e trace=open,openat lscpu' /tmp/lscpu.tmp | grep '^open.*cpui
 When using test input file(s), the live system data will be used if the corresponding test file is not specified.
 
 Systems (kernels) lacking cpu frequency reporting produce no output from lscpu.
+
+The use of --nodash is recommended for compatibility with downstream analysis tools. White space
+appearing in metric names is unconditionally transformed to _.
 
 .SH SEE ALSO
 sensors(1), lscpu(1), Plugin_filesingle(7), ldmsd.


### PR DESCRIPTION
updates utility script to optionally suppress - in the labels/names published by the kernel.