### PR TITLE
convert __dlog gdb-only controls to option -L control

### DIFF
--- a/ldms/man/ldmsd.man
+++ b/ldms/man/ldmsd.man
@@ -103,7 +103,7 @@ are executed sequentially, except for \fBprdcr_start\fR, \fBupdtr_start\fR,
 the deferred). Then, upon failover pairing success or failure, the other
 deferred configuration objects will be started. Please also note that while
 failover service is in use, prdcr, updtr, and strgp cannot be altered (start,
-stop, or reconfigure) over in-band configuration.
+stop, or reconfigure) over in-band configuration. See also REORDERED COMMANDS below.
 .TP
 .BI "-m, --set_memory" " MEMORY_SIZE"
 .br
@@ -174,6 +174,20 @@ The default level is ERROR. QUIET produces only user-requested output.
 .TP
 .BR -t
 Truncate the log file if it already exists.
+.TP
+.BI -L, --log_config " <CINT:PATH> | <CINT> | <PATH>"
+.br
+Append configuration replay messages or configuration debugging messages to the log indicated by -l (when PATH is omitted) or to the file named PATH. Bit values of CINT correspond to:
+.nf
+      0: no messages
+      1: debug messages from the generic 'request' handler
+      2: config history messages in replayable format
+      4: query history messages in replayable format
+      8: failover debugging messages
+     16: include delta time prefix when using PATH
+     32: include epoch timestamp prefix when using PATH
+.fi
+These values may be added together to enable multiple outputs. All messages are logged at the user-requested level, LDMSD_LALL. CINT values 2, 26 and 27 are often interesting. When CINT is omitted, 1 is the default. When PATH is used, the log messages are flushed to as they are generated.
 
 .SS
 Kernel Metric Options:
@@ -206,9 +220,9 @@ option <COMMAND-LINE OPTIONS>
 .TP
 .BI -k, --publish_kernel
 .TP
-.BI -l, --log_file
-log_file=<pat
-.BI -m, --sett_memory
+.BI -l, --log_file " PATH"
+.TP
+.BI -m, --set_memory
 .TP
 .BI -n, --daemon_name
 .TP
@@ -219,6 +233,8 @@ log_file=<pat
 .BI -s, --kernel_set_path
 .TP
 .BI -v, --log_level
+.TP
+.BI -L, --log_config " <CINT[:PATH]>"
 
 .SS Specifying the listen endpoints in configuraton files
 .TP
@@ -262,6 +278,9 @@ foo         user 20596 0x86bb0000 0x86bc0000
 Set the environment variables ZAP_UGNI_PTAG and ZAP_UGNI_COOKIE with the appropriate ptag and cookie.
 .PP
 Run ldmsd directly or as part of a script launched from aprun. In either case, Use aprun with the correct -p <ptag> when running.
+
+.SH REORDERED COMMANDS
+Certain commands in are reordered when processing input scripts specified with -c. Items related to failover are handled as described in the '-c' section above. Other commands are promoted to run before any non-promoted commands from the loaded script. In particular, env, loglevel, listen, auth, and option are promoted.
 
 .SH NOTES
 OCM flags are unsupported at this time.

--- a/ldms/scripts/examples/many
+++ b/ldms/scripts/examples/many
@@ -1,11 +1,21 @@
 portbase=61076
 MESSAGE starting agg and two collectors
+DAEMONS $(seq 3)
 JOBDATA $TESTDIR/job.data 1 2 3
+VGARGS="--tool=drd"
+VGARGS="--track-origins=yes --leak-check=full --show-leak-kinds=definite"
+/bin/rm ${LOGDIR}/log_config.*
 #vgon
-VGARGS="--track-origins=yes --leak-check=full --show-leak-kinds=all"
-LDMSD -p prolog.jobidinfo `seq 3`
-#vgoff
+LDMSD_EXTRA="-L 15:${LOGDIR}/log_config.1"
+LDMSD -p prolog.jobidinfo 1
+LDMSD_EXTRA="-L 2:${LOGDIR}/log_config.2"
+LDMSD -p prolog.jobidinfo 2
+LDMSD_EXTRA="-L 31:${LOGDIR}/log_config.3"
+LDMSD -p prolog.jobidinfo 3
+vgoff
 LDMS_LS 1
+LDMS_LS 2
+LDMS_LS 3
 SLEEP 15
 KILL_LDMSD `seq 3`
 MESSAGE logs and data under ${TESTDIR}

--- a/ldms/scripts/ldms-reverse-conf.sh
+++ b/ldms/scripts/ldms-reverse-conf.sh
@@ -2,6 +2,7 @@
 in=$1
 tac $in | \
 grep -v '^# ' | \
+grep -v 'option ' | \
 grep -v 'listen ' | \
 grep -v 'config ' | \
 sed -e 's/strgp_start/strgp_stop/' | \

--- a/ldms/scripts/ldms-static-test.sh.in
+++ b/ldms/scripts/ldms-static-test.sh.in
@@ -31,6 +31,7 @@ if test -z "$LDMSD_PLUGIN_LIBPATH"; then
 fi
 export LDMSD_PLUGIN_LIBPATH
 export LD_LIBRARY_PATH=${ovis_ldms_plugins_rpath}:${BUILDDIR}/lib:${exec_prefix}/lib:$ovis_ldms_plugins:$LD_LIBRARY_PATH
+export PYTHONPATH=${ovis_ldms_pythondir}:$PYTHONPATH
 
 function clusage {
 cat << EOF

--- a/ldms/scripts/pll-ldms-static-test.sh.in
+++ b/ldms/scripts/pll-ldms-static-test.sh.in
@@ -37,6 +37,7 @@ if test -z "$LDMSD_PLUGIN_LIBPATH"; then
 fi
 export LDMSD_PLUGIN_LIBPATH
 export LD_LIBRARY_PATH=${ovis_ldms_plugins_rpath}:${BUILDDIR}/lib:${exec_prefix}/lib:$ovis_ldms_plugins:$LD_LIBRARY_PATH
+export PYTHONPATH=${ovis_ldms_pythondir}:$PYTHONPATH
 
 function clusage {
 cat << EOF

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -851,6 +851,8 @@ int ldmsd_cfgobjs_start(int (*filter)(ldmsd_cfgobj_t))
 			ldmsd_cfg_unlock(LDMSD_CFGOBJ_PRDCR);
 			goto out;
 		}
+		__dlog(DLOG_CFGOK, "prdcr_start name=%s interval=%ld # delay\n",
+			obj->name, ((ldmsd_prdcr_t)obj)->conn_intrvl_us);
 	}
 	ldmsd_cfg_unlock(LDMSD_CFGOBJ_PRDCR);
 
@@ -866,6 +868,12 @@ int ldmsd_cfgobjs_start(int (*filter)(ldmsd_cfgobj_t))
 			ldmsd_cfg_unlock(LDMSD_CFGOBJ_UPDTR);
 			goto out;
 		}
+		__dlog(DLOG_CFGOK, "updtr_start name=%s interval=%ld"
+			" offset=%ld auto_interval=%d # delayed\n",
+			obj->name,
+			((ldmsd_updtr_t)obj)->default_task.sched.intrvl_us,
+			((ldmsd_updtr_t)obj)->default_task.sched.offset_us,
+			((ldmsd_updtr_t)obj)->is_auto_task);
 	}
 	ldmsd_cfg_unlock(LDMSD_CFGOBJ_UPDTR);
 
@@ -881,6 +889,8 @@ int ldmsd_cfgobjs_start(int (*filter)(ldmsd_cfgobj_t))
 			ldmsd_cfg_unlock(LDMSD_CFGOBJ_STRGP);
 			goto out;
 		}
+                __dlog(DLOG_CFGOK, "strgp_start name=%s # delayed \n",
+                        obj->name);
 	}
 	ldmsd_cfg_unlock(LDMSD_CFGOBJ_STRGP);
 

--- a/ldms/src/ldmsd/ldmsd_failover.c
+++ b/ldms/src/ldmsd/ldmsd_failover.c
@@ -73,24 +73,10 @@
 
 #define ARRAY_LEN(x) (sizeof(x)/sizeof(*(x)))
 
-/* So that we can change this in gdb */
-static int failover_debug = 0;
+/* Use -L 8 or set ldmsd_req_debug |= 8 to enable failover messages */
+/* static int failover_debug; */
 
 #define __ASSERT(x) assert(x)
-
-void __ldmsd_log(enum ldmsd_loglevel level, const char *fmt, va_list ap);
-
-__attribute__((format(printf, 1, 2)))
-static inline
-void __dlog(const char *fmt, ...)
-{
-	if (!failover_debug)
-		return;
-	va_list ap;
-	va_start(ap, fmt);
-	__ldmsd_log(LDMSD_LALL, fmt, ap);
-	va_end(ap);
-}
 
 /*
  * active-side tasks:
@@ -802,7 +788,7 @@ int __failover_send_reset(ldmsd_failover_t f, ldms_t xprt)
 	ldmsd_req_cmd_t rcmd = NULL;
 
 	if (__F_GET(f, __FAILOVER_OUTSTANDING_UNPAIR)) {
-		__dlog("(DEBUG) ERROR: Outstanding unpair.\n");
+		__dlog(DLOG_FOVER,"(DEBUG) ERROR: Outstanding unpair.\n");
 		rc = EINPROGRESS;
 		goto out;
 	}
@@ -1019,7 +1005,7 @@ void __failover_xprt_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 	ldmsd_failover_t f = cb_arg;
 	switch (e->type) {
 	case LDMS_XPRT_EVENT_CONNECTED:
-		__dlog("Failover: xprt connected\n");
+		__dlog(DLOG_FOVER,"Failover: xprt connected\n");
 		ldms_xprt_priority_set(f->ax, 1);
 		__failover_lock(f);
 		/* so that retry operations can follow up not too slow */
@@ -1030,7 +1016,7 @@ void __failover_xprt_cb(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 		__failover_unlock(f);
 		break;
 	case LDMS_XPRT_EVENT_DISCONNECTED:
-		__dlog("Failover: xprt disconnected\n");
+		__dlog(DLOG_FOVER,"Failover: xprt disconnected\n");
 	case LDMS_XPRT_EVENT_ERROR:
 	case LDMS_XPRT_EVENT_REJECTED:
 		__failover_lock(f);
@@ -1068,7 +1054,7 @@ int __failover_active_connect(ldmsd_failover_t f)
 {
 	/* f->lock is held */
 	int rc = 0;
-	__dlog("Failover: connecting, flags: %#lx\n", f->flags);
+	__dlog(DLOG_FOVER,"Failover: connecting, flags: %#lx\n", f->flags);
 	__ASSERT(f->ax == NULL);
 	__ASSERT(f->conn_state == FAILOVER_CONN_STATE_DISCONNECTED);
 	f->ax = ldms_xprt_new_with_auth(f->xprt, ldmsd_linfo,
@@ -1088,7 +1074,7 @@ err1:
 	f->ax = NULL;
 	f->conn_state = FAILOVER_CONN_STATE_DISCONNECTED;
 out:
-	__dlog("Failover: __failover_active_connect() rc: %d, flags: %#lx\n",
+	__dlog(DLOG_FOVER,"Failover: __failover_active_connect() rc: %d, flags: %#lx\n",
 	       rc, f->flags);
 	return rc;
 }
@@ -1098,11 +1084,11 @@ static
 void __ping_stat_dlog(ldmsd_failover_t f)
 {
 	/* f->lock is held */
-	__dlog("Failover stat: number of pings: %d\n", f->ping_n);
-	__dlog("Failover stat: ping MAX: %ld\n", f->ping_max);
-	__dlog("Failover stat: ping AVG: %ld\n", f->ping_avg);
-	__dlog("Failover stat: ping SSE: %lf\n", f->ping_sse);
-	__dlog("Failover stat: ping SD: %lf\n", f->ping_sd);
+	__dlog(DLOG_FOVER,"Failover stat: number of pings: %d\n", f->ping_n);
+	__dlog(DLOG_FOVER,"Failover stat: ping MAX: %ld\n", f->ping_max);
+	__dlog(DLOG_FOVER,"Failover stat: ping AVG: %ld\n", f->ping_avg);
+	__dlog(DLOG_FOVER,"Failover stat: ping SSE: %lf\n", f->ping_sse);
+	__dlog(DLOG_FOVER,"Failover stat: ping SD: %lf\n", f->ping_sd);
 }
 
 struct failover_ping_data {
@@ -1139,7 +1125,7 @@ int __on_ping_resp(ldmsd_req_cmd_t rcmd)
 	int i;
 	__failover_lock(f);
 
-	__dlog("Failover: PING resp recv\n");
+	__dlog(DLOG_FOVER,"Failover: PING resp recv\n");
 
 	/* Update ping statistics */
 	gettimeofday(&f->echo_ts, NULL);
@@ -1202,12 +1188,12 @@ int __on_ping_resp(ldmsd_req_cmd_t rcmd)
 	/* pick the larger of the two */
 	dur = (dur > dur2)?(dur):(dur2);
 
-	__dlog("Failover: timeout (duration): %lu\n", dur);
+	__dlog(DLOG_FOVER,"Failover: timeout (duration): %lu\n", dur);
 
 	tv.tv_sec = dur / 1000000;
 	tv.tv_usec = dur % 1000000;
 	timeradd(&f->echo_ts, &tv, &f->timeout_ts);
-	__dlog("Failover: timeout (timestamp): %lu.%06lu\n",
+	__dlog(DLOG_FOVER,"Failover: timeout (timestamp): %lu.%06lu\n",
 		f->timeout_ts.tv_sec, f->timeout_ts.tv_usec);
 
 out:
@@ -1228,7 +1214,7 @@ void __failover_ping(ldmsd_failover_t f)
 	const char *name;
 	if (__F_GET(f, __FAILOVER_OUTSTANDING_PING)) {
 		f->ping_skipped++;
-		__dlog("Failover: OUTSTANDING_PING ... will not ping\n");
+		__dlog(DLOG_FOVER,"Failover: OUTSTANDING_PING ... will not ping\n");
 		return;
 	}
 	rcmd = ldmsd_req_cmd_new(f->ax, LDMSD_FAILOVER_PING_REQ,
@@ -1559,7 +1545,7 @@ int __peercfg_start(ldmsd_failover_t f)
 
 	if (is_activated)
 		__F_ON(f, __FAILOVER_PEERCFG_ACTIVATED);
-	__dlog("Failover: __peercfg_start(), flags: %#lx, rc: %d\n",
+	__dlog(DLOG_FOVER,"Failover: __peercfg_start(), flags: %#lx, rc: %d\n",
 	       f->flags, rc);
 	return 0;
 }
@@ -2385,7 +2371,7 @@ int failover_ping_handler(ldmsd_req_ctxt_t req)
 		errstr = "peer name unmatched";
 		goto err;
 	}
-	__dlog("Failover: PING received, our flags: %#lx\n", f->flags);
+	__dlog(DLOG_FOVER,"Failover: PING received, our flags: %#lx\n", f->flags);
 	data.state = f->state;
 	data.conn_state = f->conn_state;
 	data.flags = f->flags;

--- a/ldms/src/ldmsd/ldmsd_prdcr.c
+++ b/ldms/src/ldmsd/ldmsd_prdcr.c
@@ -926,6 +926,7 @@ int __ldmsd_prdcr_start(ldmsd_prdcr_t prdcr, ldmsd_sec_ctxt_t ctxt)
 	ldmsd_task_start(&prdcr->task, prdcr_task_cb, prdcr,
 			 LDMSD_TASK_F_IMMEDIATE,
 			 prdcr->conn_intrvl_us, 0);
+	ldmsd_log(LDMSD_LINFO, "Starting producer %s\n", prdcr->obj.name);
 out:
 	ldmsd_prdcr_unlock(prdcr);
 	return rc;
@@ -962,6 +963,7 @@ int __ldmsd_prdcr_stop(ldmsd_prdcr_t prdcr, ldmsd_sec_ctxt_t ctxt)
 		rc = EBUSY;
 		goto out;
 	}
+	ldmsd_log(LDMSD_LINFO, "Stopping producer %s\n", prdcr->obj.name);
 	if (prdcr->type == LDMSD_PRDCR_TYPE_LOCAL)
 		prdcr_reset_sets(prdcr);
 	ldmsd_task_stop(&prdcr->task);

--- a/ldms/src/ldmsd/ldmsd_request.h
+++ b/ldms/src/ldmsd/ldmsd_request.h
@@ -55,7 +55,20 @@
 #ifndef LDMS_SRC_LDMSD_LDMSD_REQUEST_H_
 #define LDMS_SRC_LDMSD_LDMSD_REQUEST_H_
 
+/* bit fields for ldmsd_req_debug */
+#define DLOG_NONE   0x0 /* __dlog is a no-op */
+#define DLOG_DEBUG  0x1 /* write handler debug events to __dlog */
+#define DLOG_CFGOK  0x2 /* write successful config change events to __dlog */
+#define DLOG_QUERY  0x4 /* write status query commands to __dlog */
+#define DLOG_FOVER  0x8 /* write failover messages to __dlog */
+#define DLOG_DELTA  0x10 /* prefix time deltas */
+#define DLOG_EPOCH  0x20 /* prefix epoch timestamps */
+#define LRD_ALL \
+  (DLOG_DEBUG|DLOG_CFGOK|DLOG_QUERY|DLOG_FOVER|DLOG_EPOCH|DLOG_DELTA)
 extern int ldmsd_req_debug;
+extern FILE *ldmsd_req_debug_file;
+extern struct timeval ldmsd_req_last_time;
+extern __attribute__((format(printf, 2, 3))) void __dlog(int match, const char *fmt, ...);
 
 enum ldmsd_request {
 	LDMSD_EXAMPLE_REQ = 0x1,


### PR DESCRIPTION
This enables configure replay (independent of source) and dynamic selection of debugging for configuration and failover that is previously  gdb-only accessible.
man page update and test included.
From the log message:
```
    Regardless of message origin (file, controller, maestro),
    this enables us to dynamically specify the recording of config requests,
    failover processing, status query requests in raw or replayable formats.
    It allows absolute and delta time stamps to be recorded.
    It distinguishes delayed start instructions from the rest in replay format.
    It allows the __dlog messages to go to the default log or to a specific file.
    It consolidates __dlog from request and failover into a single function.
    The -L option can be used in file or command line, though like other cmdline options if
    given in file, it is promoted to the front of the file.
```