### PR TITLE
fix rec_mid uninit/misuse

### DIFF
--- a/ldms/src/decomp/as_is/decomp_as_is.c
+++ b/ldms/src/decomp/as_is/decomp_as_is.c
@@ -833,7 +833,7 @@ static int __decomp_as_is_decompose(ldmsd_strgp_t strgp, ldms_set_t set,
 				goto col_fill;
 			}
 			mcol->col_mval = ldms_record_metric_get(mcol->rec, mcol->dcol->rec_mid);
-			mtype = ldms_record_metric_type_get(mcol->le, rec_mid, &mcol->col_mlen);
+			mtype = ldms_record_metric_type_get(mcol->le, mcol->dcol->rec_mid, &mcol->col_mlen);
 			continue;
 		}
 


### PR DESCRIPTION
It looks like an uninit temporary rec_mid was used where a lookup based on context is needed. 