### PR TITLE
Fix munge auth check

### DIFF
--- a/ldms/src/auth/ldms_auth_munge.c
+++ b/ldms/src/auth/ldms_auth_munge.c
@@ -101,13 +101,9 @@ ldms_auth_t __auth_munge_new(ldms_auth_plugin_t plugin,
 	munge_err_t merr;
 	char *test_cred;
 
-	merr = munge_encode(&test_cred, NULL, NULL, 0);
-	if (merr != EMUNGE_SUCCESS)
-		goto err0;
-
 	a = calloc(1, sizeof(*a));
 	if (!a)
-		goto free_test_cred;
+		goto err0;
 
 	mctx = munge_ctx_create();
 	if (!mctx)
@@ -120,6 +116,12 @@ ldms_auth_t __auth_munge_new(ldms_auth_plugin_t plugin,
 			goto err2;
 	}
 
+	/* Test munge connection */
+	merr = munge_encode(&test_cred, mctx, NULL, 0);
+	if (merr != EMUNGE_SUCCESS)
+		goto err2;
+	free(test_cred);
+
 	a->mctx = mctx;
 	return &a->base;
 
@@ -127,8 +129,6 @@ err2:
 	munge_ctx_destroy(mctx);
 err1:
 	free(a);
-free_test_cred:
-	free(test_cred);
 err0:
 	return NULL;
 }


### PR DESCRIPTION
Munge authentication checking must be performed after the context has
been set. Otherwise, we will always check against the default settings
and ignore the options specified by users.