### PR TITLE
Introducing `flex` decomposition

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -871,6 +871,7 @@ ldms/src/sampler/Makefile
 ldms/src/decomp/Makefile
 ldms/src/decomp/static/Makefile
 ldms/src/decomp/as_is/Makefile
+ldms/src/decomp/flex/Makefile
 ldms/src/contrib/Makefile
 ldms/src/sampler/blob_stream/Makefile
 ldms/src/store/stream/Makefile

--- a/ldms/man/ldmsd_decomposition.man
+++ b/ldms/man/ldmsd_decomposition.man
@@ -9,22 +9,26 @@ ldmsd_decomposition - manual for LDMSD decomposition
 A decomposition is a routine that converts LDMS set into one or more rows before
 feeding them to the store. Currently, only \fBstore_sos\fR, \fBstore_csv\fR, and
 \fBstore_kafka\fR support decomposition. To use decomposition, simply specify
-\fBdecomposition=\fIDECOMP_CONFI_JSON_FILE\fR option in the \fBstrgp_add\fR
-command. There are two types of decompositions: \fBstatic\fR and \fBas_is\fR.
-\fBstatic\fR decomposition statically and strictly decompose LDMS set according
-to the definitions in the \fIDECOMP_CONFI_JSON_FILE\fR. \fBas_is\fR
-decomposition on the other hand takes all metrics and converts them as-is.
-Please see section \fBSTATIC DECOMPOSITION\fR and \fBAS_IS DECOMPOSITION\fR for
-more information.
+\fBdecomposition=\fIDECOMP_CONFIG_JSON_FILE\fR option in the \fBstrgp_add\fR
+command. There are three types of decompositions: \fBstatic\fR, \fBas_is\fR,
+and `flex`. \fBstatic\fR decomposition statically and strictly decompose LDMS
+set according to the definitions in the \fIDECOMP_CONFIG_JSON_FILE\fR.
+\fBas_is\fR decomposition on the other hand takes all metrics and converts them
+as-is into rows. \fBflex\fR decomposition applies various decompositions by LDMS
+schema digest mapping from the configuration.
+
+Please see section \fBSTATIC DECOMPOSITION\fR, \fBAS_IS DECOMPOSITION\fR , and
+\fBFLEX DECOMPOSITION\fR for more information.
 
 More decomposition types may be added in the future. The decomposition mechanism
-is pluggable. Please see `as_is` and `static` decomposition implementation in
-\:`ldms/src/decomp/` directory in the source tree for more information.
+is pluggable. Please see \fBas_is\fR, \fBstatic\fR, and \fBflex\fR decomposition
+implementation in \:`ldms/src/decomp/` directory in the source tree for more
+information.
 
 
 .SH STATIC DECOMPOSITION
 The \fBstatic\fR decomposition statically and strictly converts LDMS set to one
-or more rows according to the \fIDECOMP_CONFI_JSON_FILE\fR. The format of the
+or more rows according to the \fIDECOMP_CONFIG_JSON_FILE\fR. The format of the
 JSON configuration file is as follows:
 
 .EX
@@ -35,15 +39,15 @@ JSON configuration file is as follows:
       "schema": "OUTPUT_ROW_SCHEMA",
       "cols": [
         { "src":"LDMS_METRIC_NAME", "dst":"OUTPUT_COL_NAME","type":"TYPE",
-	  "array_len": ARRAY_LEN_IF_TYPE_IS_ARRAY,
-	  "rec_member": "REC_MEMBER_NAME_IF_SRC_IS_RECORD",
-	  "fill": "FILL_VALUE"
-	},
-	...
+          "array_len": ARRAY_LEN_IF_TYPE_IS_ARRAY,
+          "rec_member": "REC_MEMBER_NAME_IF_SRC_IS_RECORD",
+          "fill": "FILL_VALUE"
+        },
+        ...
       ],
       "indices": [
-	{ "name":"INDEX_NAME", "cols":[ OUTPUT_COLUMNS, ... ] },
-	...
+        { "name":"INDEX_NAME", "cols":[ OUTPUT_COLUMNS, ... ] },
+        ...
       ]
     },
     ...
@@ -90,8 +94,8 @@ DirectMap varies by CPU architecture).
         { "src":"MemActive",    "dst":"active",  "type":"u64"                        }
       ],
       "indices": [
-	{ "name":"time_comp", "cols":["ts", "comp_id"] },
-	{ "name":"time", "cols":["ts"] }
+        { "name":"time_comp", "cols":["ts", "comp_id"] },
+        { "name":"time", "cols":["ts"] }
       ]
     },
     {
@@ -99,14 +103,14 @@ DirectMap varies by CPU architecture).
       "cols": [
         { "src":"timestamp",    "dst":"ts",          "type":"ts"               },
         { "src":"component_id", "dst":"comp_id",     "type":"u64"              },
-	{ "src":"DirectMap4k",  "dst":"directmap4k", "type":"u64",   "fill": 0 },
-	{ "src":"DirectMap2M",  "dst":"directmap2M", "type":"u64",   "fill": 0 },
-	{ "src":"DirectMap4M",  "dst":"directmap4M", "type":"u64",   "fill": 0 },
-	{ "src":"DirectMap1G",  "dst":"directmap1G", "type":"u64",   "fill": 0 }
+        { "src":"DirectMap4k",  "dst":"directmap4k", "type":"u64",   "fill": 0 },
+        { "src":"DirectMap2M",  "dst":"directmap2M", "type":"u64",   "fill": 0 },
+        { "src":"DirectMap4M",  "dst":"directmap4M", "type":"u64",   "fill": 0 },
+        { "src":"DirectMap1G",  "dst":"directmap1G", "type":"u64",   "fill": 0 }
       ],
       "indices": [
-	{ "name":"time_comp", "cols":["ts", "comp_id"] },
-	{ "name":"time", "cols":["ts"] }
+        { "name":"time_comp", "cols":["ts", "comp_id"] },
+        { "name":"time", "cols":["ts"] }
       ]
     }
   ]
@@ -127,15 +131,15 @@ The following is an example of a static decomposition with "rec_member" usage.
         { "src":"instance",     "dst":"inst",    "type":"char_array", "array_len":64 },
         { "src":"component_id", "dst":"comp_id", "type":"u64"                        },
         { "src":"netdev_list",  "rec_member":"name",
-	   "dst":"netdev.name", "type":"char_array", "array_len":16 },
+          "dst":"netdev.name", "type":"char_array", "array_len":16 },
         { "src":"netdev_list",  "rec_member":"rx_bytes",
-	  "dst":"netdev.rx_bytes", "type":"u64" },
+          "dst":"netdev.rx_bytes", "type":"u64" },
         { "src":"netdev_list",  "rec_member":"tx_bytes",
-	  "dst":"netdev.tx_bytes", "type":"u64" },
+          "dst":"netdev.tx_bytes", "type":"u64" },
       ],
       "indices": [
-	{ "name":"time_comp", "cols":["ts", "comp_id"] },
-	{ "name":"time", "cols":["ts"] }
+        { "name":"time_comp", "cols":["ts", "comp_id"] },
+        { "name":"time", "cols":["ts"] }
       ]
     }
   ]
@@ -146,7 +150,7 @@ In this case, if the "netdev_list" has N members, the decomposition will expand
 the set into N rows.
 
 
-.SH `as_is` decomposition
+.SH AS_IS DECOMPOSITION
 The \fBas_is\fR decomposition generate rows as-is according to metrics in the
 LDMS set. To avoid schema conflict, such as meminfo collecting from
 heterogeneous CPU architectures, \fBas_is\fR decomposition appends the short
@@ -184,6 +188,106 @@ indices:
     { "name": "time", "cols": [ "timestamp" ] },
     { "name": "time_comp", "cols": [ "timestamp", "component_id" ] }
   ]
+}
+.EE
+
+
+.SH FLEX DECOMPOSITION
+The \fBflex\fR decomposition applies various decompositions by LDMS schema
+digests specified in the configuration. The configurations of the applied
+decompositions are also specified in `flex` decomposition file as follows:
+
+.EX
+{
+  "type": "flex",
+  /* defining decompositions to be applied */
+  "decomposition": {
+    "<DECOMP_1>": {
+      "type": "<DECOMP_1_TYPE>",
+      ...
+    },
+    ...
+  },
+  /* specifying digests and the decompositions to apply */
+  "digest": {
+    "<LDMS_DIGEST_1>": "<DECOMP_A>",
+    "<LDMS_DIGEST_2>": [ "<DECOMP_B>", "<DECOMP_c>" ],
+    ...
+    "*": "<DECOMP_Z>" /* optional : the unmatched */
+  }
+}
+.EE
+
+.B Example:
+In the following example, the "meminfo" LDMS sets have 2 digests due to
+different metrics from different architecture. The configuration then maps those
+digests to "meminfo" static decomposition (producing "meminfo_filter" rows). It
+also showcases the ability to apply multiple decompositions to a matching
+digest. The procnetdev2 sets with digest
+"E8B9CC8D83FB4E5B779071E801CA351B69DCB9E9CE2601A0B127A2977F11C62A" will have
+"netdev2" static decomposition and "the_default" as-is decomposition applied to
+them. The sets that do not match any specific digest will match the "*" digest.
+In this example, "the_default" as-is decomposition is applied.
+
+.EX
+{
+  "type": "flex",
+  "decomposition": {
+    "meminfo": {
+      "type": "static",
+      "rows": [
+        {
+          "schema": "meminfo_filter",
+          "cols": [
+            { "src":"timestamp",    "dst":"ts",      "type":"ts"                         },
+            { "src":"producer",     "dst":"prdcr",   "type":"char_array", "array_len":64 },
+            { "src":"instance",     "dst":"inst",    "type":"char_array", "array_len":64 },
+            { "src":"component_id", "dst":"comp_id", "type":"u64"                        },
+            { "src":"MemFree",      "dst":"free",    "type":"u64"                        },
+            { "src":"MemActive",    "dst":"active",  "type":"u64"                        }
+          ],
+          "indices": [
+            { "name":"time_comp", "cols":["ts", "comp_id"] },
+            { "name":"time", "cols":["ts"] }
+          ]
+        }
+      ]
+    },
+    "netdev2" : {
+      "type" : "static",
+      "rows": [
+        {
+          "schema": "procnetdev2",
+          "cols": [
+            { "src":"timestamp", "dst":"ts","type":"ts" },
+            { "src":"component_id", "dst":"comp_id","type":"u64" },
+            { "src":"netdev_list", "rec_member":"name", "dst":"dev.name",
+              "type":"char_array", "array_len": 16 },
+              { "src":"netdev_list", "rec_member":"rx_bytes", "dst":"dev.rx_bytes",
+                "type":"u64" },
+                { "src":"netdev_list", "rec_member":"tx_bytes", "dst":"dev.tx_bytes",
+                  "type":"u64" }
+          ],
+          "indices": [
+            { "name":"time_comp", "cols":["ts", "comp_id"] }
+          ]
+        }
+      ]
+    },
+    "the_default": {
+      "type": "as_is",
+      "indices": [
+        { "name": "time", "cols": [ "timestamp" ] },
+        { "name": "time_comp", "cols": [ "timestamp", "component_id" ] }
+      ]
+    }
+  },
+  "digest": {
+    "71B03E47E7C9033E359DB5225BC6314A589D8772F4BC0866B6E79A698C8799C0": "meminfo",
+    "59DD05D768CFF8F175496848486275822A6A9795286FD9B534FDB9434EAF4D50": "meminfo",
+    "E8B9CC8D83FB4E5B779071E801CA351B69DCB9E9CE2601A0B127A2977F11C62A": [ "netdev2", "the_default" ],
+    "*": "the_default"
+  }
 }
 .EE
 

--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -1139,6 +1139,78 @@ const char *ldms_digest_str(ldms_digest_t digest, char *buf, int buf_len)
 	return buf;
 }
 
+static unsigned char hex_int[] = {
+	['0'] = 0,
+	['1'] = 1,
+	['2'] = 2,
+	['3'] = 3,
+	['4'] = 4,
+	['5'] = 5,
+	['6'] = 6,
+	['7'] = 7,
+	['8'] = 8,
+	['9'] = 9,
+
+	['A'] = 10,
+	['a'] = 10,
+	['B'] = 11,
+	['b'] = 11,
+	['C'] = 12,
+	['c'] = 12,
+	['D'] = 13,
+	['d'] = 13,
+	['E'] = 14,
+	['e'] = 14,
+	['F'] = 15,
+	['f'] = 15,
+
+	[255] = 0,
+};
+
+static unsigned char hex_valid[] = {
+	['0'] = 1,
+	['1'] = 1,
+	['2'] = 1,
+	['3'] = 1,
+	['4'] = 1,
+	['5'] = 1,
+	['6'] = 1,
+	['7'] = 1,
+	['8'] = 1,
+	['9'] = 1,
+
+	['A'] = 1,
+	['a'] = 1,
+	['B'] = 1,
+	['b'] = 1,
+	['C'] = 1,
+	['c'] = 1,
+	['D'] = 1,
+	['d'] = 1,
+	['E'] = 1,
+	['e'] = 1,
+	['F'] = 1,
+	['f'] = 1,
+
+	[255] = 0,
+};
+
+int ldms_str_digest(const char *str, ldms_digest_t digest)
+{
+	int len = strlen(str);
+	unsigned char *d = digest->digest;
+	const unsigned char *c;
+	if (len != 2*sizeof(digest->digest))
+		return EINVAL;
+	for (c = (unsigned char*)str; *c; c += 2) {
+		if (!hex_valid[*c] || !hex_valid[*(c+1)])
+			return EINVAL;
+		*d = (hex_int[*c]<<4) | (hex_int[*(c+1)]);
+		d += 1;
+	}
+	return 0;
+}
+
 int ldms_schema_fprint(ldms_schema_t schema, FILE *fp)
 {
 	ldms_mdef_t m;

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -1739,6 +1739,17 @@ extern ldms_digest_t ldms_set_digest_get(ldms_set_t s);
 extern const char *ldms_digest_str(ldms_digest_t digest, char *buf, int buf_len);
 
 /**
+ * Populate \c digest according to hex string representation.
+ *
+ * \param [in]  str    The hexadecimal string representation of the digest.
+ * \param [out] digest The digest.
+ *
+ * \retval 0     If there are no errors, or
+ * \retval errno If there is an error.
+ */
+int ldms_str_digest(const char *str, ldms_digest_t digest);
+
+/**
  * \brief Compare LDMS digests
  *
  * This function compares two digests and

--- a/ldms/src/decomp/Makefile.am
+++ b/ldms/src/decomp/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = static as_is
+SUBDIRS = static as_is flex

--- a/ldms/src/decomp/flex/Makefile.am
+++ b/ldms/src/decomp/flex/Makefile.am
@@ -1,0 +1,12 @@
+lib_LTLIBRARIES =
+pkglib_LTLIBRARIES =
+
+AM_LDFLAGS = @OVIS_LIB_ABS@
+AM_CPPFLAGS = $(DBGFLAGS) @OVIS_INCLUDE_ABS@
+
+DECOMP_LIBADD = ../../core/libldms.la \
+		../../ldmsd/libldmsd_request.la
+
+libdecomp_flex_la_SOURCES = decomp_flex.c
+libdecomp_flex_la_LIBADD  = $(DECOMP_LIBADD)
+pkglib_LTLIBRARIES += libdecomp_flex.la

--- a/ldms/src/decomp/flex/decomp_flex.c
+++ b/ldms/src/decomp/flex/decomp_flex.c
@@ -1,0 +1,401 @@
+/* -*- c-basic-offset: 8 -*-
+ * Copyright (c) 2022 National Technology & Engineering Solutions
+ * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
+ * NTESS, the U.S. Government retains certain rights in this software.
+ * Copyright (c) 2022 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the BSD-type
+ * license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *      Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *      Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *      Neither the name of Sandia nor the names of any contributors may
+ *      be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ *      Neither the name of Open Grid Computing nor the names of any
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *      Modified source versions must be plainly marked as such, and
+ *      must not be misrepresented as being the original software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#define _GNU_SOURCE
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <assert.h>
+#include <errno.h>
+
+#include <openssl/sha.h>
+
+#include "ovis_json/ovis_json.h"
+#include "coll/rbt.h"
+
+#include "ldmsd.h"
+#include "ldmsd_request.h"
+
+/* Implementation is in ldmsd_decomp.c */
+ldmsd_decomp_t ldmsd_decomp_get(const char *decomp, ldmsd_req_ctxt_t reqc);
+
+static ldmsd_decomp_t __decomp_flex_config(ldmsd_strgp_t strgp,
+			json_entity_t cfg, ldmsd_req_ctxt_t reqc);
+static int __decomp_flex_decompose(ldmsd_strgp_t strgp, ldms_set_t set,
+				     ldmsd_row_list_t row_list, int *row_count);
+static void __decomp_flex_release_rows(ldmsd_strgp_t strgp,
+					 ldmsd_row_list_t row_list);
+static void __decomp_flex_release_decomp(ldmsd_strgp_t strgp);
+
+struct ldmsd_decomp_s __decomp_flex = {
+	.config = __decomp_flex_config,
+	.decompose = __decomp_flex_decompose,
+	.release_rows = __decomp_flex_release_rows,
+	.release_decomp = __decomp_flex_release_decomp,
+};
+
+ldmsd_decomp_t get()
+{
+	return &__decomp_flex;
+}
+
+/* ==== JSON helpers ==== */
+
+static json_entity_t __jdict_ent(json_entity_t dict, const char *key)
+{
+	json_entity_t attr;
+	json_entity_t val;
+
+	attr = json_attr_find(dict, key);
+	if (!attr) {
+		errno = ENOKEY;
+		return NULL;
+	}
+	val = json_attr_value(attr);
+	return val;
+}
+
+#define JSTR(P) ((P)->value.str_)
+
+/* ==== generic decomp ==== */
+/* convenient macro to put error message in both ldmsd log and `reqc` */
+#define DECOMP_ERR(reqc, rc, fmt, ...) do { \
+		ldmsd_lerror("decomposer: " fmt, ##__VA_ARGS__); \
+		if (reqc) { \
+			(reqc)->errcode = rc; \
+			Snprintf(&(reqc)->line_buf, &(reqc)->line_len, "decomposer: " fmt, ##__VA_ARGS__); \
+		} \
+	} while (0)
+
+/* ==== flex decomposition === */
+
+typedef struct __decomp_flex_decomp_rbn_s {
+	struct rbn rbn;
+	struct ldmsd_decomp_s *decomp_api;
+	struct ldmsd_strgp strgp;
+	char name[OVIS_FLEX]; /* also rbn key */
+} *__decomp_flex_decomp_rbn_t;
+
+static
+int __decomp_flex_decomp_rbn_s_cmp(void *tree_key, const void *key)
+{
+	return strcmp(tree_key, key);
+}
+
+typedef struct __decomp_flex_digest_rbn_s {
+	struct rbn rbn;
+	struct ldms_digest_s digest; /* also rbn key */
+	int n_decomp; /* number of decomposers to apply */
+	__decomp_flex_decomp_rbn_t decomp_rbn[OVIS_FLEX]; /* refs to the utilized decomposers */
+} *__decomp_flex_digest_rbn_t;
+
+static
+int __decomp_flex_digest_rbn_s_cmp(void *tree_key, const void *key)
+{
+	return memcmp(tree_key, key, sizeof(struct ldms_digest_s));
+}
+
+typedef struct __decomp_flex_cfg_s {
+	struct ldmsd_decomp_s decomp;
+	struct rbt digest_rbt;
+	struct rbt decomp_rbt;
+	__decomp_flex_digest_rbn_t default_digest;
+} *__decomp_flex_cfg_t;
+
+static void __decomp_flex_cfg_free(__decomp_flex_cfg_t dcfg)
+{
+	struct rbn *rbn;
+	__decomp_flex_decomp_rbn_t decomp_rbn;
+	if (dcfg->default_digest)
+		free(dcfg->default_digest);
+	while ((rbn = rbt_min(&dcfg->digest_rbt))) {
+		rbt_del(&dcfg->digest_rbt, rbn);
+		free(rbn);
+	}
+	while ((decomp_rbn = (void*)rbt_min(&dcfg->decomp_rbt))) {
+		rbt_del(&dcfg->decomp_rbt, &decomp_rbn->rbn);
+		if (decomp_rbn->strgp.decomp)
+			decomp_rbn->decomp_api->release_decomp(&decomp_rbn->strgp);
+		free(decomp_rbn);
+	}
+	free(dcfg);
+}
+
+static void
+__decomp_flex_release_decomp(ldmsd_strgp_t strgp)
+{
+	if (strgp->decomp) {
+		__decomp_flex_cfg_free((void*)strgp->decomp);
+		strgp->decomp = NULL;
+	}
+}
+
+static ldmsd_decomp_t
+__decomp_flex_config(ldmsd_strgp_t strgp, json_entity_t jcfg,
+		      ldmsd_req_ctxt_t reqc)
+{
+	__decomp_flex_cfg_t dcfg = NULL;
+	int n_decomp, i;
+	json_entity_t jdecomp, jdigest, jattr, jkey, jval, jtype;
+
+	/* decomposition */
+	jdecomp = __jdict_ent(jcfg, "decomposition");
+	if (!jdecomp) {
+		DECOMP_ERR(reqc, EINVAL, "'decomposition' attribute is missing\n");
+		goto err_0;
+	}
+	if (jdecomp->type != JSON_DICT_VALUE) {
+		DECOMP_ERR(reqc, EINVAL, "'decomposition' must be a dictionary\n");
+		goto err_0;
+	}
+
+	/* digest */
+	jdigest = __jdict_ent(jcfg, "digest");
+	if (!jdigest) {
+		DECOMP_ERR(reqc, EINVAL, "'digest' attribute is missing\n");
+		goto err_0;
+	}
+	if (jdigest->type != JSON_DICT_VALUE) {
+		DECOMP_ERR(reqc, EINVAL, "'digest' must be a dictionary\n");
+		goto err_0;
+	}
+
+	dcfg = calloc(1, sizeof(*dcfg));
+	if (!dcfg) {
+		DECOMP_ERR(reqc, ENOMEM, "Not enough memory\n");
+		goto err_0;
+	}
+	dcfg->decomp = __decomp_flex;
+	rbt_init(&dcfg->decomp_rbt, __decomp_flex_decomp_rbn_s_cmp);
+	rbt_init(&dcfg->digest_rbt, __decomp_flex_digest_rbn_s_cmp);
+
+	__decomp_flex_decomp_rbn_t decomp_rbn;
+	struct ldmsd_decomp_s *decomp_api;
+
+	/* processing decompotision */
+	for (jattr = json_attr_first(jdecomp); jattr; jattr = json_attr_next(jattr)) {
+		jkey = jattr->value.attr_->name;
+		assert(jkey->type == JSON_STRING_VALUE);
+		jval = jattr->value.attr_->value;
+		if (jval->type != JSON_DICT_VALUE) {
+			DECOMP_ERR(reqc, EINVAL, "decomposition['%s'] must be "
+					 "a dictionary\n", JSTR(jkey)->str);
+			goto err_1;
+		}
+		jtype = __jdict_ent(jval, "type");
+		if (!jtype) {
+			DECOMP_ERR(reqc, EINVAL, "decomposition['%s'] must "
+					 "specify 'type' attribute\n",
+					 JSTR(jkey)->str);
+			goto err_1;
+		}
+		if (jtype->type != JSON_STRING_VALUE) {
+			DECOMP_ERR(reqc, EINVAL, "decomposition['%s']['type'] "
+					 "must be a string\n",
+					 JSTR(jkey)->str);
+			goto err_1;
+		}
+		decomp_api = ldmsd_decomp_get(JSTR(jtype)->str, reqc);
+		if (!decomp_api) {
+			/* ldmsd_decomp_get() already populate reqc error */
+			goto err_1;
+		}
+		decomp_rbn = calloc(1, sizeof(*decomp_rbn) +
+					jkey->value.str_->str_len + 1);
+		if (!decomp_rbn) {
+			DECOMP_ERR(reqc, ENOMEM, "Not enough memory\n");
+			goto err_1;
+		}
+		memcpy(decomp_rbn->name, JSTR(jkey)->str, JSTR(jkey)->str_len);
+		decomp_rbn->decomp_api = decomp_api;
+		decomp_rbn->strgp.decomp = decomp_api->config(&decomp_rbn->strgp, jval, reqc);
+		if (!decomp_rbn->strgp.decomp) {
+			/* reqc error has been populated */
+			free(decomp_rbn);
+			goto err_1;
+		}
+		rbn_init(&decomp_rbn->rbn, decomp_rbn->name);
+		rbt_ins(&dcfg->decomp_rbt, &decomp_rbn->rbn);
+	}
+
+	json_entity_t jlist;
+	__decomp_flex_digest_rbn_t digest_rbn;
+
+	/* processing digest */
+	for (jattr = json_attr_first(jdigest); jattr; jattr = json_attr_next(jattr)) {
+		jkey = jattr->value.attr_->name;
+		assert(jkey->type == JSON_STRING_VALUE);
+		jval = jattr->value.attr_->value;
+		jlist = NULL;
+		if (jval->type == JSON_LIST_VALUE) {
+			jlist = jval;
+			jval = TAILQ_FIRST(&jlist->value.list_->item_list);
+			n_decomp = jlist->value.list_->item_count;
+		} else if (jval->type == JSON_STRING_VALUE) {
+			n_decomp = 1;
+		} else {
+			/* invalid value */
+			DECOMP_ERR(reqc, EINVAL, "digest['%s'] value must be"
+					"a string or a list of strings.\n",
+					JSTR(jkey)->str);
+			goto err_1;
+		}
+		int rc;
+		struct ldms_digest_s digest = {};
+		if (0 == strcmp(JSTR(jkey)->str, "*")) {
+			digest_rbn = dcfg->default_digest;
+		} else {
+			rc = ldms_str_digest(JSTR(jkey)->str, &digest);
+			if (rc) {
+				DECOMP_ERR(reqc, rc, "Invalid digest '%s'.\n",
+					JSTR(jkey)->str);
+				goto err_1;
+			}
+			digest_rbn = (void*)rbt_find(&dcfg->digest_rbt, &digest);
+		}
+		if (digest_rbn) {
+			DECOMP_ERR(reqc, EINVAL,
+				   "Multiple definition of digest['%s'].\n",
+				   JSTR(jkey)->str);
+			goto err_1;
+		}
+		digest_rbn = calloc(1, sizeof(*digest_rbn) +
+					n_decomp*sizeof(digest_rbn->decomp_rbn[0]));
+		if (!digest_rbn) {
+			DECOMP_ERR(reqc, ENOMEM, "Not enough memory\n");
+			goto err_1;
+		}
+		memcpy(&digest_rbn->digest, &digest, sizeof(digest));
+		rbn_init(&digest_rbn->rbn, &digest_rbn->digest);
+		digest_rbn->n_decomp = n_decomp;
+		if (0 == strcmp(JSTR(jkey)->str, "*")) {
+			dcfg->default_digest = digest_rbn;
+		} else {
+			rbt_ins(&dcfg->digest_rbt, &digest_rbn->rbn);
+		}
+		i = 0;
+		while (jval) {
+			if (jval->type != JSON_STRING_VALUE) {
+				DECOMP_ERR(reqc, EINVAL, "digest['%s'] value must be"
+					"a string or a list of strings.\n",
+					JSTR(jkey)->str);
+				goto err_1;
+			}
+			decomp_rbn = (void*)rbt_find(&dcfg->decomp_rbt, JSTR(jval)->str);
+			if (!decomp_rbn) {
+				DECOMP_ERR(reqc, ENOENT, "decomposition '%s' is not defined.\n",
+						JSTR(jval)->str);
+				goto err_1;
+			}
+			digest_rbn->decomp_rbn[i] = decomp_rbn;
+			if (jlist) {
+				jval = TAILQ_NEXT(jval, item_entry);
+			} else {
+				jval = NULL;
+			}
+			i++;
+		}
+		assert(i == n_decomp);
+	}
+
+	return &dcfg->decomp;
+ err_1:
+	__decomp_flex_cfg_free(dcfg);
+ err_0:
+	return NULL;
+}
+
+static int __decomp_flex_decompose(ldmsd_strgp_t strgp, ldms_set_t set,
+				    ldmsd_row_list_t row_list, int *row_count)
+{
+	__decomp_flex_cfg_t dcfg = (void*)strgp->decomp;
+	ldms_digest_t digest = ldms_set_digest_get(set);
+	struct ldmsd_row_list_s rlist;
+	int rcount, i, rc;
+	__decomp_flex_digest_rbn_t digest_rbn;
+	__decomp_flex_decomp_rbn_t decomp_rbn;
+
+	TAILQ_INIT(&rlist);
+
+	digest_rbn = (void*)rbt_find(&dcfg->digest_rbt, digest);
+	if (!digest_rbn) {
+		if (!dcfg->default_digest)
+			return 0;
+		digest_rbn = dcfg->default_digest;
+	}
+	for (i = 0; i < digest_rbn->n_decomp; i++) {
+		rcount = 0;
+		decomp_rbn = digest_rbn->decomp_rbn[i];
+		rc = decomp_rbn->decomp_api->decompose(
+				&decomp_rbn->strgp,
+				set, &rlist, &rcount);
+		if (rc)
+			goto err_0;
+		TAILQ_CONCAT(row_list, &rlist, entry);
+		/* rlist is now empty */
+		*row_count += rcount;
+	}
+	return 0;
+
+ err_0:
+	__decomp_flex_release_rows(strgp, row_list);
+	return rc;
+}
+
+static void __decomp_flex_release_rows(ldmsd_strgp_t strgp,
+					 ldmsd_row_list_t row_list)
+{
+	ldmsd_row_t row;
+	while ((row = TAILQ_FIRST(row_list))) {
+		TAILQ_REMOVE(row_list, row, entry);
+		free(row);
+	}
+}

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -489,6 +489,9 @@ struct ldmsd_strgp {
 	/** Decomposer resource handle */
 	struct ldmsd_decomp_s *decomp;
 	char *decomp_name;
+
+	/** Regular expression for the schema */
+	regex_t schema_regex;
 };
 
 

--- a/ldms/src/ldmsd/ldmsd_decomp.c
+++ b/ldms/src/ldmsd/ldmsd_decomp.c
@@ -211,6 +211,13 @@ int ldmsd_decomp_config(ldmsd_strgp_t strgp, const char *json_path, ldmsd_req_ct
 	char *buff = NULL;
 	ldmsd_decomp_t decomp_api;
 
+	if (strgp->decomp) {
+		/* already configured */
+		rc = EALREADY;
+		DECOMP_ERR(reqc, EALREADY, "Already configurd\n");
+		goto err_0;
+	}
+
 	/* Load JSON from file */
 	fd = open(json_path, O_RDONLY);
 	if (fd < 0) {

--- a/ldms/src/ldmsd/ldmsd_decomp.c
+++ b/ldms/src/ldmsd/ldmsd_decomp.c
@@ -199,6 +199,12 @@ static ldmsd_decomp_t __decomp_get(const char *decomp, ldmsd_req_ctxt_t reqc)
 	return dc;
 }
 
+/* Export so that decomp_flex can call, but don't advertise this in ldmsd.h */
+ldmsd_decomp_t ldmsd_decomp_get(const char *decomp, ldmsd_req_ctxt_t reqc)
+{
+	return __decomp_get(decomp, reqc);
+}
+
 /* protected by strgp lock */
 int ldmsd_decomp_config(ldmsd_strgp_t strgp, const char *json_path, ldmsd_req_ctxt_t reqc)
 {

--- a/ldms/src/ldmsd/ldmsd_strgp.c
+++ b/ldms/src/ldmsd/ldmsd_strgp.c
@@ -625,8 +625,15 @@ int ldmsd_strgp_update_prdcr_set(ldmsd_strgp_t strgp, ldmsd_prdcr_set_t prd_set)
 	int rc = 0;
 	ldmsd_strgp_ref_t ref;
 
-	if (strcmp(strgp->schema, prd_set->schema_name))
-		return ENOENT;
+	if (strgp->schema) {
+		/* schema exact match */
+		if (strcmp(strgp->schema, prd_set->schema_name))
+			return ENOENT;
+	} else {
+		/* regex match */
+		if (regexec(&strgp->schema_regex, prd_set->schema_name, 0, NULL, 0))
+			return ENOENT;
+	}
 
 	ref = strgp_ref_find(prd_set, strgp);
 	switch (strgp->state) {


### PR DESCRIPTION
This is a series of commits to enable `flex` decomposition feature:
- Add regex support for schema matching in `strgp_add` (`strgp_add name=ST regex=.*` instead of `strgp_add name=ST schema=meminfo`). This is so that sets from multiple schemas can be processed with the `flex` decomposition without specifying `strgp` for each of them.
- decomposition re-config check.
- Export `ldmsd_decomp_get()`, this is needed by `decomp_flex.c`.
- Add `ldms_str_digest()` utility that parse hex string to `ldms_digest`.
- Add `flex` decomposition

This + #977 (the required fix) has been tested with https://github.com/ovis-hpc/ldms-test/blob/flex/test-all.sh