### PR TITLE
suppress rollover of empty csv files

### DIFF
--- a/ldms/man/Plugin_store_csv.man
+++ b/ldms/man/Plugin_store_csv.man
@@ -43,7 +43,7 @@ take on the value configured in the default config line or opt_file.
 .SH STORE_CSV CONFIGURATION ATTRIBUTE SYNTAX
 .TP
 .BR config
-name=<plugin_name> path=<path> [ altheader=<0/!0> typeheader=<typeformat> time_format=<0/1> ietfcsv=<0/1> buffer=<0/1/N> buffertype=<3/4> rolltype=<rolltype> rollover=<rollover> userdata=<0/!0>] [rename_template=<metapath> [rename_uid=<int-uid> [rename_gid=<int-gid] rename_perm=<octal-mode>]] [create_uid=<int-uid>] [create_gid=<int-gid] [create_perm=<octal-mode>] [opt_file=filename] [ietfcsv=<0/1>] [typeheader=<0/1/2>] [array_expand=<false/true>] [array_sep=<separating char>] [array_lquote=<left-quote char>] [array_rquote=<right-quote char>]
+name=<plugin_name> path=<path> [ altheader=<0/!0> typeheader=<typeformat> time_format=<0/1> ietfcsv=<0/1> buffer=<0/1/N> buffertype=<3/4> rolltype=<rolltype> rollover=<rollover> rollempty=<0/1> userdata=<0/!0>] [rename_template=<metapath> [rename_uid=<int-uid> [rename_gid=<int-gid] rename_perm=<octal-mode>]] [create_uid=<int-uid>] [create_gid=<int-gid] [create_perm=<octal-mode>] [opt_file=filename] [ietfcsv=<0/1>] [typeheader=<0/1/2>] [array_expand=<false/true>] [array_sep=<separating char>] [array_lquote=<left-quote char>] [array_rquote=<right-quote char>]
 .br
 ldmsd_controller configuration line
 .RS
@@ -108,10 +108,12 @@ By default, the store does not rollover and the data is written to a continously
 1
 .br
 wake approximately every rollover seconds and roll.
+Rollover is suppressed if no data at all has been written and rollempty=0.
 .TP
 2
 .br
 wake daily at rollover seconds after midnight (>=0) and roll.
+Rollover is suppressed if no data at all has been written and rollempty=0.
 .TP
 3
 .br
@@ -123,11 +125,16 @@ roll after approximately rollover bytes are written.
 5
 .br
 wake at rollover seconds after midnight (>=0) and roll, then repeat every rollagain (> rollover) seconds during the day. For example "rollagain=3600 rollover=0 rolltype=5" rolls files hourly.
+Rollover is suppressed if no data at all has been written and rollempty=0.
 .RE
 .TP
 rollover=<rollover>
 .br
 Rollover value controls the frequency of rollover (e.g., number of bytes, number of records, time interval, seconds after midnight). Note that these values are estimates.
+.TP
+rollempty=0
+.br
+Turn off rollover of empty files. Default value is 1 (create extra empty files).
 .TP
 create_perm=<modebits>
 .br

--- a/ldms/man/Plugin_store_function_csv.man
+++ b/ldms/man/Plugin_store_function_csv.man
@@ -66,10 +66,12 @@ By default, the store does not rollover and the data is written to a continously
 1
 .br
 wake approximately every rollover seconds and roll.
+Rollover is suppressed if no data at all has been written and rollempty=0.
 .TP
 2
 .br
 wake daily at rollover seconds after midnight (>=0) and roll.
+Rollover is suppressed if no data at all has been written and rollempty=0.
 .TP
 3
 .br
@@ -82,6 +84,10 @@ roll after approximately rollover bytes are written.
 rollover=<rollover>
 .br
 Rollover value controls the frequency of rollover (e.g., number of bytes, number of records, time interval, seconds after midnight). Note that these values are estimates.
+.TP
+rollempty=0
+.br
+Turn off rollover of empty files. Default value is 1 (create extra empty files).
 .RE
 
 

--- a/ldms/scripts/examples/rollemptycsv
+++ b/ldms/scripts/examples/rollemptycsv
@@ -1,0 +1,36 @@
+export plugname=meminfo
+portbase=61096
+#export VGARGS="--track-origins=yes --leak-check=full"
+LDMSD -p prolog.sampler 1
+#vgon
+LDMSD 2
+LDMSD 3
+SLEEP 2
+#vgoff
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1 -v
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2 -v
+MESSAGE ldms_ls on host 2:
+LDMS_LS 3 -v
+SLEEP 30
+KILL_LDMSD 1
+SLEEP 90
+KILL_LDMSD $(seq 2 3)
+noempty=$(ls $STOREDIR/$HOSTNAME/rollempty0/rollemptycsv.* |wc -l)
+yesempty=$(ls $STOREDIR/$HOSTNAME/rollempty1/rollemptycsv.* |wc -l)
+if ! test "$bypass" = "1"; then
+	if test $noempty -lt 2 -o $yesempty -lt 2; then
+		echo "FAIL: roll-over files $STOREDIR/$HOSTNAME/rollempty*/rollemptycsv.* not created."
+		bypass=1
+	fi
+	# There should be a substantial difference
+	# between rollempty=0 and rollempty=1 output file counts
+	diffempty=$(( $yesempty - $noempty))
+	if test $diffempty -lt 8; then
+		echo "FAIL: rollempty setting not working as expected."
+		echo "FAIL: rollempty=0 -> $noempty; rollempty=1 -> $yesempty"
+		bypass=1
+	fi
+	echo "rollempty=0 -> $noempty; rollempty=1 -> $yesempty"
+fi

--- a/ldms/scripts/examples/rollemptycsv.2
+++ b/ldms/scripts/examples/rollemptycsv.2
@@ -1,0 +1,13 @@
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0 rollover=2 rolltype=1 rollempty=0 rename_template=${STOREDIR}/%{HOSTNAME}/%C/%B
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_start name=localhost1
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+strgp_add name=store_${testname} plugin=store_csv schema=${testname} container=rollempty0
+strgp_prdcr_add name=store_${testname} regex=.*
+strgp_start name=store_${testname}

--- a/ldms/scripts/examples/rollemptycsv.3
+++ b/ldms/scripts/examples/rollemptycsv.3
@@ -1,0 +1,13 @@
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0 rollover=2 rolltype=1 rollempty=1 rename_template=${STOREDIR}/%{HOSTNAME}/%C/%B
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_start name=localhost1
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+strgp_add name=store_${testname} plugin=store_csv schema=${testname} container=rollempty1
+strgp_prdcr_add name=store_${testname} regex=.*
+strgp_start name=store_${testname}

--- a/ldms/src/store/stream/Plugin_stream_csv_store.man
+++ b/ldms/src/store/stream/Plugin_stream_csv_store.man
@@ -53,10 +53,12 @@ By default, the store does not rollover and the data is written to a continously
 1
 .br
 wake approximately every rollover seconds and roll.
+Rollover is suppressed if no data at all has been written.
 .TP
 2
 .br
 wake daily at rollover seconds after midnight (>=0) and roll.
+Rollover is suppressed if no data at all has been written.
 .TP
 3
 .br
@@ -69,6 +71,7 @@ roll after approximately rollover bytes are written.
 5
 .br
 wake at rollover seconds after midnight (>=0) and roll, then repeat every rollagain (> rollover) seconds during the day. For example "rollagain=3600 rollover=0 rolltype=5" rolls files hourly.
+Rollover is suppressed if no data at all has been written.
 .RE
 .TP
 rollover=<rollover>

--- a/ldms/src/store/stream/stream_csv_store.c
+++ b/ldms/src/store/stream/stream_csv_store.c
@@ -1054,6 +1054,8 @@ static void roll_cb(void *obj, void *cb_arg)
 	case ROLL_BY_INTERVAL:
 	case ROLL_BY_MIDNIGHT:
 	case ROLL_BY_MIDNIGHT_AGAIN:
+		if (stream_handle->store_count == 0)
+			goto out;
 		break;
 	case ROLL_BY_RECORDS:
 		if (stream_handle->store_count < rollover) {


### PR DESCRIPTION
rolling empty files periodically is an inode-wasting thing to do.
this stops it for store_csv, store_function_csv and the stream csv store.