### PR TITLE
add bulk append/buf recycle timing to ovis_json_perf_test

### DIFF
--- a/lib/src/ovis_json/input/ovis_json_perf_test.sh
+++ b/lib/src/ovis_json/input/ovis_json_perf_test.sh
@@ -1,11 +1,15 @@
 #! /bin/bash
 tmp=$(mktemp -t $USER.ovis_json_perf_test.XXXXXX)
 $BIN/ovis_json_perf_test 100000 > $tmp
+#valgrind -v --track-origins=yes $BIN/ovis_json_perf_test 100 > $tmp
 if ! test -f $tmp; then
 	echo "ERROR: no output file $tmp"
 	exit 1
 fi
-st=$(cat $tmp |grep sprintf  |sed -e 's/.* //g')
-jb=$(cat $tmp |grep jbuf  |sed -e 's/.* //g')
-slowdown=$(echo "scale=2;$jb/$st" |bc)
-echo jbuf/sprintf duration ratio is $slowdown
+st=$(cat $tmp |grep "sprintf time" |sed -e 's/.* //g')
+je=$(cat $tmp |grep "elements time" |sed -e 's/.* //g')
+jb=$(cat $tmp |grep "fmt time" |sed -e 's/.* //g')
+eslowdown=$(echo "scale=2;$je/$st" |bc)
+bslowdown=$(echo "scale=2;$jb/$st" |bc)
+echo elements/sprintf duration ratio is $eslowdown
+echo bulkfmt/sprintf duration ratio is $bslowdown


### PR DESCRIPTION
extended jbuf benchmark with format usage suggested by ogc and jbuf_reset.
current result in my vm is:
elements/sprintf duration ratio is 3.53  (the old test)
bulkfmt/sprintf duration ratio is 1.02 (the one-call format + reset test)