### PR TITLE
Fix test_sampler config add_schema num_metrics

### DIFF
--- a/ldms/src/sampler/examples/test_sampler/test_sampler.c
+++ b/ldms/src/sampler/examples/test_sampler/test_sampler.c
@@ -835,6 +835,8 @@ static int config_add_schema(struct attr_value_list *avl)
 			}
 			s++;
 		}
+	} else {
+		num_metrics = atoi(value);
 	}
 
 	temp = calloc(num_metrics + 1, sizeof(struct ldms_metric_template_s));


### PR DESCRIPTION
`add_schema` config command of `test_sampler` can specify either an explicit list of metrics or `num_metrics` (just the number of metrics). In the latter case, the `num_metrics` variable in the code was not set to the value given by the user. It was uninitialized. This made the sampler miscalculated the required memory size and stomp on others' memory (e.g.  corrupting malloc chunks).