### PR TITLE
move direct installs to /etc into $(docdir)/sample_init_scripts/opt

### DIFF
--- a/.github/workflows/4.3.3-compat-test.yaml
+++ b/.github/workflows/4.3.3-compat-test.yaml
@@ -45,6 +45,7 @@ jobs:
         ../configure --prefix=/opt/ovis-4 --enable-etc --enable-munge
         make
         make install
+        ln -s /opt/ovis-4/share/doc/ovis-ldms/sample_init_scripts/opt/etc /opt/ovis-4
     - name: test preparation
       run: |
         set -e

--- a/ldms/etc/Makefile.am
+++ b/ldms/etc/Makefile.am
@@ -1,4 +1,6 @@
 ACLOCAL_AMFLAGS = -I m4
+docdir = $(datadir)/doc/@PACKAGE@/sample_init_scripts/opt/etc
+
 SUBDIRS =
 
 # init script
@@ -24,7 +26,7 @@ BUILT_FILES_SRC = $(BUILT_FILES:=.in)
 
 EXTRA_DIST=$(BUILT_FILES_SRC)
 
-sysconfldmsdir=$(sysconfdir)/ldms
+sysconfldmsdir=$(docdir)/ldms
 dist_sysconfldms_DATA= \
 	aggregator.conf.cray_xc.example \
 	sampler.conf.cray_xc.example \

--- a/ldms/etc/init.d/Makefile.am
+++ b/ldms/etc/init.d/Makefile.am
@@ -1,8 +1,10 @@
+docdir = $(datadir)/doc/@PACKAGE@/sample_init_scripts/opt/etc
+
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)/$(sysconfdir)/init.d/
-	$(INSTALL_SCRIPT) $(builddir)/ldmsd_aggregator $(DESTDIR)/$(sysconfdir)/init.d/
-	$(INSTALL_SCRIPT) $(builddir)/ldmsd_sampler $(DESTDIR)/$(sysconfdir)/init.d/
+	$(MKDIR_P) $(DESTDIR)/$(docdir)/init.d/
+	$(INSTALL_SCRIPT) $(builddir)/ldmsd_aggregator $(DESTDIR)/$(docdir)/init.d/
+	$(INSTALL_SCRIPT) $(builddir)/ldmsd_sampler $(DESTDIR)/$(docdir)/init.d/
 
 uninstall-local:
-	rm -f $(DESTDIR)/$(sysconfdir)/init.d/ldmsd_aggregator
-	rm -f $(DESTDIR)/$(sysconfdir)/init.d/ldmsd_sampler
+	rm -f $(DESTDIR)/$(docdir)/init.d/ldmsd_aggregator
+	rm -f $(DESTDIR)/$(docdir)/init.d/ldmsd_sampler

--- a/ldms/etc/logrotate.d/Makefile.am
+++ b/ldms/etc/logrotate.d/Makefile.am
@@ -1,10 +1,11 @@
 EXTRA_DIST = ldmsd_aggregator ldmsd_sampler
+docdir = $(datadir)/doc/@PACKAGE@/sample_init_scripts/opt/etc
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)/$(sysconfdir)/ovis/logrotate.d/
-	$(INSTALL_DATA) $(srcdir)/ldmsd_aggregator $(DESTDIR)/$(sysconfdir)/ovis/logrotate.d/
-	$(INSTALL_DATA) $(srcdir)/ldmsd_sampler $(DESTDIR)/$(sysconfdir)/ovis/logrotate.d/
+	$(MKDIR_P) $(DESTDIR)/$(docdir)/ovis/logrotate.d/
+	$(INSTALL_DATA) $(srcdir)/ldmsd_aggregator $(DESTDIR)/$(docdir)/ovis/logrotate.d/
+	$(INSTALL_DATA) $(srcdir)/ldmsd_sampler $(DESTDIR)/$(docdir)/ovis/logrotate.d/
 
 uninstall-local:
-	rm -f $(DESTDIR)/$(sysconfdir)/ovis/logrotate.d/ldmsd_aggregator
-	rm -f $(DESTDIR)/$(sysconfdir)/ovis/logrotate.d/ldmsd_sampler
+	rm -f $(DESTDIR)/$(docdir)/ovis/logrotate.d/ldmsd_aggregator
+	rm -f $(DESTDIR)/$(docdir)/ovis/logrotate.d/ldmsd_sampler

--- a/ldms/etc/systemd/Makefile.am
+++ b/ldms/etc/systemd/Makefile.am
@@ -1,4 +1,6 @@
-SYSTEMD_DIR = $(DESTDIR)$(sysconfdir)/systemd/system
+docdir = $(datadir)/doc/@PACKAGE@/sample_init_scripts/opt/etc
+
+SYSTEMD_DIR = $(DESTDIR)$(docdir)/systemd/system
 
 do_subst = @LDMS_SUBST_RULE@
 
@@ -11,7 +13,7 @@ BUILT_FILES_SRC = $(BUILT_FILES:=.in)
 
 EXTRA_DIST = $(BUILT_FILES_SRC)
 
-sysconfsystemdsystemdir=$(sysconfdir)/systemd/system
+sysconfsystemdsystemdir=$(docdir)/systemd/system
 nodist_sysconfsystemdsystem_DATA=$(BUILT_FILES)
 
 $(builddir)/%.service: $(srcdir)/%.service.in

--- a/lib/etc/ld.so.conf.d/Makefile.am
+++ b/lib/etc/ld.so.conf.d/Makefile.am
@@ -5,5 +5,7 @@ do_subst = @LDMS_SUBST_RULE@
 ovis-ld-so.conf: ovis-ld-so.conf.in
 	$(do_subst) < $< > $@
 
-sysconfldsodir = $(sysconfdir)/ld.so.conf.d
+docdir = $(datadir)/doc/@PACKAGE@/sample_init_scripts/opt/etc
+
+sysconfldsodir = $(docdir)/ld.so.conf.d
 sysconfldso_DATA = ovis-ld-so.conf

--- a/lib/etc/ovis/Makefile.am
+++ b/lib/etc/ovis/Makefile.am
@@ -1,13 +1,14 @@
+docdir = $(datadir)/doc/@PACKAGE@/sample_init_scripts/opt/etc
 
 do_subst = @LDMS_SUBST_RULE@
 
 set-ovis-variables.sh: set-ovis-variables.sh.in
 	$(do_subst) < $< > $@
 
-sysconfovisdir = $(sysconfdir)/ovis
+sysconfovisdir = $(docdir)/ovis
 dist_sysconfovis_DATA = ovis-functions.sh
 
-sysconfprofiledir = $(sysconfdir)/profile.d
+sysconfprofiledir = $(docdir)/profile.d
 sysconfprofile_DATA = set-ovis-variables.sh
 
 EXTRA_DIST = set-ovis-variables.sh.in

--- a/util/sample_init_scripts/README
+++ b/util/sample_init_scripts/README
@@ -2,7 +2,6 @@ For TOSS deployment, see genders/.
 	This uses a cluster-wide genders file to manage
 	daemon config consistency under systemd or sysvinit.
 
-For irregular clusters, see rhel/
-	This uses tedious lists to manage daemon config consistency.
-	Save yourself the pain and install libgenders.
+For other clusters see opt/
+	This uses assorted local scripts to manage local daemons under systemd.
 


### PR DESCRIPTION
This does not remove the --enable-etc option. Since docdir is unconditionally writable during build, it is not necessary to have the option. I can remove the option (always write opt/etc example into docdir) if wanted as an additional patch. 