### PR TITLE
fix missing error check & init to prevent uninit pointer use

### DIFF
--- a/ldms/src/ldmsd/test/ldmsd_stream_publish.c
+++ b/ldms/src/ldmsd/test/ldmsd_stream_publish.c
@@ -32,6 +32,7 @@ static struct option long_opts[] = {
 	{0,          0,                 0,  0 }
 };
 
+void usage(int argc, char **argv) __attribute__((noreturn));
 void usage(int argc, char **argv)
 {
 	printf("usage: %s -x <xprt> -h <host> -p <port> "
@@ -188,7 +189,7 @@ int main(int argc, char **argv)
 		repeat = 1;
 
 	int rc;
-	ldms_t ldms;
+	ldms_t ldms = NULL;
 	if (stream_new || line_mode) {
 		/* Create a transport endpoint */
 		ldms = ldms_xprt_new_with_auth(xprt, NULL, auth, NULL);
@@ -197,6 +198,10 @@ int main(int argc, char **argv)
 			printf("Error %d connecting to peer\n", rc);
 			return rc;
 		}
+	}
+	if (!ldms) {
+		printf("%s: -n, -N or -l required.\n", argv[0]);
+		usage(argc, argv);
 	}
 	if (stream_new) {
 		/* Create and send a STREAM_NEW message */


### PR DESCRIPTION
ldmsd_stream_publish when invoked with incomplete/incorrect options can use a null ldms stream pointer.
