### PR TITLE
README.md badge click to test summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ldms-test/weekly-report/master/status.json)](https://github.com/ldms-test/weekly-report/blob/master/test-all.log)
+[![status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ldms-test/weekly-report/master/status.json)](https://github.com/ldms-test/weekly-report/blob/master/summary.md)
 
 # OVIS / LDMS
 


### PR DESCRIPTION
Instead of full test log, the README.md badge links to the test report summary in the test report repository (simple passed/failed by test cases). Each test case in the summary list will link to the log for the particular test case.