### PR TITLE
Fix distutils deprecation in ldmsd_controller (Ubuntu 22.04)

### DIFF
--- a/ldms/python/ldmsd/ldmsd_util.py
+++ b/ldms/python/ldmsd/ldmsd_util.py
@@ -68,7 +68,7 @@ import io
 from io import StringIO
 import errno
 import tty
-from distutils.spawn import find_executable
+import shutil
 
 def add_cmd_line_arg(arg, value = None):
     """Return a string of command line option and value
@@ -366,7 +366,7 @@ class LDMSD(object):
         """
         self.cmd_args = []
         if gdb_port:
-            ldmsd_path = find_executable("ldmsd")
+            ldmsd_path = shutil.which("ldmsd")
             if not ldmsd_path:
                 raise RuntimeError("ldmsd not found")
             self.cmd_args.extend([


### PR DESCRIPTION
ldmsd_controller uses `ldmsd_util.py` which used `find_executable()`
from the deprecated Python package `distutils`. This patch replaces
`find_executable()` with the equivalent `shutil.which()` call.