### PR TITLE
Variorum LDMS Plugin for vendor-neutral power management

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -351,6 +351,26 @@ dnl options for contributed samplers
 OPTION_DEFAULT_DISABLE([ipmireader], [ENABLE_IPMIREADER])
 OPTION_DEFAULT_DISABLE([tutorial-sampler],[ENABLE_TUTORIAL_SAMPLER])
 
+dnl Variorum dependency support
+AC_ARG_ENABLE([variorum],
+    [AS_HELP_STRING([--enable-variorum], [require components that depend upon libvariorum (and libjansson) @<:@default=check@:>@])],
+    [],
+    [enable_variorum="check"])
+AS_IF([test "x$enable_variorum" != xno],[
+    AC_LIB_HAVE_LINKFLAGS([variorum], [], [#include <variorum.h>
+                           #include <variorum_topology.h>])
+    AS_IF([test "x$enable_variorum" != xcheck],[
+        AS_IF([test "x$HAVE_LIBVARIORUM" = xno],
+            [AC_MSG_ERROR([libvariorum or headers not found])])
+    ])
+    AC_LIB_HAVE_LINKFLAGS([jansson], [], [#include <jansson.h>])
+    AS_IF([test "x$enable_variorum" != xcheck],[
+        AS_IF([test "x$HAVE_LIBJANSSON" = xno],
+            [AC_MSG_ERROR([libjansson or headers not found])])
+    ])
+])
+AM_CONDITIONAL([HAVE_LIBVARIORUM], [test "x$HAVE_LIBVARIORUM" = xyes])
+AM_CONDITIONAL([HAVE_LIBJANSSON], [test "x$HAVE_LIBJANSSON" = xyes])
 
 dnl check for libcurl if influx is configured
 OPTION_DEFAULT_DISABLE([influx], [ENABLE_INFLUX])
@@ -987,6 +1007,7 @@ ldms/src/contrib/sampler/daos/Makefile
 ldms/src/contrib/sampler/daos/test/Makefile
 ldms/src/contrib/sampler/ipmireader/Makefile
 ldms/src/contrib/sampler/tutorial/Makefile
+ldms/src/contrib/sampler/variorum_sampler/Makefile
 ldms/src/contrib/sampler/geopm_sampler/Makefile
 ldms/src/third-plugins/Makefile
 ldms/src/ldmsd/Makefile

--- a/ldms/src/contrib/sampler/Makefile.am
+++ b/ldms/src/contrib/sampler/Makefile.am
@@ -28,3 +28,9 @@ if ENABLE_DAOS_SAMPLER
     MAYBE_DAOS_SAMPLER = daos
 endif
 SUBDIRS += $(MAYBE_DAOS_SAMPLER)
+
+if HAVE_LIBJANSSON
+if HAVE_LIBVARIORUM
+SUBDIRS += variorum_sampler
+endif
+endif

--- a/ldms/src/contrib/sampler/variorum_sampler/Makefile.am
+++ b/ldms/src/contrib/sampler/variorum_sampler/Makefile.am
@@ -1,0 +1,16 @@
+pkglib_LTLIBRARIES =
+lib_LTLIBRARIES =
+dist_man7_MANS =
+dist_man1_MANS =
+EXTRA_DIST =
+
+AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
+AM_LDFLAGS = @OVIS_LIB_ABS@
+COMMON_LIBADD = -lsampler_base -lldms -lovis_util -lcoll \
+		@LDFLAGS_GETTIME@
+
+libvariorum_sampler_la_SOURCES = variorum_sampler.c
+libvariorum_sampler_la_LIBADD = $(COMMON_LIBADD) $(LTLIBVARIORUM) $(LTLIBJANSSON)
+pkglib_LTLIBRARIES += libvariorum_sampler.la
+dist_man7_MANS += Plugin_variorum_sampler.man
+EXTRA_DIST += README.md

--- a/ldms/src/contrib/sampler/variorum_sampler/Plugin_variorum_sampler.man
+++ b/ldms/src/contrib/sampler/variorum_sampler/Plugin_variorum_sampler.man
@@ -1,0 +1,66 @@
+.\" Manpage for Plugin_variorum_sampler
+.\" Contact j_hannebert@coloradocollege.edu, patki1@llnl.gov, shoga1@llnl.gov, brink2@llnl.gov or rountree4@llnl.gov to correct errors or typos.
+.TH man 7 "27 Jun 2022" "v4" "LDMS Plugin variorum_sampler man page"
+
+.SH NAME
+Plugin_variorum_sampler - man page for the LDMS Variorum plugin
+
+.SH SYNOPSIS
+Within ldmsd_controller or a configuration file:
+.br
+config name=variorum_sampler [common attributes]
+
+.SH DESCRIPTION
+With LDMS (Lightweight Distributed Metric Service), plugins for the ldmsd (ldms daemon) are configured via ldmsd_controller
+or a configuration file. The variorum_sampler plugin provides power data using the JSON API in Variorum, a vendor-neutral library that provides access to low-level hardware knobs.
+The sampler, when configured, automatically detects the number of sockets on the host machine and then provides, for each socket, an LDMS record containing power data.
+For each socket, the values provided are: node power consumption in Watts (identical across sockets); socket ID number; CPU power consumption in Watts;
+GPU power consumption in Watts (aggregated across all GPUs on the socket, and
+reported as -1 on unsupported platforms); and memory power consumption in Watts.
+
+.PP
+The variorum sampler depends on Variorum 0.6.0 or higher and Jansson. The sampler cannot be built without these libraries. If either library is installed in a non-standard location, paths to the respective install directories should be provided to Autoconf using
+the --with-libjansson-prefix and/or --with-libvariorum-prefix flag.
+
+.SH CONFIGURATION ATTRIBUTE SYNTAX
+The variorum sampler plugin uses the sampler_base base class. This man page covers only the configuration attributes, or those with default values, specific to the this plugin; see ldms_sampler_base.man for the attributes of the base class.
+
+.TP
+.BR config
+name=<plugin_name> exclude_ports=<devs>
+.br
+configuration line
+.RS
+.TP
+name=<plugin_name>
+.br
+This MUST be variorum_sampler.
+.TP
+schema=<schema>
+.br
+Optional schema name. It is intended that the same sampler on different nodes with different metrics have a
+different schema. If not specified, will default to `variorum_sampler`.
+.RE
+
+.SH BUGS
+No known bugs; however, if Variorum cannot access the hardware knobs, the sampler will be unable to access any data. This will result in an error being printed to the log file: "variorum_sampler: unable to obtain JSON object data". This error can be resolved by ensuring that
+hardware knob access is enabled using the requirements here: https://variorum.readthedocs.io/en/latest/HWArchitectures.html
+
+.SH EXAMPLES
+.PP
+Within ldmsd_controller or a configuration file:
+.nf
+load name=variorum_sampler
+config name=variorum_sampler producer=vm1_1 instance=vm1_1/variorum_sampler
+start name=variorum_sampler interval=1000000
+.fi
+
+.SH AUTHORS
+Jessica Hannebert <j_hannebert@coloradocollege.edu> (Colorado College, internship at Lawrence Livermore National Laboratory).
+Tapasya Patki <patki1@llnl.gov> (Lawrence Livermore National Laboratory).
+Kathleen Shoga <shoga1@llnl.gov> (Lawrence Livermore National Laboratory).
+Stephanie Brink <brink2@llnl.gov> (Lawrence Livermore National Laboratory).
+Barry Rountree <rountree4@llnl.gov> (Lawrence Livermore National Laboratory).
+
+.SH SEE ALSO
+ldmsd(8), ldms_quickstart(7), ldmsd_controller(8), ldms_sampler_base(7)

--- a/ldms/src/contrib/sampler/variorum_sampler/README.md
+++ b/ldms/src/contrib/sampler/variorum_sampler/README.md
@@ -58,7 +58,7 @@ internally, for which documentation can be found here:
 
 For each socket, the values provided are: node power consumption in Watts (identical across sockets);
 socket ID number; CPU power consumption in Watts;
-GPU power consumption in Watts (aggregated across all GPUs on the socket, and   
+GPU power consumption in Watts (aggregated across all GPUs on the socket, and
 reported as -1 on unsupported platforms); and
 memory power consumption in Watts.
 

--- a/ldms/src/contrib/sampler/variorum_sampler/README.md
+++ b/ldms/src/contrib/sampler/variorum_sampler/README.md
@@ -1,0 +1,66 @@
+VARIORUM LDMS SAMPLER PLUGIN
+=========================
+
+This directory contains the source for the Variorum LDMS Sampler Plugin.
+This sampler uses the JSON API from Variorum, a vendor-neutral library
+that provides access to low-level power knobs regardless of system
+architecture and implementation.
+
+Build Requirements
+------------------
+
+The Variorum LDMS sampler currently requires version 0.6.0 or higher
+of the Variorum library (``libvariorum.so``). This library must be built
+from source. The sampler also requires jansson, which is a Variorum
+dependency. If both libraries are installed in standard locations,
+Autotools will locate them automatically. Otherwise, the user must use
+the flags ``--with-libjansson-prefix=/jansson/path`` and ``--with-libvariorum-prefix=/variorum/path``
+to point to the correct respective install locations when building LDMS.
+
+### Installing Variorum
+
+Variorum can be installed using the instructions here:
+[Building Variorum](https://variorum.readthedocs.io/en/latest/BuildingVariorum.html)
+
+The following bash commands show the steps for installation:
+
+    # install hwloc and jansson dependencies
+    sudo apt-get install libhwloc15 libhwloc-dev libjansson4 libjansson-dev
+
+    git clone https://github.com/llnl/variorum
+
+    cd variorum
+    mkdir build install
+    cd build
+
+    cmake -DCMAKE_INSTALL_PREFIX=../install ../src
+    make -j8
+    make install
+
+Note: the ``cmake`` command may require a ``host-config`` file, as
+described here: [Host Config Files](https://variorum.readthedocs.io/en/latest/BuildingVariorum.html#host-config-files)
+
+OVIS Build
+----------
+
+The sampler is enabled by default in the configure script
+if Variorum and Jansson are both found. Please refer to the OVIS documentation
+for general guidance on building the OVIS/LDMS codebase.
+
+Using the Variorum LDMS Sampler
+----------------------------
+
+The sampler, when configured, automatically detects the number of sockets
+on the host machine and then provides, for each socket, an LDMS record
+containing power data. The sampler calls ``variorum_get_node_power_json``
+internally, for which documentation can be found here:
+[Variorum JSON-Support Functions](https://variorum.readthedocs.io/en/latest/api/json_support_functions.html)
+
+For each socket, the values provided are: node power consumption in Watts (identical across sockets);
+socket ID number; CPU power consumption in Watts;
+GPU power consumption in Watts (aggregated across all GPUs on the socket, and   
+reported as -1 on unsupported platforms); and
+memory power consumption in Watts.
+
+More details on using the sampler can be found on the
+[man page](Plugin_variorum_sampler.man).

--- a/ldms/src/contrib/sampler/variorum_sampler/variorum_sampler.c
+++ b/ldms/src/contrib/sampler/variorum_sampler/variorum_sampler.c
@@ -1,0 +1,249 @@
+/* -*- c-basic-offset: 8 -*- */
+/* Copyright 2022 Lawrence Livermore National Security, LLC
+ * See the top-level COPYING file for details.
+ *
+ * SPDX-License-Identifier: (GPL-2.0 OR BSD-3-Clause)
+ */
+
+#define _GNU_SOURCE
+#include <inttypes.h>
+#include <unistd.h>
+#include <sys/errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ldms.h"
+#include "ldmsd.h"
+#include "sampler_base.h"
+#include "variorum.h"
+#include "jansson.h"
+#include "variorum_topology.h"
+
+#define SAMP "variorum_sampler"
+
+static ldms_set_t set = NULL;
+static ldmsd_msg_log_f msglog;
+static base_data_t base;
+static int nsockets;
+static const char *SOCKET_METRICS[] = {"power_cpu_watts_socket_", "power_gpu_watts_socket_", "power_mem_watts_socket_"};
+static char** metric_names = NULL;
+static int i_node;
+static int i_sock;
+static int i_cpu;
+static int i_gpu;
+static int i_mem;
+static int lh_idx;
+static ldms_mval_t* rec_idxs;
+static char* result_string;
+
+static int create_metric_set(base_data_t base)
+{
+        int rc, i, metric, socket;
+        char metric_name[28];
+        char socket_num[11];
+        ldms_schema_t schema;
+        ldms_mval_t rec_inst;
+
+        // allocate space for metric names
+        if (!metric_names) {
+                metric_names = malloc(3 * nsockets * sizeof(char*));
+        }
+        for (metric = 0; metric < (3 * nsockets); metric++) {
+                metric_names[metric] = malloc(39);
+        }
+
+        // allocate space for record pointers
+        if (!rec_idxs) {
+                rec_idxs = malloc(nsockets * sizeof(ldms_mval_t));
+        }
+
+        schema = base_schema_new(base);
+        if (!schema) {
+                msglog(LDMSD_LERROR,
+                "%s: The schema '%s' could not be created, errno=%d.\n",
+                __FILE__, base->schema_name, errno);
+                rc = errno;
+                goto err;
+        }
+
+        // create record
+        ldms_record_t rec_def = ldms_record_create("variorum_socket_record");
+        i_node = ldms_record_metric_add(rec_def, "node_watts", "watts", LDMS_V_D64, 0);
+        i_sock = ldms_record_metric_add(rec_def, "socket_ID", "number", LDMS_V_U64, 0);
+        i_cpu = ldms_record_metric_add(rec_def, "cpu_watts", "watts", LDMS_V_D64, 0);
+        i_gpu = ldms_record_metric_add(rec_def, "gpu_watts", "watts", LDMS_V_D64, 0);
+        i_mem = ldms_record_metric_add(rec_def, "mem_watts", "watts", LDMS_V_D64, 0);
+
+        // calculate required heap size to support 1 record per socket
+        size_t heap_sz = nsockets * ldms_record_heap_size_get(rec_def);
+
+        // add record definition to the schema
+        int rec_def_idx = ldms_schema_record_add(schema, rec_def);
+
+        // add the metric list to the schema
+        int lh_idx = ldms_schema_metric_list_add(schema, "power", NULL, heap_sz);
+
+        set = base_set_new(base);
+        if (!set) {
+                rc = errno;
+                goto err;
+        }
+
+        ldms_mval_t lh = ldms_metric_get(set, lh_idx);
+
+        for(socket = 0; socket < nsockets; socket++) {
+                // create a new record
+                rec_inst = ldms_record_alloc(set, rec_def_idx);
+                rec_idxs[socket] = rec_inst;
+                // set the socket number
+                ldms_record_set_u64(rec_inst, i_sock, socket);
+                // put the record into the list
+                ldms_list_append_record(set, lh, rec_inst);
+                // create metric name list (for querying json object later on)
+                for(metric = 0; metric < 3; metric++) {
+                        strcpy(metric_name,SOCKET_METRICS[metric]);
+                        sprintf(socket_num,"%d",socket);
+                        strcat(metric_name,socket_num);
+                        strcpy(metric_names[(metric*nsockets)+socket], metric_name);
+                }
+        }
+
+        // allocate space for sampling JSON data depending on number of sockets
+        result_string = (char *) malloc((nsockets * 150 + 500) * sizeof(char));
+
+        return 0;
+
+ err:
+        return rc;
+
+}
+
+static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct attr_value_list *avl)
+{
+
+        int rc;
+        int depth;
+
+        if (set) {
+                msglog(LDMSD_LERROR, SAMP ": Set already created.\n");
+                return EINVAL;
+        }
+
+        // determine number of sockets
+        nsockets = variorum_get_num_sockets();
+
+        // prepare the base for metric collection
+        base = base_config(avl, SAMP, SAMP, msglog);
+        if (!base) {
+                rc = errno;
+                goto err;
+        }
+
+        rc = create_metric_set(base);
+        if (rc) {
+                msglog(LDMSD_LERROR, SAMP ": failed to create a metric set.\n");
+                goto err;
+        }
+
+        return 0;
+ err:
+        base_del(base);
+        return rc;
+}
+
+static int sample(struct ldmsd_sampler *self)
+{
+        json_t *power_obj = NULL;
+        int ret, socket;
+
+        if (!set) {
+                msglog(LDMSD_LERROR, SAMP ": plugin not initialized\n");
+                return EINVAL;
+        }
+
+        base_sample_begin(base);
+
+        // get variorum data
+        ret = variorum_get_node_power_json(&result_string);
+        if (ret != 0) {
+                msglog(LDMSD_LERROR, SAMP ": unable to obtain JSON object data\n");
+                return EINVAL;
+        }
+
+        power_obj = json_loads(result_string, JSON_DECODE_ANY, NULL);
+
+        double power_node = json_real_value(json_object_get(power_obj, "power_node_watts"));
+        double power_cpu, power_gpu, power_mem;
+
+        // update each record
+        for(socket = 0; socket < nsockets; socket++) {
+                ldms_record_set_double(rec_idxs[socket], i_node, power_node);
+                power_cpu = json_real_value(json_object_get(power_obj, metric_names[socket]));
+                ldms_record_set_double(rec_idxs[socket], i_cpu, power_cpu);
+                power_gpu = json_real_value(json_object_get(power_obj, metric_names[nsockets+socket]));
+                ldms_record_set_double(rec_idxs[socket], i_gpu, power_gpu);
+                power_mem = json_real_value(json_object_get(power_obj, metric_names[(2*nsockets)+socket]));
+                ldms_record_set_double(rec_idxs[socket], i_mem, power_mem);
+        }
+
+        ldms_metric_modify(set, lh_idx);
+
+        json_decref(power_obj);
+        base_sample_end(base);
+
+        return 0;
+
+}
+
+static ldms_set_t get_set(struct ldmsd_sampler *self)
+{
+        return set;
+}
+
+static void term(struct ldmsd_plugin *self)
+{
+        int metric;
+
+        if (metric_names) {
+                for (metric = 0; metric < 3 * nsockets; metric++) {
+                        free(metric_names[metric]);
+                }
+                free(metric_names);
+        }
+        if (result_string) {
+                free(result_string);
+        }
+        if (rec_idxs) {
+                free(rec_idxs);
+        }
+        if (base) {
+                base_del(base);
+        }
+        if (set) {
+                ldms_set_delete(set);
+        }
+        set = NULL;
+}
+
+static const char *usage(struct ldmsd_plugin *self)
+{
+        return  "config name=" SAMP " " BASE_CONFIG_USAGE;
+}
+
+static struct ldmsd_sampler variorum_sampler_plugin = {
+        .base = {
+            .name = SAMP,
+            .type = LDMSD_PLUGIN_SAMPLER,
+            .term = term,
+            .config = config,
+            .usage= usage,
+        },
+        .get_set = get_set,
+        .sample = sample,
+};
+
+struct ldmsd_plugin *get_plugin(ldmsd_msg_log_f pf)
+{
+        msglog = pf;
+        return &variorum_sampler_plugin.base;
+}


### PR DESCRIPTION
This pull request introduces a vendor-neutral power monitoring plugin that reports node, CPU (socket), memory and GPU power using LLNL's Variorum library (https://variorum.readthedocs.io/).  

