### PR TITLE
Add the jbuf_reset interface

### DIFF
--- a/lib/src/ovis_json/ovis_json.c
+++ b/lib/src/ovis_json/ovis_json.c
@@ -42,6 +42,11 @@ jbuf_t jbuf_new(void)
 	return jb;
 }
 
+void jbuf_reset(jbuf_t jb)
+{
+	jb->cursor = 0;
+}
+
 void jbuf_free(jbuf_t jb)
 {
 	free(jb);

--- a/lib/src/ovis_json/ovis_json.h
+++ b/lib/src/ovis_json/ovis_json.h
@@ -338,5 +338,6 @@ extern jbuf_t jbuf_append_attr(jbuf_t jb, const char *name, const char *fmt, ...
 extern jbuf_t jbuf_append_str(jbuf_t jb, const char *fmt, ...);
 extern jbuf_t jbuf_append_va(jbuf_t jb, const char *fmt, va_list ap);
 extern void jbuf_free(jbuf_t jb);
+extern void jbuf_reset(jbuf_t jb);
 
 #endif


### PR DESCRIPTION
A jbuf_t maintains an internal cursor that is advanced as data is
appended to the buffer. The jbuf_reset interface resets this cursor
pointer to zero so that the buffer can be reused avoiding the overhead
of jbuf_new() and jbuf_free() for each jbuf record.