### PR TITLE
Add a config command to query the configuration file paths

### DIFF
--- a/ldms/python/ldmsd/ldmsd_config.py
+++ b/ldms/python/ldmsd/ldmsd_config.py
@@ -148,6 +148,7 @@ LDMSD_CTRL_CMD_MAP = {'usage': {'req_attr': [], 'opt_attr': ['name']},
                       'set_stats': {'req_attr':[], 'opt_attr': []},
                       'listen': {'req_attr':['xprt', 'port'], 'opt_attr': ['host', 'auth']},
                       'metric_sets_default_authz': {'req_attr':[], 'opt_attr': ['uid', 'gid', 'perm']},
+                      'config_file_list': {'req_attr': [], 'opt_attr': []},
                       ##### Failover. #####
                       'failover_config': {
                                 'req_attr': [

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1637,6 +1637,23 @@ class LdmsdCmdParser(cmd.Cmd):
     def complete_auth_add(self, text, line, begidx, endidx):
         return self.__complete_attr_list('auth_add', text)
 
+    def do_config_file_list(self, arg):
+        """
+        Report the paths of the configuration files
+
+        Parameters - None
+        """
+        resp = self.handle('config_file_list', arg)
+        if resp['errcode'] == 0:
+            cfg_files =  json.loads(resp['msg'])
+            print("Configuration files")
+            print("-------------------")
+            for f in cfg_files:
+                print(f"{f}")
+
+    def complete_config_file_list(self, text, line, begidx, endidx):
+        return self.__complete_attr_list('config_file_list', text)
+
     def do_option(self, arg):
         """
         ONLY SUPPORTED IN CONFIGURATION FILES

--- a/ldms/python/ldmsd/ldmsd_request.py
+++ b/ldms/python/ldmsd/ldmsd_request.py
@@ -346,6 +346,7 @@ class LDMSD_Request(object):
     SET_STATS = 0x600 + 15
     LISTEN = 0x600 + 16
     SET_DEFAULT_AUTHZ = 0x600 + 17
+    CONFIG_FILE_LIST = 0x600 + 18
 
     FAILOVER_CONFIG        = 0x700
     FAILOVER_PEERCFG_START = 0x700  +  1
@@ -458,6 +459,8 @@ class LDMSD_Request(object):
             'auth_add'      :  {'id' : AUTH_ADD },
 
             'metric_sets_default_authz' : {'id' : SET_DEFAULT_AUTHZ },
+
+            'config_file_list' : {'id' : CONFIG_FILE_LIST },
     }
 
     TYPE_CONFIG_CMD = 1

--- a/ldms/src/ldmsd/ldmsd_request.h
+++ b/ldms/src/ldmsd/ldmsd_request.h
@@ -124,7 +124,9 @@ enum ldmsd_request {
 	LDMSD_SET_STATS_REQ,
 	LDMSD_LISTEN_REQ,
 	LDMSD_SET_DEFAULT_AUTHZ_REQ,
+	LDMSD_CONFIG_FILE_LIST_REQ,
 	LDMSD_CMDLINE_OPTIONS_SET_REQ,
+
 
 	/* failover requests by user */
 	LDMSD_FAILOVER_CONFIG_REQ = 0x700, /* "failover_config" user command */

--- a/ldms/src/ldmsd/ldmsd_request_util.c
+++ b/ldms/src/ldmsd/ldmsd_request_util.c
@@ -66,6 +66,7 @@ const struct req_str_id req_str_id_table[] = {
 	{  "auth_add",           LDMSD_AUTH_ADD_REQ  },
 	{  "auth_del",           LDMSD_AUTH_DEL_REQ  },
 	{  "config",             LDMSD_PLUGN_CONFIG_REQ  },
+	{  "config_file_list",   LDMSD_CONFIG_FILE_LIST_REQ  },
 	{  "daemon",             LDMSD_DAEMON_STATUS_REQ  },
 	{  "daemon_exit",        LDMSD_EXIT_DAEMON_REQ  },
 	{  "daemon_status",      LDMSD_DAEMON_STATUS_REQ  },


### PR DESCRIPTION
The 'config_file_list' command reports the paths of the configuration
files given to LDMSD at the command line and thru the include command.