### PR TITLE
add -x -p -h args so ldmsd_controller options are like others

### DIFF
--- a/ldms/man/ldmsd_controller.man
+++ b/ldms/man/ldmsd_controller.man
@@ -33,21 +33,21 @@ PATH
 
 .SH LDMSD_CONTROLLER OPTIONS
 .TP
-.BI --host " HOST"
+.BI -h,--host " HOST"
 Hostname of \fBldmsd\fR to connect to
 .TP
-.BI --port " PORT"
+.BI -p,--port " PORT"
 The port of \fBldmsd\fR to connect to
 .TP
-.BI --xprt " XPRT"
+.BI -x,--xprt " XPRT"
 The transport type (\fBsock\fR, \fBrdma\fR, \fBugni\fR).
 .TP
-.BI -a " AUTH" " | --auth" " AUTH"
+.BI -a,--auth " AUTH"
 The LDMS authentication plugin. Please see
 .BR ldms_authentication (7)
 for more information.
 .TP
-.BI "-A " NAME = VALUE " | --auth-arg " NAME = VALUE
+.BI -A,--auth-arg " NAME=VALUE "
 Options
 .IR NAME = VALUE
 Passing the \fINAME\fR=\fIVALUE\fR option to the LDMS Authentication plugin.
@@ -64,7 +64,7 @@ Path to the config file
 .br
 Execute the script and send the output commands to the connected ldmsd
 .TP
-.BR -h
+.BR -?
 Display help
 .TP
 .BR --help

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1712,13 +1712,16 @@ if __name__ == "__main__":
                                          "To connect to an ldmsd, either give " \
                                          "the socket path of the ldmsd or " \
                                          "give both hostname and inet control port. " \
-                                         "If all are given, the sockname takes the priority.")
-        parser.add_argument('--host',
+                                         "If all are given, the sockname takes the priority.",
+                                         add_help=False)
+        parser.add_argument('-?', '--help', action='help', default='==SUPPRESS==',
+                help='show this help message and exit')
+        parser.add_argument('-h','--host',
                             help = "Hostname of ldmsd to connect to",
                             default = 'localhost')
-        parser.add_argument('--port',
+        parser.add_argument('-p','--port',
                             help = "Inet ctrl listener port of ldmsd")
-        parser.add_argument('--xprt',
+        parser.add_argument('-x','--xprt',
                             help = "LDMS Transport type",
                             choices = ['sock', 'ugni', 'rdma', 'fabric'],
                             default = 'sock')


### PR DESCRIPTION
changes -h (or --help) to -? or --help to remedy collision with our -h host common syntax.