### PR TITLE
Fix memory leak, missing doc, missing err handling

### DIFF
--- a/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
+++ b/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
@@ -186,7 +186,9 @@ static int ibmad_schema_create()
         sch = ldms_schema_new(conf.schema_name);
         if (sch == NULL)
                 goto err1;
-        jobid_helper_schema_add(sch);
+        rc = jobid_helper_schema_add(sch);
+	if (rc < 0)
+		goto err2;
         rc = ldms_schema_meta_array_add(sch, "ca_name", LDMS_V_CHAR_ARRAY, 64);
         if (rc < 0)
                 goto err2;
@@ -692,7 +694,12 @@ static int config(struct ldmsd_plugin *self,
 
         log_fn(LDMSD_LDEBUG, SAMP" config() called\n");
 
-	jobid_helper_config(avl);
+	int jc = jobid_helper_config(avl);
+        if (jc) {
+		log_fn(LDMSD_LERROR, SAMP": set name for job_set="
+			" is too long.\n");
+		return jc;
+	}
 	base_auth_parse(avl, &auth, log_fn);
 
         value = av_value(avl, "schema");

--- a/ldms/src/sampler/jobid_helper.c
+++ b/ldms/src/sampler/jobid_helper.c
@@ -7,7 +7,7 @@
 
 #include "jobid_helper.h"
 
-static char *job_set_name;
+static char job_set_name[MAX_JOB_SET_NAME];
 static ldms_set_t job_set;
 static int job_id_idx = -1;
 static int app_id_idx;
@@ -22,11 +22,11 @@ int jobid_helper_schema_add(ldms_schema_t schema)
 
 	rc = ldms_schema_metric_add(schema, "job_id", LDMS_V_U64);
 	if (rc < 0) {
-		return -1;
+		return rc;
 	}
 	rc = ldms_schema_metric_add(schema, "app_id", LDMS_V_U64);
 	if (rc < 0) {
-		return -1;
+		return rc;
 	}
 
 	return 0;
@@ -115,13 +115,17 @@ void jobid_helper_metric_update(ldms_set_t set)
 
 }
 
-void jobid_helper_config(struct attr_value_list *avl)
+int jobid_helper_config(struct attr_value_list *avl)
 {
 	char *value;
 
 	value = av_value(avl, "job_set");
-	if (!value)
-		job_set_name = strdup("job_info");
-	else
-		job_set_name = strdup(value);
+	if (!value) {
+		strcpy(job_set_name, "job_info");
+	} else {
+		if (strlen(value) > MAX_JOB_SET_NAME -1)
+			return ENAMETOOLONG;
+		strcpy(job_set_name, value);
+	}
+	return 0;
 }

--- a/ldms/src/sampler/jobid_helper.h
+++ b/ldms/src/sampler/jobid_helper.h
@@ -9,9 +9,40 @@
 
 #include "ldms.h"
 #include "ldmsd.h"
+/* Functions to manage info about a common set instance from
+ * which all other sets extract the current job_id value(s).
+ * Assumptions:
+ * - All samplers extracting a jobid are configured to
+ *   extract it from the same common set instance.
+ * - The common set instance is not recreated after its
+ *   initial appearance, for the life of the daemon.
+ * - All samplers using this API will be stopped
+ *   before the common set is destroyed.
+ *   (Violation of this may lead to reading freed memory).
+ * - There is only one job per node, unless the
+ *   named job info set includes metric 'job_slot_list'.
+ */
 
-void jobid_helper_config(struct attr_value_list *avl);
+#define MAX_JOB_SET_NAME 256
+
+/* Extract the 'job_set' attribute from avl to find
+ * the job_id source set name.
+ * \return 0 if ok or error if the name length found
+ * is > MAX_JOB_SET_NAME.
+ */
+int jobid_helper_config(struct attr_value_list *avl);
+
+/* Add job_id and app_id to the schema given.
+ * \return the failure value of ldms_schema_metric_add
+ * or 0 if it succeeds for all added metrics.
+ */
 int jobid_helper_schema_add(ldms_schema_t schema);
+
+/* Copy the job_id, app_id values from the configured
+ * source set into their locations in the given set.
+ * If the expected source set is not yet present, this
+ * becomes a no-op.
+ */
 void jobid_helper_metric_update(ldms_set_t set);
 
 #endif /* __JOBID_HELPER_H */

--- a/ldms/src/sampler/lustre_client/lustre_client.c
+++ b/ldms/src/sampler/lustre_client/lustre_client.c
@@ -251,8 +251,18 @@ static int config(struct ldmsd_plugin *self,
 		}
 	}
 	(void)base_auth_parse(avl, &auth, log_fn);
-	jobid_helper_config(avl);
-	comp_id_helper_config(avl, &cid);
+	int jc = jobid_helper_config(avl);
+        if (jc) {
+		log_fn(LDMSD_LERROR, SAMP": set name for job_set="
+			" is too long.\n");
+		return jc;
+	}
+	int cc = comp_id_helper_config(avl, &cid);
+        if (cc) {
+		log_fn(LDMSD_LERROR, SAMP": value of component_id="
+			" is invalid.\n");
+		return cc;
+	}
         return 0;
 }
 


### PR DESCRIPTION
This documents jobid_helper.h and fixes an 'N_samplers -1' string leak in jobid_helper.c, and fixes related call sites.
Also fixes an immmediately adjacent unchecked return code from comp_id_helper_config.