### PR TITLE
Install ${PREFIX}/etc but not /etc

### DIFF
--- a/.github/workflows/4.3.3-compat-test.yaml
+++ b/.github/workflows/4.3.3-compat-test.yaml
@@ -45,7 +45,6 @@ jobs:
         ../configure --prefix=/opt/ovis-4 --enable-etc --enable-munge
         make
         make install
-        ln -s /opt/ovis-4/share/doc/ovis-ldms/sample_init_scripts/opt/etc /opt/ovis-4
     - name: test preparation
       run: |
         set -e

--- a/configure.ac
+++ b/configure.ac
@@ -825,6 +825,8 @@ AS_IF([test "x$with_dcgm" != xno],
       [have_dcgm=false])
 AM_CONDITIONAL([HAVE_DCGM], [test x$have_dcgm = xtrue])
 
+AM_CONDITIONAL([SYSCONFDIR_NOT_ETC], [test "${sysconfdir}" != "/etc"])
+
 # define substitutions for configvars and other sed-generated files.
 # note carefully the escapes.
 OVIS_DO_SUBST([LDMS_SUBST_RULE], ["sed \

--- a/lib/etc/ld.so.conf.d/Makefile.am
+++ b/lib/etc/ld.so.conf.d/Makefile.am
@@ -9,3 +9,8 @@ docdir = $(datadir)/doc/@PACKAGE@/sample_init_scripts/opt/etc
 
 sysconfldsodir = $(docdir)/ld.so.conf.d
 sysconfldso_DATA = ovis-ld-so.conf
+
+if SYSCONFDIR_NOT_ETC
+sysconfldsoddir = $(sysconfdir)/ld.so.conf.d
+sysconfldsod_DATA = ovis-ld-so.conf
+endif

--- a/lib/etc/ovis/Makefile.am
+++ b/lib/etc/ovis/Makefile.am
@@ -11,5 +11,9 @@ dist_sysconfovis_DATA = ovis-functions.sh
 sysconfprofiledir = $(docdir)/profile.d
 sysconfprofile_DATA = set-ovis-variables.sh
 
-EXTRA_DIST = set-ovis-variables.sh.in
+if SYSCONFDIR_NOT_ETC
+sysconfprofileddir=$(sysconfdir)/profile.d
+sysconfprofiled_DATA=set-ovis-variables.sh
+endif
 
+EXTRA_DIST = set-ovis-variables.sh.in


### PR DESCRIPTION
PR #985 relocated ${PREFIX}/etc to a much deeper location
${PREFIX}/share/doc/ovis-ldms/sample_init_scripts/opt/etc. This may be
fine for example startup scripts (for init.d and systemd), but is
extremely inconvenient for ENV files like
${PREFIX}/etc/profile.d/set-ovis-variables.sh and
${PREFIX}/etc/ld.so.conf.d/ovis-ld-so.conf.  The relocation also broke
tests that use these two files to setup OVIS environment.

This patch partially reverts #985 by installing
${PREFIX}/etc/profile.d/set-ovis-variables.sh and
${PREFIX}/etc/ld.so.conf.d/ovis-ld-so.conf. To prevent installing these
files into "/etc", the installation is guarded by the sysconfdir
checking condition, i.e. if "$(sysconfdir)" is "/etc", they won't be
installed.