### PR TITLE
Double the number of job slots from the given value in slurm_sampler

### DIFF
--- a/ldms/src/sampler/slurm/slurm_sampler.c
+++ b/ldms/src/sampler/slurm/slurm_sampler.c
@@ -570,7 +570,7 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 
 	value = av_value(avl, "job_count");
 	if (value)
-		job_list_len = atoi(value);
+		job_list_len = atoi(value) * 2;
 	int i;
 	rc = ENOMEM;
 	for (i = 0; i < job_list_len; i++) {


### PR DESCRIPTION
The extra job slots are buffers of complete jobs, so aggregators will get updates on the job complete status before they get replaced by new jobs.