### PR TITLE
Enable logging for legacy stores where a set schema has different definitions

### DIFF
--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -459,6 +459,9 @@ struct ldmsd_strgp {
 	/** Schema name of the metric set on the producer */
 	char *schema;
 
+	/** The digest of the first set used in opening the store */
+	ldms_digest_t digest;
+
 	/** The container name in which the storage backend will place data */
 	char *container;
 


### PR DESCRIPTION

A storage policy maps to a set schema and assumes all sets of the same schema
have the same metric list. If this is not true, due to misconfiguration or
multiple architectures on the system, LDMSD may crash when it tries to store
sets.

With the patch, LDMSD logs a message when it finds a set that has a different
schema digest from its storage policy's cached digest. Also, LDMSD does not
store such sets. In another word, LDMSD will store sets that a storage policy
has cached its digest.