### PR TITLE
Not destroy deleting sets that a client has reference on it

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -142,11 +142,12 @@ ldms_t ldms_xprt_get(ldms_t x)
 	return x;
 }
 
-static int ldms_xprt_connected(struct ldms_xprt *x)
+int ldms_xprt_connected(struct ldms_xprt *x)
 {
 	assert(x && x->ref_count);
 	return (x->disconnected == 0 && x->zap_ep && zap_ep_connected(x->zap_ep));
 }
+
 LIST_HEAD(xprt_list, ldms_xprt) xprt_list;
 ldms_t ldms_xprt_first()
 {


### PR DESCRIPTION
When a set delete timeout has reached, delete_proc() does not destroy the set that one of its push or lookup peer is connected. This prevents the race between delete_proc() and the SET_DELETE reply from the client.