### PR TITLE
fix missing error check allowing uninit pointer use

### DIFF
--- a/ldms/src/ldmsd/test/ldmsd_stream_publish.c
+++ b/ldms/src/ldmsd/test/ldmsd_stream_publish.c
@@ -198,6 +198,10 @@ int main(int argc, char **argv)
 			return rc;
 		}
 	}
+	if (!ldms) {
+		printf("%s: -n, -N or -l required.\n");
+		usage(argc, argv);
+	}
 	if (stream_new) {
 		/* Create and send a STREAM_NEW message */
 		rc = ldmsd_stream_new_publish(stream, ldms);


### PR DESCRIPTION
ldmsd_stream_publish when invoked with incomplete/incorrect options can use a null ldms stream pointer.