### PR TITLE
Containerized arm64 cython --gdb work around

### DIFF
--- a/ldms/python/Makefile.am
+++ b/ldms/python/Makefile.am
@@ -22,9 +22,11 @@ ldms_la_CFLAGS = -g -O0  $(PY_INCLUDES) $(PYTHON_CPPFLAGS)
 ldms_la_LDFLAGS = $(PYTHON_LDFLAGS) -module -shared
 ldms_la_LIBADD = $(top_builddir)/ldms/src/core/libldms.la
 
+CYTHON_GDB = $(shell [ "$(uname -p)" = "x86_64" ] && echo --gdb || echo "" )
+
 $(LDMS_PYX_C): ldms.pyx ldms.pxd
 	echo PYTHON_LDFLAGS are "$(PYTHON_LDFLAGS)"
-	$(CYTHON) -3 --directive language_level=3 --fast-fail --gdb -I $(srcdir) $< -o $@
+	$(CYTHON) -3 --directive language_level=3 --fast-fail $(CYTHON_GDB) -I $(srcdir) $< -o $@
 
 SUBDIRS = ldmsd cmds
 


### PR DESCRIPTION
cython with `--gdb` option resulted in "segmentation fault" when `make`
built ldms python module on arm64 (aarch64) containers. This issue does
not appear on x86_64 containers. This patch adds a work around to
only enable `cython --gdb` option for x86_64 architecture.