### PR TITLE
Fix ldms.pyx Xprt connect/listen synchronous error handling

### DIFF
--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -3026,6 +3026,9 @@ cdef class Xprt(object):
         rc = ldms_xprt_connect_by_name(self.xprt, BYTES(host), BYTES(port),
                                        xprt_cb, <void*>self)
         if rc:
+            # synchronously failed, self.xprt is no good. Need to "put" it down.
+            ldms_xprt_put(self.xprt)
+            self.xprt = NULL
             raise ConnectionError(rc, "ldms_xprt_connect_by_name() error: {}" \
                                       .format(ERRNO_SYM(rc)))
         if cb:
@@ -3068,6 +3071,9 @@ cdef class Xprt(object):
         rc = ldms_xprt_listen_by_name(self.xprt, BYTES(host), BYTES(port),
                                       passive_xprt_cb, <void*>self)
         if rc:
+            # synchronously failed, self.xprt is no good. Need to "put" it down.
+            ldms_xprt_put(self.xprt)
+            self.xprt = NULL
             raise ConnectionError(rc, "ldms_xprt_listen_by_name() error: {}" \
                                       .format(ERRNO_SYM(rc)))
 


### PR DESCRIPTION
When ldms xprt connect/listen failed synchronously, the caller must drop
the xprt and don't ever touch it again. The Xprt object held the C xprt
after connect/listen synchronous failure, making it proned to
Xprt.close() by the Python application (e.g. maestro) which subsequently
incorrectly called `ldms_xprt_close()` on the C xprt that lead to a
segmentation fault. This patch modifies the ldms.pyx Xprt.connect() and
Xprt.listen() to properly handle the connect/listen synchronous error.