### PR TITLE
fixes #957 race on __ldms_format_set_meta_as_json

### DIFF
--- a/ldms/src/core/ldms_private.h
+++ b/ldms/src/core/ldms_private.h
@@ -181,6 +181,10 @@ extern int __ldms_get_local_set_list(struct ldms_name_list *head);
 extern void __ldms_empty_name_list(struct ldms_name_list *name_list);
 
 extern void __ldms_dir_update(ldms_set_t set, enum ldms_dir_type t);
+/* format set meta info (not metrics) into buf.
+ * \return count of characters added.
+ * NOTE: set->lock mutex must be held before this is called.
+ */
 extern size_t __ldms_format_set_meta_as_json(struct ldms_set *set,
 					     int need_comma,
 					     char *buf, size_t buf_size);

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -817,9 +817,11 @@ static void process_dir_request(struct ldms_xprt *x, struct ldms_request *req)
 
 		if (0 == ldms_access_check(x, LDMS_ACCESS_READ, uid, gid, perm)) {
 			/* no access, skip it */
+			pthread_mutex_lock(&set->lock);
 			cnt += __ldms_format_set_meta_as_json(set, last_cnt,
 						      &reply->dir.json_data[cnt],
 						      len - hdrlen - cnt - 3 /* ]}\0 */);
+			pthread_mutex_unlock(&set->lock);
 		}
 
 		if (/* Too big to fit in transport message, send what we have */


### PR DESCRIPTION
__ldms_format_set_meta_as_json has an assumption of a lock on the set,
but one of the call paths to __ldms_format_set_meta_as_json was missing
that lock. ldmsd_set_register (descendants) and ldms_transaction_end are
some of the other sites using it.