### PR TITLE
add man page and usability options to ldmsd_stream_subscribe

### DIFF
--- a/ldms/src/ldmsd/test/Makefile.am
+++ b/ldms/src/ldmsd/test/Makefile.am
@@ -21,3 +21,4 @@ sbin_PROGRAMS += ldmsd_stream_subscribe
 ldmsd_stream_subscribe_SOURCES = ldmsd_stream_subscribe.c
 ldmsd_stream_subscribe_LDADD = $(COMMON_LD_ADD)
 ldmsd_stream_subscribe_LDFLAGS = $(AM_LDFLAGS) -pthread 
+dist_man7_MANS += ldmsd_stream_subscribe.man

--- a/ldms/src/ldmsd/test/ldmsd_stream_subscribe.man
+++ b/ldms/src/ldmsd/test/ldmsd_stream_subscribe.man
@@ -1,0 +1,105 @@
+.\" Manpage for ldmsd_stream_subscribe
+.\" Contact ovis-help@ca.sandia.gov to correct errors or typos.
+.TH man 7 "21 Aug 2021" "v4" "LDMS utility ldmsd_streams_subscribe man page"
+
+.SH NAME
+ldmsd_stream_subscribe - man page for the LDMS ldmsd_stream_subscribe utility
+
+.SH SYNOPSIS
+At the command line:
+ldmsd_stream_subscribe [args]
+
+.SH DESCRIPTION
+The ldmsd_stream_subscribe program subscribes to a stream in place of a full ldmsd daemon, writing received messages to a file or to stdout.
+
+.SH COMMAND LINE SYNTAX
+
+.TP
+ldmsd_stream_subscribe -x <xprt> -h <host> -p <port> -s <stream-name> -a <auth> -A <auth-opt> -f <file> -D -i -R -q -E
+
+.br
+.RS
+.TP
+-x,--xprt <xprt>
+.br
+transport type on which to listen.
+.TP
+-p,--port <port>
+.br
+port on which to listen.
+.TP
+-h,--host <port>
+.br
+hostname or IP address of interface on which to listen.
+.TP
+-a,--auth <auth>
+.br
+authentication to expect from publishers.
+.TP
+-A,--auth_arg <auth-opt>
+.br
+auth options if needed (for e.g. ovis auth or munge on unusual port)
+.TP
+-s,--stream <stream-name>
+.br
+Name of the stream to subscribe.
+.TP
+-f,--file <file>
+.br
+File where messages delivered are written. If not specified, STDOUT.
+.TP
+-E,--events-raw
+.br
+Suppress delivery envelope information in message output.
+.TP
+-q,--quiet
+.br
+Suppress message output to file or stdout entirely.
+.TP
+-D,--daemonize
+.br
+Put the process in the background as a daemon.
+.TP
+-R,--daemon-noroot
+.br
+Prevent file system root (/) change-directory when starting the daemon.
+(Does nothing if -D is not present).
+.br
+.TP
+-i,--daemon-io
+.br
+Keep the input and output file descriptors attached to the daemon instead
+of closing them. (Does nothing if -D is not present).
+.RE
+
+.SH BUGS
+No known bugs.
+
+.SH NOTES
+.PP
+This program is in development and may change at any time.
+.PP
+Using "-a none" is insecure and should only be used with care.
+
+.SH EXAMPLES
+.PP
+Running in user mode as a sink to test a stream publishing program writing to tag 'mystream':
+.nf
+ldmsd_stream_subscribe -x sock -h 127.0.0.1 -p 20411 -s mystream -a none -f messages.out -D -R
+.fi
+
+.PP
+Running in root mode and testing on port 511
+.nf
+ldmsd_stream_subscribe -x sock -h 127.0.0.1 -p 511 -s mystream -a munge -f /var/log/ldms-stream/messages.out -D
+.fi
+
+.PP
+Sending data to listening subscriber
+.nf
+echo '{ "a": "worthless message"}' | ./ldmsd_stream_publish -x sock -h 127.0.0.1 -p 20411 -s mystream -a none -t json
+
+.fi
+
+.SH SEE ALSO
+ldmsd(8), ldms_quickstart(7), ldmsd_stream_publish(8), ldms_authentication(7)


### PR DESCRIPTION
This adds a man page and options so that ldmsd_stream_subscribe can be used as a testing tool  with -D for those other than root.
The daemon(0,0) command causes -D to fail for non-root users; the options below allow the users to adjust the args.
-R,--daemon-noroot suppresses the 'cd /' part of the daemon command.
-i,--daemon-io suppresses the closing of IO channels at the fork so messages go to the terminal while the daemonized process continues

For other debugging/use purposes, the -E,--events-raw suppresses the generation of the EVENT:{} wrapper around messages (which may not be json), but does add the carriage return after each message logged.
