### PR TITLE
Fix ldmsd_stream_publish's bug caused by #979

### DIFF
--- a/ldms/src/ldmsd/test/ldmsd_stream_publish.c
+++ b/ldms/src/ldmsd/test/ldmsd_stream_publish.c
@@ -193,15 +193,16 @@ int main(int argc, char **argv)
 	if (stream_new || line_mode) {
 		/* Create a transport endpoint */
 		ldms = ldms_xprt_new_with_auth(xprt, NULL, auth, NULL);
+		if (!ldms) {
+			rc = errno;
+			printf("Failed to create the LDMS transport endpoint.\n");
+			return rc;
+		}
 		rc = ldms_xprt_connect_by_name(ldms, host, port, NULL, NULL);
 		if (rc){
 			printf("Error %d connecting to peer\n", rc);
 			return rc;
 		}
-	}
-	if (!ldms) {
-		printf("%s: -n, -N or -l required.\n", argv[0]);
-		usage(argc, argv);
 	}
 	if (stream_new) {
 		/* Create and send a STREAM_NEW message */


### PR DESCRIPTION
The pull request #979 prevents users from using ldmsd_stream_publish
with the -f option. To be precise, it causes ldmsd_stream_publish to
always return an error if one of the -n, -N, and -l options is not
given. The patch fixes the problem.