### PR TITLE
fix missing free before logger starts.

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -368,6 +368,7 @@ void __ldmsd_log(enum ldmsd_loglevel level, const char *fmt, va_list ap)
 	if (!ldmsd_is_initialized()) {
 		/* No workers, so directly log to the file */
 		(void) __log(level, msg, &tv, &tm);
+		free(msg);
 		return;
 	}
 


### PR DESCRIPTION
vasprintf needs freeing in the early error case. this is otherwise handle by log_actor after init.