### PR TITLE
[FEAT] ldms gpu metrics sampler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -288,6 +288,7 @@ OPTION_DEFAULT_ENABLE([synthetic], [ENABLE_SYNTHETIC])
 OPTION_DEFAULT_ENABLE([varset], [ENABLE_VARSET])
 OPTION_DEFAULT_ENABLE([lnet_stats], [ENABLE_LNET_STATS])
 OPTION_DEFAULT_ENABLE([meminfo], [ENABLE_MEMINFO])
+OPTION_DEFAULT_DISABLE([gpumetrics], [ENABLE_GPU_METRICS])
 OPTION_DEFAULT_ENABLE([coretemp], [ENABLE_CORETEMP])
 OPTION_DEFAULT_DISABLE([filesingle], [ENABLE_FILESINGLE])
 OPTION_DEFAULT_DISABLE([msr_interlagos], [ENABLE_MSR_INTERLAGOS])
@@ -880,6 +881,7 @@ ldms/src/sampler/appinfo_lib/Makefile
 ldms/src/sampler/kgnilnd/Makefile
 ldms/src/sampler/tx2mon/Makefile
 ldms/src/sampler/meminfo/Makefile
+ldms/src/contrib/sampler/gpu_metrics_sampler/Makefile
 ldms/src/sampler/procinterrupts/Makefile
 ldms/src/sampler/procnetdev2/Makefile
 ldms/src/sampler/variable/Makefile

--- a/ldms/src/contrib/sampler/Makefile.am
+++ b/ldms/src/contrib/sampler/Makefile.am
@@ -15,5 +15,6 @@ endif
 SUBDIRS += $(MAYBE_TUTORIAL_SAMPLER)
 
 
-
-
+if ENABLE_GPU_METRICS
+SUBDIRS += gpu_metrics_sampler
+endif

--- a/ldms/src/contrib/sampler/gpu_metrics_sampler/Makefile.am
+++ b/ldms/src/contrib/sampler/gpu_metrics_sampler/Makefile.am
@@ -1,0 +1,86 @@
+# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2011-2018 National Technology & Engineering Solutions
+# of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+# NTESS, the U.S. Government retains certain rights in this software.
+# Copyright (c) 2011-2018 Open Grid Computing, Inc. All rights reserved.
+#
+# This software is available to you under a choice of one of two
+# licenses.  You may choose to be licensed under the terms of the GNU
+# General Public License (GPL) Version 2, available from the file
+# COPYING in the main directory of this source tree, or the BSD-type
+# license below:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#      Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#      Redistributions in binary form must reproduce the above
+#      copyright notice, this list of conditions and the following
+#      disclaimer in the documentation and/or other materials provided
+#      with the distribution.
+#
+#      Neither the name of Sandia nor the names of any contributors may
+#      be used to endorse or promote products derived from this software
+#      without specific prior written permission.
+#
+#      Neither the name of Open Grid Computing nor the names of any
+#      contributors may be used to endorse or promote products derived
+#      from this software without specific prior written permission.
+#
+#      Modified source versions must be plainly marked as such, and
+#      must not be misrepresented as being the original software.
+#
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+pkglib_LTLIBRARIES =
+lib_LTLIBRARIES =
+dist_man7_MANS =
+dist_man1_MANS =
+
+
+CFLAGS0 = -Dsanitize_address=true
+CFLAGS1 = -D_FORTIFY_SOURCE=2 -O2 -D_GLIBCXX_ASSERTIONS -fasynchronous-unwind-tables -fexceptions -fpie -fPIC
+CFLAGS2 = -fstack-protector-strong -Werror=format-security -Wall
+LDFLAGS0 = -Wl,-z,defs -Wl,-z,now -Wl,-z,relro
+
+SDLCFLAGS = $(CFLAGS0) $(CFLAGS1) $(CFLAGS2) $(CFLAGSIMULATION)
+SDLLDFLAGS = $(LDFLAGS0)
+
+
+AM_CPPFLAGS = @OVIS_INCLUDE_ABS@ $(SDLCFLAGS)
+AM_LDFLAGS = @OVIS_LIB_ABS@ $(SDLLDFLAGS)
+COMMON_LIBADD = -lsampler_base -lldms -lovis_util -lcoll \
+		@LDFLAGS_GETTIME@
+GMGLIBS = -L. -lgmg -L/usr/lib/x86_64-linux-gnu/ -lze_loader
+
+if ENABLE_GPU_METRICS
+
+
+noinst_LIBRARIES = libgmg.a
+libgmg_a_SOURCES = gmg_common_util.c gmg_log.c gather_gpu_metrics_from_one_api.c gmg_ldms_util.c
+
+libgpumetrics_la_SOURCES = gpu_metrics_ldms_sampler.c
+libgpumetrics_la_LIBADD = $(COMMON_LIBADD) $(GMGLIBS)
+pkglib_LTLIBRARIES += libgpumetrics.la
+
+bin_PROGRAMS = bin/gpu_metrics_gatherer
+bin_gpu_metrics_gatherer_SOURCES = gather_gpu_metrics.cpp
+bin_gpu_metrics_gatherer_LDADD = $(GMGLIBS)
+
+
+endif

--- a/ldms/src/contrib/sampler/gpu_metrics_sampler/gather_gpu_metrics.cpp
+++ b/ldms/src/contrib/sampler/gpu_metrics_sampler/gather_gpu_metrics.cpp
@@ -1,0 +1,149 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "gather_gpu_metrics_from_one_api.h"
+#include <level_zero/zes_api.h>
+
+#include <iostream>
+#include <iomanip>
+#include <chrono>
+
+using namespace std::chrono;
+using namespace std;
+
+
+void printGpuMetrics(ze_device_handle_t device, uint32_t devNumber) {
+    cout << " " << devNumber << "    -1 Format: Value          Descriptive text" << endl;
+
+    uint32_t metricNumber = 0;
+    cout << fixed << setprecision(2);
+    cout << " " << devNumber << "     " << metricNumber++ << "         "
+         << getGpuUtilization(device) << "           gpu_util (%)" << endl;
+
+    cout << " " << devNumber << "     " << metricNumber++ << "         "
+         << getMemoryUtilization(device) << "           mem_util (%)" << endl;
+
+    cout << " " << devNumber << "     " << metricNumber++ << "         "
+         << getMemVRAMUsed(device) << "       mem_vram_used" << endl;
+
+    cout << " " << devNumber << "     " << metricNumber++ << "         "
+         << getSysClockFreq(device) << "           sys_clock_freq (MHz)" << endl;
+
+    cout << " " << devNumber << "     " << metricNumber++ << "         "
+         << getMemoryReadBandwidth(device) << "          mem_read_bandwidth (kilobaud)" << endl;
+
+    cout << " " << devNumber << "     " << metricNumber++ << "         "
+         << getMemoryWriteBandwidth(device) << "          mem_write_bandwidth (kilobaud)" << endl;
+
+    cout << " " << devNumber << "     " << metricNumber++ << "         "
+         << getPerfLevel(device) << "           perf_level" << endl;
+
+    cout << " " << devNumber << "     " << metricNumber++ << "         "
+         << getPowerUsage(device) << "             power_usage (mW)" << endl;
+
+    cout << " " << devNumber << "     " << metricNumber++ << "         "
+         << getGpuTemp(device) << "          gpu_temp (Celsius)" << endl;
+}
+
+int sampleGpuMetrics(int argc, char *argv[]) {
+    auto start = high_resolution_clock::now();
+
+    ze_result_t res = initializeOneApi();
+    if (res != ZE_RESULT_SUCCESS) {
+        cerr << "!!!initializeOneApi => 0x" << hex << res << endl;
+        return 1;
+    }
+
+    cout << "-1    -1         GPU Driver discovery ..." << endl;
+    ze_driver_handle_t hDriver = getDriver();
+    if (hDriver == NULL) {
+        cerr << "!!!getDriver() => NULL" << endl;
+        return 2;
+    }
+
+    auto stop = high_resolution_clock::now();
+    auto duration = duration_cast<microseconds>(stop - start);
+    cout << "-1    -1         GPU driver discovered in " << duration.count() / 1000 <<
+         " ms" << endl;
+
+    cout << "-1    -1         Enumerating devices managed by driver[0] ..." << endl;
+    uint32_t numDevices = 0;
+    ze_device_handle_t *phDevices = enumerateGpuDevices(hDriver, &numDevices);
+    if (phDevices == NULL) {
+        cerr << "!!!enumerateGpuDevices() => NULL" << endl;
+        return 3;
+    }
+    cout << "-1    -1         " << numDevices << " GPU device(s) discovered" << endl;
+
+    uint32_t devNumber = 0;
+    for (uint32_t i = 0; i < numDevices; i++) {
+        cout << " " << devNumber << "    -1         Device name = " << getGpuDeviceName(phDevices[devNumber]) << endl;
+        cout << " " << devNumber << "    -1         Device uuid = " << convertUuidToString(getGpuUuid(phDevices[devNumber])) << endl;
+        cout << " " << devNumber << "    -1         Serial number = " << getGpuSerialNumber(phDevices[devNumber])<< endl;
+        printGpuMetrics(phDevices[i], devNumber++);
+    }
+
+    freeZeDeviceHandle(phDevices);
+    phDevices = NULL;
+
+    return 0;
+}
+
+int main(int argc, char *argv[]) {
+#ifdef ENABLE_AUTO_SIMULATION
+    autoSetSimulationMode();
+#endif
+    auto start = high_resolution_clock::now();
+    int res = sampleGpuMetrics(argc, argv);
+    if (res != 0) {
+        return res;
+    }
+    auto stop = high_resolution_clock::now();
+    auto duration = duration_cast<microseconds>(stop - start);
+    cout << "-1    -1         " << "GPU metrics gatherer took " << duration.count() / 1000 << " ms" << endl;
+    return 0;
+}

--- a/ldms/src/contrib/sampler/gpu_metrics_sampler/gather_gpu_metrics_from_one_api.c
+++ b/ldms/src/contrib/sampler/gpu_metrics_sampler/gather_gpu_metrics_from_one_api.c
@@ -1,0 +1,804 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "gmg_log.h"
+#include "gather_gpu_metrics_from_one_api.h"
+#include "gmg_ldms_util.h"
+#include <string.h>
+#include <time.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+static uint64_t mallocCount = 0;
+
+size_t getMallocCount() {
+    return mallocCount;
+}
+
+static void *GMG_MALLOC(size_t size) {
+    GMGLOG(LDMSD_LDEBUG, ">>GMG_MALLOC(size=%ld)\n", size);
+    void *p = calloc(size, 1);
+    if (!p) {
+        GMGLOG(LDMSD_LERROR, "!!!calloc(size=%ld, 1) => NULL\n", size);
+        return NULL;
+    }
+    mallocCount++;
+    GMGLOG(LDMSD_LDEBUG, "<<GMG_MALLOC(size=%ld) => %p\n", size, p);
+    return p;
+}
+
+static void gmgFree(void *p) {
+    GMGLOG(LDMSD_LDEBUG, ">>gmgFree(p=%p)\n", p);
+    if (!p) {
+        GMGLOG(LDMSD_LERROR, "!!!Attempting to free a NULL pointer\n");
+        return;
+    }
+    free(p);
+    GMGLOG(LDMSD_LDEBUG, "<<gmgFree()\n");
+    --mallocCount;
+}
+
+#define GMG_FREE(p) { \
+    gmgFree((p)); \
+    (p) = NULL;   \
+}
+
+const long samplingIntervalInMs = 10;
+
+/**
+ * Simulation Data Definitions
+ */
+static const uint32_t cNumberOfSimulatedDrivers = 1;
+static const uint32_t cNumberOfSimulatedDevices = 6;
+
+
+bool g_bIsInSimulationMode = false;
+
+bool getSimulationMode() {
+    return g_bIsInSimulationMode;
+}
+
+void setSimulationMode(bool bIsInSimulationMode) {
+    g_bIsInSimulationMode = bIsInSimulationMode;
+    GMGLOG(LDMSD_LDEBUG, "Setting g_bIsInSimulationMode=%d\n", bIsInSimulationMode);
+}
+
+#ifdef ENABLE_AUTO_SIMULATION
+void autoSetSimulationMode() {
+    if (isFileExists(SIMULATION_CONTROL_FILE)) {
+        setSimulationMode(true);
+    }
+}
+#endif
+
+ze_result_t initializeOneApi() {
+    GMGLOG(LDMSD_LINFO, ">>initializeOneApi()\n");
+    if (g_bIsInSimulationMode) {
+        return ZE_RESULT_SUCCESS;
+    }
+
+    if (setenv("ZES_ENABLE_SYSMAN", "1", 1) == -1) {
+        GMGLOG(LDMSD_LERROR, "Cannot set environment variable ZES_ENABLE_SYSMAN=1\n");
+        return ZE_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    ze_result_t res = zeInit(ZE_INIT_FLAG_GPU_ONLY);
+    GMGLOG(LDMSD_LINFO, "<<initializeOneApi()\n");
+    return res;
+}
+
+static ze_result_t gmgDriverGet(
+        uint32_t *pCount,
+        ze_driver_handle_t *phDrivers) {
+    if (g_bIsInSimulationMode) {
+        *pCount = cNumberOfSimulatedDrivers;
+        if (phDrivers == NULL) return ZE_RESULT_SUCCESS;
+
+        for (size_t i = 0; i < *pCount; i++) {
+            phDrivers[i] = (ze_driver_handle_t)(i + 1);
+        }
+        return ZE_RESULT_SUCCESS;
+    }
+
+    return zeDriverGet(pCount, phDrivers);
+}
+
+static ze_result_t gmgDeviceGet(
+        ze_driver_handle_t hDriver,
+        uint32_t *pCount,
+        ze_device_handle_t *phDevices) {
+    if (g_bIsInSimulationMode) {
+        *pCount = cNumberOfSimulatedDevices;
+        if (phDevices == NULL) return ZE_RESULT_SUCCESS;
+
+        for (size_t i = 0; i < *pCount; i++) {
+            phDevices[i] = (ze_device_handle_t)(i + 1);
+        }
+        return ZE_RESULT_SUCCESS;
+    }
+
+    return zeDeviceGet(hDriver, pCount, phDevices);
+}
+
+
+static ze_result_t gmgDeviceGetProperties(
+        ze_device_handle_t hDevice,
+        ze_device_properties_t *pDeviceProperties) {
+    if (g_bIsInSimulationMode) {
+        strncpy(pDeviceProperties->name, "Intel(R) Graphics [0x0bd5]", ZE_MAX_DEVICE_NAME);
+        for (uint32_t i = 0; i < ZE_MAX_DEVICE_UUID_SIZE; i++) {
+            pDeviceProperties->uuid.id[i] = i;
+        }
+        return ZE_RESULT_SUCCESS;
+    }
+
+    return zeDeviceGetProperties(hDevice, pDeviceProperties);
+}
+
+ze_result_t gmgsEngineGetActivity(
+        zes_engine_handle_t hEngine,
+        zes_engine_stats_t *pStats) {
+
+    if (g_bIsInSimulationMode) {
+        const long BILLION = 1000000000L;
+        struct timespec currentTime;
+
+        clock_gettime(CLOCK_REALTIME, &currentTime);
+        pStats->activeTime = (BILLION * currentTime.tv_sec + currentTime.tv_nsec) / 100;
+        clock_gettime(CLOCK_REALTIME, &currentTime);
+        pStats->timestamp = BILLION * currentTime.tv_sec + currentTime.tv_nsec;
+
+        return ZE_RESULT_SUCCESS;
+    }
+
+    ze_result_t res = zesEngineGetActivity(hEngine, pStats);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!zesEngineGetActivity(hEngine=%p,pStats=%p) => 0x%x\n",
+               hEngine, pStats, res);
+    }
+    return res;
+}
+
+ze_result_t gmgsDeviceEnumEngineGroups(
+        zes_device_handle_t hDevice,
+        uint32_t *pCount,
+        zes_engine_handle_t *phEngine) {
+    if (g_bIsInSimulationMode) {
+        *pCount = 1;    // only need ZES_ENGINE_GROUP_ALL = 0
+        if (phEngine == NULL) return ZE_RESULT_SUCCESS;
+
+        phEngine[ZES_ENGINE_GROUP_ALL] = (zes_engine_handle_t) 1;
+        return ZE_RESULT_SUCCESS;
+    }
+
+    ze_result_t res = zesDeviceEnumEngineGroups(hDevice, pCount, phEngine);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!zesDeviceEnumEngineGroups(hDevice=%p,pCount=%p,phEngine=%p) => 0x%x\n",
+               hDevice, pCount, phEngine, res);
+    }
+    return res;
+}
+
+static
+ze_driver_handle_t *enumerateDrivers(uint32_t *pCount) {
+    ze_result_t res = gmgDriverGet(pCount, NULL);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!gmgDriverGet(pCount=%p, NULL) => 0x%x\n", pCount, res);
+        return NULL;
+    }
+
+    if (*pCount < 1) {
+        GMGLOG(LDMSD_LERROR, "!!!*pCount=%d < 1\n", *pCount);
+        return NULL;
+    }
+
+    size_t memSizeDrivers = sizeof(ze_driver_handle_t) * *pCount;
+    ze_driver_handle_t *phDrivers = GMG_MALLOC(memSizeDrivers);
+
+    res = gmgDriverGet(pCount, phDrivers);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!gmgDriverGet(pCount=%p,phDrivers=%p) => 0x%x\n", pCount, phDrivers, res);
+        GMG_FREE(phDrivers);
+        return NULL;
+    }
+
+    return phDrivers;
+}
+
+ze_driver_handle_t getDriver() {
+    GMGLOG(LDMSD_LINFO, ">>getDriver()\n");
+    uint32_t numDrivers = 0;
+    ze_driver_handle_t *phDrivers = enumerateDrivers(&numDrivers);
+    if (phDrivers == NULL) {
+        return NULL;
+    }
+
+    ze_driver_handle_t hDriver = phDrivers[0];
+    GMG_FREE(phDrivers);
+    GMGLOG(LDMSD_LINFO, "<<getDriver()\n");
+    return hDriver;
+}
+
+ze_device_handle_t *enumerateGpuDevices(ze_driver_handle_t hDriver, uint32_t *pCount) {
+    GMGLOG(LDMSD_LINFO, ">>enumerateGpuDevices()\n");
+
+    ze_result_t res = gmgDeviceGet(hDriver, pCount, NULL);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!gmgDeviceGet(hDriver=%p,pCount=%p,NULL) => 0x%x\n", hDriver, pCount, res);
+        return NULL;
+    }
+    GMGLOG(LDMSD_LDEBUG, "*pCount = %d\n", *pCount);
+    if (*pCount < 1) {
+        GMGLOG(LDMSD_LERROR, "!!!*pCount=%d < 1\n", *pCount);
+        return NULL;
+    }
+
+    ze_device_handle_t *phDevices = GMG_MALLOC(sizeof(ze_device_handle_t) * *pCount);
+    res = gmgDeviceGet(hDriver, pCount, phDevices);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!gmgDeviceGet(hDriver=%p,pCount=%p,phDevices=%p) => 0x%x\n", hDriver, pCount,
+               phDevices, res);
+        GMG_FREE(phDevices);
+        return NULL;
+    }
+
+    GMGLOG(LDMSD_LINFO, "<<enumerateGpuDevices()\n");
+    return phDevices;
+}
+
+void freeZeDeviceHandle(
+        ze_device_handle_t *
+        phDevice) {
+    GMG_FREE(phDevice);
+}
+
+const char *getGpuDeviceName(
+        ze_device_handle_t hDevice) {
+    static char szName[ZE_MAX_DEVICE_NAME+1];
+    memset(szName, 0, sizeof(szName)/sizeof(szName[0]));
+
+    ze_device_properties_t deviceProperties = {
+            ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES};
+
+    ze_result_t res = gmgDeviceGetProperties(hDevice, &deviceProperties);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!gmgDeviceGetProperties(hDevice=%p, &deviceProperties=%p) => 0x%x",
+               hDevice, &deviceProperties, res);
+        return szName;
+    }
+
+    size_t nameLength = strnlen(deviceProperties.name, ZE_MAX_DEVICE_NAME);
+    GMGLOG(LDMSD_LDEBUG, "%s has length = %ld\n", deviceProperties.name, nameLength);
+
+    strncpy(szName, deviceProperties.name, ZE_MAX_DEVICE_NAME);
+    return szName;
+}
+
+const uint8_t *getGpuUuid(
+        ze_device_handle_t hDevice) {
+    static uint8_t uuid[ZE_MAX_DEVICE_UUID_SIZE];
+    memset(uuid, 0, ZE_MAX_DEVICE_UUID_SIZE);
+
+    ze_device_properties_t deviceProperties = {
+            ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES};
+
+    ze_result_t res = gmgDeviceGetProperties(hDevice, &deviceProperties);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!gmgDeviceGetProperties(hDevice=%p, &deviceProperties=%p) => 0x%x",
+               hDevice, &deviceProperties, res);
+        return uuid;
+    }
+
+    for (size_t i = 0; i < ZE_MAX_DEVICE_UUID_SIZE; i++) {
+        uuid[i] = deviceProperties.uuid.id[i];
+    }
+
+    return uuid;
+}
+
+static zes_engine_handle_t *getEngineDomains(ze_device_handle_t hDevice, uint32_t *pCount) {
+    gmgsDeviceEnumEngineGroups(hDevice, pCount, NULL);
+    if (*pCount == 0) {
+        GMGLOG(LDMSD_LERROR, "!!!count = 0\n");
+        return NULL;
+    }
+
+    size_t memSize = sizeof(zes_engine_handle_t) * *pCount;
+    zes_engine_handle_t *phEngine = GMG_MALLOC(memSize);
+    ze_result_t res = gmgsDeviceEnumEngineGroups(hDevice, pCount, phEngine);
+
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!gmgsDeviceEnumEngineGroups(hDevice=%p,pCount=%p,phEngine=%p) => 0x%x\n",
+               hDevice, pCount, phEngine, res);
+        GMG_FREE(phEngine);
+        return NULL;
+    }
+
+    return phEngine;
+}
+
+double getGpuUtilization(ze_device_handle_t hDevice) {
+    uint32_t count = 0;
+    zes_engine_handle_t *phEngine = getEngineDomains(hDevice, &count);
+    if (phEngine == NULL) {
+        GMGLOG(LDMSD_LERROR, "!!!getEngineDomains(hDevice=%p, &count=%p) => NULL, count=%d\n", hDevice, &count, count);
+        return -99.9;
+    }
+
+    zes_engine_stats_t engineStats0 = {};
+    zes_engine_stats_t engineStats1 = {};
+
+    double gpuUtilization = -99.9;
+    do {
+        // ZES_ENGINE_GROUP_ALL is 0
+        if (gmgsEngineGetActivity(phEngine[ZES_ENGINE_GROUP_ALL], &engineStats0) != ZE_RESULT_SUCCESS) {
+            break;
+        }
+        if (msSleep(samplingIntervalInMs) != 0) {
+            break;
+        }
+        if (gmgsEngineGetActivity(phEngine[ZES_ENGINE_GROUP_ALL], &engineStats1) != ZE_RESULT_SUCCESS) {
+            break;
+        }
+
+        gpuUtilization = 100.0 * (engineStats1.activeTime - engineStats0.activeTime) /    // in percentage
+                         (engineStats1.timestamp - engineStats0.timestamp);
+    } while (false);
+    GMG_FREE(phEngine);
+
+    return gpuUtilization;
+}
+
+static
+zes_mem_handle_t *getMemoryModules(ze_device_handle_t hDevice, uint32_t *pCount) {
+    zesDeviceEnumMemoryModules(hDevice, pCount, NULL);
+    if (*pCount == 0) {
+        GMGLOG(LDMSD_LERROR, "!!!Could not retrieve memory modules\n");
+        return NULL;
+    }
+    size_t memSize = sizeof(zes_engine_handle_t) * *pCount;
+    zes_mem_handle_t *phMemoryModules = GMG_MALLOC(memSize);
+    ze_result_t res =zesDeviceEnumMemoryModules(hDevice, pCount, phMemoryModules);
+
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!zesDeviceEnumMemoryModules(hDevice=%p,pCount=%p,phMemoryModules=%p) => 0x%x\n",
+               hDevice, pCount, phMemoryModules, res);
+        GMG_FREE(phMemoryModules);
+        return NULL;
+    }
+
+    return phMemoryModules;
+}
+
+double getMemoryUtilization(
+        ze_device_handle_t hDevice) {
+    if (g_bIsInSimulationMode) {
+        return 4.0;
+    }
+
+    uint32_t count = 0;
+    zes_mem_handle_t *phMemoryModules = getMemoryModules(hDevice, &count);
+    if (phMemoryModules == NULL) {
+        GMGLOG(LDMSD_LERROR, "!!!getMemoryModules(hDevice=%p, &count=%p) => NULL, count=%d\n", hDevice, &count, count);
+        return -99.9;
+    }
+
+    int64_t allocatableMemory = 0;
+    int64_t usedMemory = 0;
+
+    for (size_t i = 0; i < count; i++) {
+        zes_mem_state_t memoryState = {};
+        zesMemoryGetState(phMemoryModules[i], &memoryState);
+        allocatableMemory += memoryState.size;
+        usedMemory += memoryState.size - memoryState.free;
+    }
+    if (allocatableMemory == 0) {
+        return 0.0;
+    }
+    GMG_FREE(phMemoryModules);
+
+    return (100.0 * usedMemory) / allocatableMemory; // in percentage
+}
+
+
+uint64_t getMemVRAMUsed(ze_device_handle_t hDevice) {
+    if (g_bIsInSimulationMode) {
+        return 42424242;
+    }
+
+    uint32_t count = 0;
+    zes_mem_handle_t *phMemoryModules = getMemoryModules(hDevice, &count);
+    if (phMemoryModules == NULL) {
+        GMGLOG(LDMSD_LERROR, "!!!getMemoryModules(hDevice=%p, &count=%p) => NULL, count=%d\n", hDevice, &count, count);
+        return 999999;
+    }
+
+    int64_t usedMemory = 0;
+    for (size_t i = 0; i < count; i++) {
+        zes_mem_state_t memoryState = {};
+        zesMemoryGetState(phMemoryModules[i], &memoryState);
+        usedMemory += memoryState.size - memoryState.free;
+    }
+    GMG_FREE(phMemoryModules);
+
+    return usedMemory;
+}
+
+
+int32_t getSysClockFreq(ze_device_handle_t hDevice) {
+    if (g_bIsInSimulationMode) {
+        return 4242;
+    }
+
+    ze_device_properties_t deviceProperties = {
+            ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES};
+    if (zeDeviceGetProperties(hDevice, &deviceProperties) != ZE_RESULT_SUCCESS) {
+        return 9999;
+    }
+    return deviceProperties.coreClockRate;
+}
+
+int64_t getCumulativeReadCounter(zes_mem_handle_t *phMemoryModules, uint32_t count) {
+    int64_t cumulativeReadCount = 0;
+    for (uint32_t i = 0; i < count; i++) {
+        zes_mem_bandwidth_t memoryBandwidth = {};
+        if (zesMemoryGetBandwidth(phMemoryModules[i], &memoryBandwidth) != ZE_RESULT_SUCCESS) {
+            return -9999;
+        }
+        GMGLOG(LDMSD_LDEBUG, "memoryBandwidth.readCounter = %ld\n", memoryBandwidth.readCounter);
+        cumulativeReadCount += memoryBandwidth.readCounter;
+    }
+
+    return cumulativeReadCount;
+}
+
+double getMemoryReadBandwidth(ze_device_handle_t hDevice) {
+    if (g_bIsInSimulationMode) {
+        return 42.0;
+    }
+
+    uint32_t count = 0;
+    zes_mem_handle_t *phMemoryModules = getMemoryModules(hDevice, &count);
+    if (phMemoryModules == NULL) {
+        GMGLOG(LDMSD_LERROR, "!!!getMemoryModules(hDevice=%p, &count=%p) => NULL, count=%d\n", hDevice, &count, count);
+        return 999999.0;
+    }
+    GMGLOG(LDMSD_LDEBUG, "count = %d\n", count);
+
+    double bandwidth = -99999.0;
+    do {
+        int64_t cumulativeReadCounter0 = getCumulativeReadCounter(phMemoryModules, count);
+        if (cumulativeReadCounter0 < 0) {
+            break;
+        }
+        if (msSleep(samplingIntervalInMs) != 0) {
+            break;
+        }
+        int64_t cumulativeReadCounter1 = getCumulativeReadCounter(phMemoryModules, count);
+        if (cumulativeReadCounter1 < 0) {
+            break;
+        }
+
+        int64_t bytesRead = cumulativeReadCounter1 - cumulativeReadCounter0;
+        bandwidth = (double) bytesRead / samplingIntervalInMs;
+    } while (false);
+    GMG_FREE(phMemoryModules);
+
+    return bandwidth;
+}
+
+int64_t getCumulativeWriteCounter(zes_mem_handle_t *phMemoryModules, uint32_t count) {
+    int64_t cumulativeWriteCount = 0;
+    for (uint32_t i = 0; i < count; i++) {
+        zes_mem_bandwidth_t memoryBandwidth = {};
+        if (zesMemoryGetBandwidth(phMemoryModules[i], &memoryBandwidth) != ZE_RESULT_SUCCESS) {
+            return -9999;
+        }
+        GMGLOG(LDMSD_LDEBUG, "memoryBandwidth.writeCounter = %ld\n", memoryBandwidth.writeCounter);
+        cumulativeWriteCount += memoryBandwidth.writeCounter;
+    }
+
+    return cumulativeWriteCount;
+}
+
+double getMemoryWriteBandwidth(ze_device_handle_t hDevice) {
+    if (g_bIsInSimulationMode) {
+        return 24.0;
+    }
+
+    uint32_t count = 0;
+    zes_mem_handle_t *phMemoryModules = getMemoryModules(hDevice, &count);
+    if (phMemoryModules == NULL) {
+        GMGLOG(LDMSD_LERROR, "!!!getMemoryModules(hDevice=%p, &count=%p) => NULL, count=%d\n", hDevice, &count, count);
+        return 999999.0;
+    }
+    GMGLOG(LDMSD_LDEBUG, "count = %d\n", count);
+
+    double bandwidth = -99999.0;
+    do {
+        int64_t cumulativeWriteCounter0 = getCumulativeWriteCounter(phMemoryModules, count);
+        if (cumulativeWriteCounter0 < 0) {
+            break;
+        }
+        if (msSleep(samplingIntervalInMs) != 0) {
+            break;
+        }
+        int64_t cumulativeWriteCounter1 = getCumulativeWriteCounter(phMemoryModules, count);
+        if (cumulativeWriteCounter1 < 0) {
+            break;
+        }
+
+        int64_t bytesWritten = cumulativeWriteCounter1 - cumulativeWriteCounter0;
+        bandwidth = (double) bytesWritten / samplingIntervalInMs;
+    } while (false);
+    GMG_FREE(phMemoryModules);
+
+    return bandwidth;
+}
+
+zes_perf_handle_t *getPerformanceFactorDomains(ze_device_handle_t hDevice, uint32_t *pCount) {
+    ze_result_t res = zesDeviceEnumPerformanceFactorDomains(hDevice, pCount, NULL);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!zesDeviceEnumPerformanceFactorDomains(hDevice=%p,&count=%p,NULL) => 0x%x\n",
+               hDevice, pCount, res);
+        return NULL;
+    }
+    if (*pCount == 0) {
+        GMGLOG(LDMSD_LERROR, "!!!Could not retrieve performance factor domains: *pCount = 0\n");
+        return NULL;
+    }
+
+    size_t memSize = sizeof(zes_perf_handle_t) * *pCount;
+    zes_perf_handle_t *phPerf = GMG_MALLOC(memSize);
+
+    res = zesDeviceEnumPerformanceFactorDomains(hDevice, pCount, phPerf);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!zesDeviceEnumPerformanceFactorDomains(hDevice=%p,pCount=%p,phPerf=%p) => 0x%x\n",
+               hDevice, pCount, phPerf, res);
+        GMG_FREE(phPerf);
+        return NULL;
+    }
+    return phPerf;
+}
+
+double getPerfLevel(ze_device_handle_t hDevice) {
+    if (g_bIsInSimulationMode) {
+        return 4.0;
+    }
+
+    uint32_t count = 0;
+    zes_perf_handle_t *pHandle = getPerformanceFactorDomains(hDevice, &count);
+    if (pHandle == NULL) {
+        return -9999.9;
+    }
+    GMGLOG(LDMSD_LDEBUG, "count = %d\n", count);
+
+    double originalFactor = -9999.9;
+    ze_result_t res = zesPerformanceFactorGetConfig(pHandle[0], &originalFactor);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!zesPerformanceFactorGetConfig(pHandle[0]=%p,&originalFactor=%p) => 0x%x\n",
+               pHandle[0], &originalFactor, res);
+    }
+    GMG_FREE(pHandle);
+
+    return originalFactor;
+}
+
+zes_pwr_handle_t *getPowerDomains(ze_device_handle_t hDevice, uint32_t *pCount) {
+    ze_result_t res = zesDeviceEnumPowerDomains(hDevice, pCount, NULL);
+    if (res != ZE_RESULT_SUCCESS) {
+        return NULL;
+    }
+    if (*pCount == 0) {
+        GMGLOG(LDMSD_LERROR, "!!!Could not retrieve power domains: *pCount == 0\n");
+        return NULL;
+    }
+
+    size_t memSize = sizeof(zes_pwr_handle_t) * *pCount;
+    zes_pwr_handle_t *phPower = GMG_MALLOC(memSize);
+
+    res = zesDeviceEnumPowerDomains(hDevice, pCount, phPower);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!zesDeviceEnumPowerDomains(hDevice=%p,pCount=%p,phPower=%p) => 0x%x\n",
+               hDevice, pCount, phPower, res);
+        GMG_FREE(phPower);
+        return NULL;
+    }
+    return phPower;
+}
+
+int32_t getPowerUsage(ze_device_handle_t hDevice) {
+    if (g_bIsInSimulationMode) {
+        return 42;
+    }
+
+    uint32_t count = 0;
+    zes_pwr_handle_t *pHandle = getPowerDomains(hDevice, &count);
+    if (pHandle == NULL) {
+        return -99;
+    }
+    GMGLOG(LDMSD_LDEBUG, "count = %d\n", count);
+
+    int32_t powerUsage = -999;
+    do {
+        zes_power_energy_counter_t energyCounter0, energyCounter1;
+        if (zesPowerGetEnergyCounter(pHandle[0], &energyCounter0) != ZE_RESULT_SUCCESS) {
+            break;
+        }
+        if (msSleep(samplingIntervalInMs) != 0) {
+            break;
+        }
+        if (zesPowerGetEnergyCounter(pHandle[0], &energyCounter1) != ZE_RESULT_SUCCESS) {
+            break;
+        }
+        powerUsage = (energyCounter1.energy - energyCounter0.energy) /
+                     (energyCounter1.timestamp - energyCounter0.timestamp);
+    } while (false);
+    GMG_FREE(pHandle);
+
+    return powerUsage;
+}
+
+int32_t getPowerCap(ze_device_handle_t hDevice) {
+    if (g_bIsInSimulationMode) {
+        return 424242;
+    }
+
+    uint32_t count = 0;
+    zes_pwr_handle_t *pHandle = getPowerDomains(hDevice, &count);
+    if (pHandle == NULL) {
+        return -99;
+    }
+    GMGLOG(LDMSD_LDEBUG, "count = %d\n", count);
+
+    zes_power_properties_t properties;
+    ze_result_t res = zesPowerGetProperties(pHandle[0], &properties);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!zesPowerGetProperties(pHandle[0]=%p,&properties=%p) => 0x%x\n",
+               pHandle[0], &properties, res);
+        return -9999;
+    }
+    GMG_FREE(pHandle);
+
+    return properties.maxLimit;
+}
+
+zes_temp_handle_t *getDeviceEnumTemperatureSensors(ze_device_handle_t hDevice, uint32_t *pCount) {
+    ze_result_t res = zesDeviceEnumTemperatureSensors(hDevice, pCount, NULL);
+    if (res != ZE_RESULT_SUCCESS) {
+        return NULL;
+    }
+    if (*pCount == 0) {
+        GMGLOG(LDMSD_LERROR, "!!!Could not enum temperature sensors: *pCount == 0\n");
+        return NULL;
+    }
+
+    size_t memSize = sizeof(zes_temp_handle_t) * *pCount;
+    zes_temp_handle_t *pHandle = GMG_MALLOC(memSize);
+
+    res = zesDeviceEnumTemperatureSensors(hDevice, pCount, pHandle);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!zesDeviceEnumTemperatureSensors(hDevice=%p,pCount=%p,pHandle=%p) => 0x%x\n",
+               hDevice, pCount, pHandle, res);
+        GMG_FREE(pHandle);
+        return NULL;
+    }
+
+    return pHandle;
+}
+
+double getGpuTemp(ze_device_handle_t hDevice) {
+    if (g_bIsInSimulationMode) {
+        return 42.0;
+    }
+
+    uint32_t count = 0;
+    zes_temp_handle_t *pHandle = getDeviceEnumTemperatureSensors(hDevice, &count);
+    if (pHandle == NULL) {
+        return -99.0;
+    }
+    GMGLOG(LDMSD_LDEBUG, "count = %d\n", count);
+
+    double gpuTemperature = -999.0;
+
+    ze_result_t res = zesTemperatureGetState(pHandle[0], &gpuTemperature);
+    if (res != ZE_RESULT_SUCCESS) {
+        return -99.9;
+    }
+    GMG_FREE(pHandle);
+
+    return gpuTemperature;
+}
+
+int64_t getPciMaxSpeed(
+        zes_device_handle_t hDevice) {
+    if (g_bIsInSimulationMode) {
+        return 424242;
+    }
+    zes_pci_stats_t state = {};
+
+    ze_result_t res = zesDevicePciGetStats(hDevice, &state);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!zesDevicePciGetStats(hDevice=%p,&state=%p) => 0x%x\n",
+               hDevice, &state, res);
+        return -99999;
+    }
+    return state.speed.maxBandwidth;
+}
+
+static ze_result_t gmgsDeviceGetProperties(
+        zes_device_handle_t hDevice,
+        zes_device_properties_t *pDeviceProperties) {
+    if (g_bIsInSimulationMode) {
+        strncpy(pDeviceProperties->serialNumber, "GPU Serial Number 999", ZES_STRING_PROPERTY_SIZE);
+        return ZE_RESULT_SUCCESS;
+    }
+
+    return zesDeviceGetProperties(hDevice, pDeviceProperties);
+}
+
+const char *getGpuSerialNumber(
+        zes_device_handle_t hDevice) {
+    static char szSerialNumber[ZES_STRING_PROPERTY_SIZE+1];
+    memset(szSerialNumber, 0, sizeof(szSerialNumber)/sizeof(szSerialNumber[0]));
+
+    zes_device_properties_t deviceProperties = {
+            ZES_STRUCTURE_TYPE_DEVICE_PROPERTIES};
+
+    ze_result_t res = gmgsDeviceGetProperties(hDevice, &deviceProperties);
+    if (res != ZE_RESULT_SUCCESS) {
+        GMGLOG(LDMSD_LERROR, "!!!gmgsDeviceGetProperties(hDevice=%p, &deviceProperties=%p) => 0x%x",
+               hDevice, &deviceProperties, res);
+        return szSerialNumber;
+    }
+
+    size_t serialNumberLength = strnlen(deviceProperties.serialNumber, ZES_STRING_PROPERTY_SIZE);
+    GMGLOG(LDMSD_LDEBUG, "%s has length = %ld\n", deviceProperties.serialNumber, serialNumberLength);
+
+    strncpy(szSerialNumber, deviceProperties.serialNumber, ZES_STRING_PROPERTY_SIZE);
+    return szSerialNumber;
+}

--- a/ldms/src/contrib/sampler/gpu_metrics_sampler/gather_gpu_metrics_from_one_api.h
+++ b/ldms/src/contrib/sampler/gpu_metrics_sampler/gather_gpu_metrics_from_one_api.h
@@ -1,0 +1,160 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef _GATHER_GPU_METRICS_FROM_ONE_API_H
+#define _GATHER_GPU_METRICS_FROM_ONE_API_H
+
+#if defined(__cplusplus)
+#pragma once
+#endif
+
+#include "gmg_common_util.h"
+#include <level_zero/zes_api.h>
+
+
+#define SAMP "gpu_metrics"
+#define MAX_METRIC_NAME_LENGTH 256
+#define MAX_NUMBER_DEVICE_INDEX 255
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#ifdef ENABLE_AUTO_SIMULATION
+#define SIMULATION_CONTROL_FILE "/opt/ucs/RUN_GPU_METRICS_GATHERERS_IN_SIMULATION_MODE"
+void autoSetSimulationMode();
+#endif
+
+size_t getMallocCount();
+
+bool getSimulationMode();
+
+void setSimulationMode(
+        bool isInSimulationMode
+);
+
+
+ze_result_t initializeOneApi();
+
+ze_driver_handle_t getDriver();
+
+ze_device_handle_t *enumerateGpuDevices(
+        ze_driver_handle_t hDriver,
+        uint32_t *pCount
+);
+
+void freeZeDeviceHandle(
+        ze_device_handle_t *phDevice
+);
+
+const char *getGpuDeviceName(
+        ze_device_handle_t hDevice
+);
+
+const uint8_t *getGpuUuid(
+        ze_device_handle_t hDevice
+);
+
+/**
+ * When invoked in SAMPLING mode, this function returns the actual gpu utilization.  When invoked in SIMULATION mode,
+ * this function returns fluctuating simulated gpu utilization.
+ * @param hDevice handle to gpu device.
+ * @return gpu utilization in percentage.
+ */
+double getGpuUtilization(
+        ze_device_handle_t hDevice
+);
+
+double getMemoryUtilization(
+        ze_device_handle_t hDevice
+);
+
+uint64_t getMemVRAMUsed(
+        ze_device_handle_t hDevice
+);
+
+int32_t getSysClockFreq(
+        ze_device_handle_t hDevice
+);
+
+double getMemoryReadBandwidth(
+        ze_device_handle_t hDevice
+);
+
+double getMemoryWriteBandwidth(
+        ze_device_handle_t hDevice
+);
+
+double getPerfLevel(
+        ze_device_handle_t hDevice
+);
+
+int32_t getPowerUsage(
+        ze_device_handle_t hDevice
+);
+
+int32_t getPowerCap(
+        ze_device_handle_t hDevice
+);
+
+double getGpuTemp(
+        ze_device_handle_t hDevice
+);
+
+int64_t getPciMaxSpeed(
+        zes_device_handle_t hDevice
+);
+
+const char *getGpuSerialNumber(
+        zes_device_handle_t hDevice
+);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif // __cplusplus
+
+#endif // _GATHER_GPU_METRICS_FROM_ONE_API_H

--- a/ldms/src/contrib/sampler/gpu_metrics_sampler/gmg_common_util.c
+++ b/ldms/src/contrib/sampler/gpu_metrics_sampler/gmg_common_util.c
@@ -1,0 +1,111 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "gmg_common_util.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <pthread.h>
+#include <string.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+
+const uint64_t MILLION = 1000 * 1000;
+const uint64_t THOUSAND = 1000;
+
+int msSleep(long ms) {
+    struct timespec ts;
+    int res;
+
+    if (ms < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    ts.tv_sec = ms / THOUSAND;
+    ts.tv_nsec = (ms % THOUSAND) * MILLION;
+
+    do {
+        res = nanosleep(&ts, &ts);
+    } while (res && errno == EINTR);
+
+    return res;
+}
+
+uint64_t getMsTimestamp() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);    // 0 - success; -1 error, EINVAL clock_id not CLOCK_REALTIME
+    return (uint64_t) ts.tv_sec * THOUSAND + (uint64_t) ts.tv_nsec / MILLION;
+}
+
+#ifdef ENABLE_AUTO_SIMULATION
+/**
+ * This function when used will cause a KW TOCTOU warning.  There is basically NO known solution.  So,
+ * we should not use this in production code.
+ */
+bool isFileExists(const char *szFilePath) {
+    return access(szFilePath, F_OK) == 0;
+}
+#endif
+
+#define UUID_LENGTH 16
+#define UUID_CHAR_BUFFER_SIZE 2 * UUID_LENGTH + 4 + 1
+const char *convertUuidToString(const uint8_t *uuid) {
+    static char szUuid[UUID_CHAR_BUFFER_SIZE];
+    memset(szUuid, 0, UUID_CHAR_BUFFER_SIZE);
+
+    snprintf(szUuid, UUID_CHAR_BUFFER_SIZE,
+             "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+             uuid[0], uuid[1], uuid[2], uuid[3], uuid[4], uuid[5], uuid[6], uuid[7],
+             uuid[8], uuid[9], uuid[10], uuid[11], uuid[12], uuid[13], uuid[14], uuid[15]
+    );
+
+    return szUuid;
+}

--- a/ldms/src/contrib/sampler/gpu_metrics_sampler/gmg_common_util.h
+++ b/ldms/src/contrib/sampler/gpu_metrics_sampler/gmg_common_util.h
@@ -1,0 +1,83 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef _GMG_COMMON_UTIL_H_
+#define _GMG_COMMON_UTIL_H_
+
+#if defined(__cplusplus)
+#pragma once
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+
+
+#define MIN(a, b) (((a)<(b))?(a):(b))
+#define MAX(a, b) (((a)>(b))?(a):(b))
+
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+int msSleep(long ms);
+
+u_int64_t getMsTimestamp();
+
+#ifdef ENABLE_AUTO_SIMULATION
+bool isFileExists(const char *szFilePath);
+#endif
+
+const char *convertUuidToString(const uint8_t *uuid);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // _GMG_COMMON_UTIL_H_

--- a/ldms/src/contrib/sampler/gpu_metrics_sampler/gmg_ldms_util.c
+++ b/ldms/src/contrib/sampler/gpu_metrics_sampler/gmg_ldms_util.c
@@ -1,0 +1,208 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2022 Intel Corporation
+ * Copyright (c) 2011-2018 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ * Copyright (c) 2011-2018 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "gmg_log.h"
+#include "gmg_ldms_util.h"
+#include <level_zero/zes_api.h>
+
+
+const metric_t metricsDefinitions[] = {
+        {.name = "device_name", .type = LDMS_V_CHAR_ARRAY, .pf = (funcPtr_t) getGpuDeviceName, .count = ZE_MAX_DEVICE_NAME},
+        {.name = "device_uuid", .type = LDMS_V_U8_ARRAY, .pf = (funcPtr_t) getGpuUuid, .count = ZE_MAX_DEVICE_UUID_SIZE},
+        {.name = "serial_number", .type = LDMS_V_CHAR_ARRAY, .pf = (funcPtr_t) getGpuSerialNumber, .count = ZES_STRING_PROPERTY_SIZE},
+        {.name = "gpu_util (%)", .type = LDMS_V_D64, .pf = (funcPtr_t) getGpuUtilization},
+        {.name = "mem_util (%)", .type = LDMS_V_D64, .pf = (funcPtr_t) getMemoryUtilization},
+        {.name = "mem_vram_used", .type = LDMS_V_U64, .pf = (funcPtr_t) getMemVRAMUsed},
+        {.name = "sys_clock_freq (MHz)", .type = LDMS_V_S32, .pf = (funcPtr_t) getSysClockFreq},
+        {.name = "mem_read_bandwidth (kilobaud)", .type = LDMS_V_D64, .pf = (funcPtr_t) getMemoryReadBandwidth},
+        {.name = "mem_write_bandwidth (kilobaud)", .type = LDMS_V_D64, .pf = (funcPtr_t) getMemoryWriteBandwidth},
+        {.name = "perf_level", .type = LDMS_V_D64, .pf = (funcPtr_t) getPerfLevel},
+        {.name = "power_usage (mW)", .type = LDMS_V_S32, .pf = (funcPtr_t) getPowerUsage},
+//        {.name = "power_cap (mW)", .type = LDMS_V_S32, .pf = (funcPtr_t) getPowerCap},    // no longer supported
+        {.name = "gpu_temp (Celsius)", .type = LDMS_V_D64, .pf = (funcPtr_t) getGpuTemp},
+//        {.name = "pci_max_bandwidth (baud)", .type = LDMS_V_U64, .pf = (funcPtr_t) getPciMaxSpeed}    // currently OneAPI does not support this
+};
+
+const size_t c_numMetrics = sizeof(metricsDefinitions) / sizeof(metricsDefinitions[0]);
+
+/**
+* Functions only used by gmg_test.
+*/
+
+void constructMetricName(const char *szBaseMetricName, uint8_t deviceId, char *szMetricName) {
+    snprintf(szMetricName, MAX_METRIC_NAME_LENGTH, "gpu%02x.", deviceId);
+    strncpy(szMetricName + 6, szBaseMetricName, MAX_METRIC_NAME_LENGTH - 6);
+    GMGLOG(LDMSD_LDEBUG, "metricName = %s\n", szMetricName);
+}
+
+/**
+ * Populates the GPU metric schema.  This is analogous to an SQL CREATE TABLE.
+ * @param schema This is a schema pointer.
+ * @param numDevices Number of GPU devices.
+ * @return >= The index of the last metric index added.
+ *         <0 Insufficient resources or duplicate name.
+ *
+ */
+int populateMetricSchema(ldms_schema_t schema, uint32_t numDevices) {
+    int rc = 0;
+
+    for (uint32_t deviceId = 0; deviceId < MIN(numDevices, MAX_NUMBER_DEVICE_INDEX); deviceId++) {
+        for (size_t i = 0; i < c_numMetrics; i++) {
+            char szMetricName[MAX_METRIC_NAME_LENGTH + 1] = {};
+            constructMetricName(metricsDefinitions[i].name, deviceId, szMetricName);
+            GMGLOG(LDMSD_LDEBUG, "metricsDefinitions[i=%d].name = %s\n", i, metricsDefinitions[i].name);
+            GMGLOG(LDMSD_LDEBUG, "szMetricName = %s\n", szMetricName);
+            if (ldms_type_is_array(metricsDefinitions[i].type)) {
+                rc = ldms_schema_metric_array_add(schema, szMetricName,
+                                                  metricsDefinitions[i].type, metricsDefinitions[i].count);
+            } else {
+                rc = ldms_schema_metric_add(schema, szMetricName, metricsDefinitions[i].type);
+            }
+            if (rc < 0) {
+                GMGLOG(LDMSD_LERROR, "!!!Insufficient resources or duplicate name: rc = %d\n", rc);
+                break;
+            }
+        }
+    }
+
+    return rc;
+}
+
+
+void setD64(ldms_set_t s, int metricId, ze_device_handle_t hDevice, doubleGetMetricFuncPtr_t pf) {
+    if (pf == NULL) {
+        GMGLOG(LDMSD_LERROR, "pf == NULL\n");
+        return;
+    }
+
+    double val = pf(hDevice);
+    GMGLOG(LDMSD_LINFO, "doublePf(hDevice=%p) => %lf\n", hDevice, val);
+
+    ldms_metric_set_double(s, metricId, val);
+}
+
+void setU64(ldms_set_t s, int metricId, ze_device_handle_t hDevice, u64GetMetricFuncPtr_t pf) {
+    if (pf == NULL) {
+        GMGLOG(LDMSD_LERROR, "pf == NULL\n");
+        return;
+    }
+
+    uint64_t val = pf(hDevice);
+    GMGLOG(LDMSD_LINFO, "u64GetMetricFuncPtr_t(hDevice=%p) => %ld\n", hDevice, val);
+
+    ldms_metric_set_u64(s, metricId, val);
+}
+
+void setS32(ldms_set_t s, int metricId, ze_device_handle_t hDevice, s32GetMetricFuncPtr_t pf) {
+    if (pf == NULL) {
+        GMGLOG(LDMSD_LERROR, "pf == NULL\n");
+        return;
+    }
+
+    int32_t val = pf(hDevice);
+    GMGLOG(LDMSD_LINFO, "s32GetMetricFuncPtr_t(hDevice=%p) => %d\n", hDevice, val);
+
+    ldms_metric_set_s32(s, metricId, val);
+}
+
+void setString(ldms_set_t s,
+               int metricId,
+               ze_device_handle_t hDevice,
+               stringGetMetricFuncPtr_t pf) {
+    const char *str = pf(hDevice);
+    ldms_metric_array_set_str(s, metricId, str);    // ldms_metric_array_set_str does not require a length argument
+}
+
+void setU8Array(ldms_set_t s, int metricId, ze_device_handle_t hDevice,
+                const8PtrGetMetricFuncPtr_t pf, uint32_t count) {
+    const uint8_t *u8Array = pf(hDevice);
+    for (uint32_t j = 0; j < count; j++) {
+        ldms_metric_array_set_u8(s, metricId, j, u8Array[j]);
+    }
+}
+
+/**
+ * Populates the GPU metrics set.  This is analogous to a row in an SQL table.
+ * @param phDevices device handle.
+ * @param numDevices Number of GPU devices.
+ * @param s Metrics set.
+ * @param firstGpuMetricId Index to first GPU metric.
+ */
+void populateMetricSet(ze_device_handle_t *phDevices, uint32_t numDevices, ldms_set_t s, int firstGpuMetricId) {
+    int metricId = firstGpuMetricId;
+
+    for (uint32_t deviceId = 0; deviceId < numDevices; deviceId++) {
+        for (size_t i = 0; i < c_numMetrics; i++) {
+            switch (metricsDefinitions[i].type) {
+                case LDMS_V_CHAR_ARRAY:
+                    setString(s, metricId++, phDevices[deviceId],
+                              (stringGetMetricFuncPtr_t) (metricsDefinitions[i].pf));
+                    break;
+                case LDMS_V_U8_ARRAY:
+                    setU8Array(s, metricId++, phDevices[deviceId],
+                               (const8PtrGetMetricFuncPtr_t) (metricsDefinitions[i].pf), metricsDefinitions[i].count);
+                    break;
+                case LDMS_V_D64:
+                    setD64(s, metricId++, phDevices[deviceId], (doubleGetMetricFuncPtr_t) (metricsDefinitions[i].pf));
+                    break;
+                case LDMS_V_S32:
+                    setS32(s, metricId++, phDevices[deviceId], (s32GetMetricFuncPtr_t) (metricsDefinitions[i].pf));
+                    break;
+                case LDMS_V_U64:
+                    setU64(s, metricId++, phDevices[deviceId], (u64GetMetricFuncPtr_t) (metricsDefinitions[i].pf));
+                    break;
+                default:
+                    GMGLOG(LDMSD_LERROR, "!!!Unexpected metric type: %d\n", metricsDefinitions[i].type);
+                    break;
+            }
+        }
+    }
+}

--- a/ldms/src/contrib/sampler/gpu_metrics_sampler/gmg_ldms_util.h
+++ b/ldms/src/contrib/sampler/gpu_metrics_sampler/gmg_ldms_util.h
@@ -1,0 +1,110 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2022 Intel Corporation
+ * Copyright (c) 2011-2018 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ * Copyright (c) 2011-2018 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef _GMG_LDMS_UTIL_H_
+#define _GMG_LDMS_UTIL_H_
+
+#include "gmg_log.h"
+#include "gather_gpu_metrics_from_one_api.h"    // brings in OneAPI headers
+
+
+typedef void (*funcPtr_t)(void);
+
+typedef const char *(*stringGetMetricFuncPtr_t)(ze_device_handle_t);
+typedef const uint8_t *(*const8PtrGetMetricFuncPtr_t)(ze_device_handle_t);
+typedef double (*doubleGetMetricFuncPtr_t)(ze_device_handle_t);
+typedef uint64_t (*u64GetMetricFuncPtr_t)(ze_device_handle_t);
+typedef int32_t (*s32GetMetricFuncPtr_t)(ze_device_handle_t);
+
+typedef struct metric {
+    const char *name;
+    enum ldms_value_type type;
+    funcPtr_t pf;
+    uint32_t count;
+} metric_t;
+
+
+extern const metric_t metricsDefinitions[];
+extern const size_t c_numMetrics;
+
+
+/**
+ * These functions are only used by the LDMS plugin to upload
+ * the GPU metrics to LDMS.
+ */
+
+/**
+ * Populates the GPU metric schema.  This is analogous to an SQL CREATE TABLE.
+ * @param schema This is a schema pointer.
+ * @param numDevices Number of GPU devices.
+ * @return >= The index of the last metric index added.
+ *         <0 Insufficient resources or duplicate name.
+ */
+int populateMetricSchema(
+        ldms_schema_t schema,
+        uint32_t numDevices
+);
+
+/**
+ * Populates the GPU metrics set.  This is analogous to a row in an SQL table.
+ * @param phDevices device handle.
+ * @param numDevices Number of GPU devices.
+ * @param s Metrics set.
+ * @param firstGpuMetricId Index to first GPU metric.
+ */
+void populateMetricSet(
+        ze_device_handle_t *phDevices,
+        uint32_t numDevices,
+        ldms_set_t s,
+        int firstGpuMetricId
+);
+
+#endif // _GMG_LDMS_UTIL_H_

--- a/ldms/src/contrib/sampler/gpu_metrics_sampler/gmg_log.c
+++ b/ldms/src/contrib/sampler/gpu_metrics_sampler/gmg_log.c
@@ -1,0 +1,66 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2022 Intel Corporation
+ * Copyright (c) 2011-2018 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ * Copyright (c) 2011-2018 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "gmg_log.h"
+
+
+static void noopLogFunc(enum ldmsd_loglevel level, const char *fmt, ...) {
+}
+
+ldmsd_msg_log_f msglog = noopLogFunc;
+
+ldmsd_msg_log_f setGmgLoggingFunction(
+        const ldmsd_msg_log_f fp) {
+    ldmsd_msg_log_f oldPf = msglog;
+    msglog = fp;
+    GMGLOG(LDMSD_LDEBUG, "Updated msglog\n");
+    return oldPf;
+}

--- a/ldms/src/contrib/sampler/gpu_metrics_sampler/gmg_log.h
+++ b/ldms/src/contrib/sampler/gpu_metrics_sampler/gmg_log.h
@@ -1,0 +1,73 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2022 Intel Corporation
+ * Copyright (c) 2011-2018 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ * Copyright (c) 2011-2018 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef _GMG_LOG_H_
+#define _GMG_LOG_H_
+
+#if defined(__cplusplus)
+#error "GMGLOG is unavailable in CPP files, since we cannot include ldmsd.h in CPP file.  There will be errors!"
+#endif
+
+#include "ldmsd.h"  // contains log function prototype; return type of log function is void.
+
+extern ldmsd_msg_log_f msglog;
+
+/**
+ * The following are provided for convenience, since msglog is fully accessible.
+ */
+// GMGLOG() is only used in gather_gpu_metrics_from_one_api.c and gmg_ldms_util.c.
+#define GMGLOG(LEVEL, FMT, ...) if (msglog) msglog((LEVEL), (FMT), ##__VA_ARGS__)
+
+ldmsd_msg_log_f setGmgLoggingFunction(
+        const ldmsd_msg_log_f fp  // ldmsd_msg_log_f is already a pointer type
+);
+
+#endif // _GMG_LOG_H_

--- a/ldms/src/contrib/sampler/gpu_metrics_sampler/gpu_metrics_ldms_sampler.c
+++ b/ldms/src/contrib/sampler/gpu_metrics_sampler/gpu_metrics_ldms_sampler.c
@@ -1,0 +1,369 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2022 Intel Corporation
+ * Copyright (c) 2011-2018 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ * Copyright (c) 2011-2018 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#define _GNU_SOURCE
+
+#include <inttypes.h>
+#include <unistd.h>
+#include <sys/errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <sys/types.h>
+#include <time.h>
+#include <pthread.h>
+#include "ldms.h"
+#include "ldmsd.h"
+#include "sampler_base.h"
+
+#include "gmg_ldms_util.h"
+#include "gather_gpu_metrics_from_one_api.h"
+
+
+static uint32_t g_numberOfDevicesInSchema = 0;
+
+static ldms_schema_t schema = NULL;
+static ldms_set_t set = NULL;
+static int metric_offset = 0;
+static base_data_t base = NULL;
+
+#define LBUFSZ 256
+
+void free_set() {
+    if (set) {
+        ldms_set_delete(set);
+        set = NULL;
+    }
+}
+
+void free_schema() {
+    if (schema) {
+        ldms_schema_delete(schema);
+        schema = NULL;
+    }
+}
+
+void free_base() {
+    if (base) {
+        base_del(base);
+        base = NULL;
+    }
+}
+
+ze_driver_handle_t getGpuDriver() {
+    ze_result_t res = initializeOneApi();   // only slow the first time it is called for each process
+    if (res != ZE_RESULT_SUCCESS) {
+        msglog(LDMSD_LERROR, "!!!initializeOneApi() => 0x%x\n", res);
+        return NULL;
+    }
+
+    ze_driver_handle_t hDriver = getDriver();
+    if (hDriver == NULL) {
+        msglog(LDMSD_LERROR, "!!!getDriver() => NULL\n");
+        return NULL;
+    }
+
+    return hDriver;
+}
+
+/**
+ * This function customizes the base plugin instance with the metric set schema of this plugin.  Note that we
+ * are not popluting any data structure with any actual data in this function.
+ * @param base instance of base plugin class.
+ * @return error code.
+ */
+static int create_metric_set_schema_and_set(base_data_t base) {
+    int rc = 0; // return code
+
+    const uint32_t c_minExpectedDevices = 6;
+
+    ze_driver_handle_t hDriver = getGpuDriver();
+    if (hDriver == NULL) {
+        msglog(LDMSD_LERROR, "!!!getGpuDriver() => NULL\n");
+        goto err;
+    }
+
+    uint32_t numDevices = 0;
+    ze_device_handle_t *phDevices = enumerateGpuDevices(hDriver, &numDevices);
+    if (phDevices == NULL) {
+        msglog(LDMSD_LERROR, "!!!enumerateGpuDevices(&numDevices=%p) => NULL, %d\n", &numDevices, numDevices);
+        goto err;
+    }
+    freeZeDeviceHandle(phDevices);
+    phDevices = NULL;
+
+    g_numberOfDevicesInSchema = MAX(numDevices,
+                                    c_minExpectedDevices);     // currently, the HW has space for up to 6 GPUs
+
+    schema = base_schema_new(base);
+    if (!schema) {
+        msglog(LDMSD_LERROR,
+               "!!!%s: The schema '%s' could not be created, errno=%d.\n",
+               __FILE__, base->schema_name, errno);
+        rc = errno;
+        goto err;
+    }
+
+    // Location of first metric to be inserting.  On my test system, a new schema already contains
+    // 3 metrics.  Metric offset is simply the upper bound of where our gpu metrics data reside.
+    // This offset is used by populateMetricSet() since the metrics set needs to be populated with
+    // the same order as the entries in the metric schema.
+    metric_offset = ldms_schema_metric_count_get(schema);
+
+    rc = populateMetricSchema(schema, g_numberOfDevicesInSchema);
+    if (rc < 0) {
+        errno = ENOMEM;
+        goto err;
+    }
+
+    set = base_set_new(base);
+    if (!set) {
+        rc = errno;
+        goto err;
+    }
+
+    return 0;
+
+    err:
+    free_set();
+    free_schema();
+    return rc;
+}
+
+static void printValList(const char *szListName, struct attr_value_list *av_list) {
+    size_t listSize = MIN(av_list->count, av_list->size);
+    for (size_t i = 0; i < listSize; i++) {
+        msglog(LDMSD_LDEBUG, "%s[%d] = %s:%s\n",
+               szListName, i, av_name(av_list, i), av_value_at_idx(av_list, i));
+    }
+}
+
+/**
+ * Check for invalid flags, with particular emphasis on warning the user about.
+ */
+static int config_check(struct attr_value_list *keyword_list, struct attr_value_list *attribute_value_list, void *arg) {
+    char *value;
+    int i;
+
+    char *deprecated[] = {"set"};
+
+    for (i = 0; i < (sizeof(deprecated) / sizeof(deprecated[0])); i++) {
+        value = av_value(attribute_value_list, deprecated[i]);
+        if (value) {
+            msglog(LDMSD_LERROR, SAMP ": !!!config argument %s has been deprecated.\n",
+                   deprecated[i]);
+            return EINVAL;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * Provides usage information.  Note that BASE_CONFIG_USAGE is defined in sampler_base.h.
+ * @param self this plugin instance.
+ * @return usage string.
+ */
+static const char *usage(struct ldmsd_plugin *self) {
+    return "config name=" SAMP " "
+    BASE_CONFIG_USAGE;
+}
+
+/**
+ * Plugin instance constructor.  Base is an instance of the sampler base "class".
+ */
+static int config(struct ldmsd_plugin *self,
+                  struct attr_value_list *keyword_list,
+                  struct attr_value_list *attribute_value_list) {
+#ifdef ENABLE_AUTO_SIMULATION
+    // Note that HPCM will restore any manual changes to sampler.conf, so it is infeasible to change to
+    // SIMULATION mode using manual conf changes.  We can do this using a file existence check.
+    autoSetSimulationMode();
+#endif
+
+    if (getSimulationMode() == true) {
+        // Log this ERROR so that it appears in /opt/clmgr/log/ldms_sampler.log
+        msglog(LDMSD_LERROR, "Simulation mode is ON\n");    // no really an error so don't prefix with '!!!'
+    }
+
+    printValList("keyword_list", keyword_list);
+    printValList("attribute_value_list", attribute_value_list);
+
+    int rc;
+
+    if (set) {
+        msglog(LDMSD_LERROR, SAMP ": !!!Set already created.\n");
+        return EINVAL;
+    }
+
+    rc = config_check(keyword_list, attribute_value_list, NULL);
+    if (rc != 0) {
+        return rc;
+    }
+
+    // Create an instance from the base "class".  This is effectively calling
+    // the base class constructor.
+    base = base_config(attribute_value_list, SAMP, SAMP, msglog);
+    if (!base) {
+        rc = errno;
+        goto err;
+    }
+
+    // Create the metric set schema in the base instance.  This plugin instance
+    // is considered well-defined after the metric set schema is defined.
+    rc = create_metric_set_schema_and_set(base);
+    if (rc) {
+        msglog(LDMSD_LERROR, SAMP ": !!!failed to create a metric set.\n");
+        goto err;
+    }
+
+    return 0;
+    err:
+    free_set();
+    free_base();
+    free_schema();
+    return rc;
+}
+
+/**
+ * LDMS call this function to obtain the current set of metrics.
+ * @param self this plugin instance.
+ * @return current set of metrics.
+ */
+static ldms_set_t get_set(struct ldmsd_sampler *self) {
+    return set;
+}
+
+/**
+ * LDMS calls this function to sample GPU metrics and store them in the metrics set.
+ * @param self
+ * @return 0 if successful; otherwise returns EINVAL.
+ */
+static int sample(struct ldmsd_sampler *self) {
+    if (!set) {
+        msglog(LDMSD_LDEBUG, SAMP ": plugin not initialized\n");
+        return EINVAL;
+    }
+
+    ze_driver_handle_t hDriver = getGpuDriver();
+    if (hDriver == NULL) {
+        msglog(LDMSD_LERROR, "!!!getGpuDriver() => NULL\n");
+        return EINVAL;
+    }
+
+    uint32_t numDevices = 0;
+    ze_device_handle_t *phDevices = enumerateGpuDevices(hDriver, &numDevices);
+    if (phDevices == NULL) {
+        msglog(LDMSD_LERROR, "!!!enumerateGpuDevices(&numDevices=%p) => NULL, %d\n", &numDevices, numDevices);
+        return EINVAL;
+    }
+    uint32_t numDevicesToSample = MIN(g_numberOfDevicesInSchema, numDevices);   // cannot sample more than schema size
+
+    base_sample_begin(base);
+    populateMetricSet(phDevices, numDevicesToSample, set, metric_offset);
+    base_sample_end(base);
+    size_t mallocCount = getMallocCount();
+    if (mallocCount != 1) {
+        // Only allocated memory is the device handler array.
+        msglog(LDMSD_LERROR, SAMP ": !!!mallocCount=%ld != 1\n", mallocCount);
+    }
+
+    freeZeDeviceHandle(phDevices);
+    phDevices = NULL;
+    return 0;
+}
+
+/**
+ * Release any opened resource.  Note that we have to call OneAPI C++ destructor to
+ * close any opened handles.
+ * @param self this plugin instance.
+ */
+static void term(struct ldmsd_plugin *self) {
+    // No longer need to free device handle array here.
+
+    size_t mallocCount = getMallocCount();
+    if (mallocCount) {
+        // This following log message is never printed;  maybe term was never called.
+        msglog(LDMSD_LERROR, SAMP ": !!!mallocCount=%ld != 0\n", mallocCount);
+    }
+
+    free_base();
+    free_set();
+    free_schema();
+}
+
+/**
+ * This structure defines the plugin instance.  .base probably refers to the
+ * base "class".  So, the assignments in base are overrides.
+ */
+static struct ldmsd_sampler gpu_metrics_plugin = {
+        .base = {
+                .name = SAMP,
+                .type = LDMSD_PLUGIN_SAMPLER,
+                .term = term,       // destructor
+                .config = config,   // constructor
+                .usage = usage,
+        },
+        .get_set = get_set,
+        .sample = sample,
+};
+
+/**
+ * LDMS calls this to obtain a plugin instance.  Plugin is initialized here.
+ * @param pf logging function provided by LDMS.
+ * @return plugin instance.
+ */
+struct ldmsd_plugin *get_plugin(ldmsd_msg_log_f pf) {
+    msglog = pf;
+    set = NULL;
+    return &gpu_metrics_plugin.base;
+}


### PR DESCRIPTION
This is an LDMS GPU metrics sampler built over the Intel OneAPI.  OneAPI can be used to sample GPU metrics.  In our testing, we mitigated the risk of resource leaks using the following strategy:
* Klocwork scan.
* Valgrind was used during functional testing of the primary business logic.
* We also track the outstanding malloc allocations by the sampler, and the sampler code will write any suspected leak to the sampler log.


Signed-off-by: sindhuja <sindhuja.gajula@intel.com>