### PR TITLE
Fix ldmsd config error but not exit bug

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -1219,6 +1219,8 @@ int ldmsd_process_config_request(ldmsd_cfg_xprt_t xprt, ldmsd_req_hdr_t request)
 	reqc->req_id = ((ldmsd_req_hdr_t)reqc->req_buf)->req_id;
 
 	rc = ldmsd_handle_request(reqc);
+	if (xprt != reqc->xprt)
+		memcpy(xprt, reqc->xprt, sizeof(*xprt));
 
 	req_ctxt_tree_lock();
 	req_ctxt_ref_put(reqc);


### PR DESCRIPTION
The commit c4f19c6 allocated a new config transport memory because the
`ldmsd_req_ctxt` can later corrupt the transport that was in the stack.
The subsequent request handling call will modify `xprt->rsp_err` if
there is an error. However, it will be modifying the newly allocated
xprt memory, leaving the config transport unchanged. Consequently, the
`rsp_err` in the config transport (on the stack) stayed 0.

This patch addresses the issue by copying the `xprt` content that is
modified by the subsequent config handler call back to the config
transport.