### PR TITLE
Test for NULL in ldms_record_metric_add()

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -4137,12 +4137,19 @@ int ldms_record_metric_add(ldms_record_t rec_def, const char *name,
 	mdef = calloc(1, sizeof(*mdef));
 	if (!mdef)
 		return -ENOMEM;
-	mdef->name = strdup(name);
-	if (!mdef->name)
-		goto err_1;
-	mdef->unit = strdup(unit);
-	if (!mdef->unit)
-		goto err_2;
+        if (name != NULL) {
+                mdef->name = strdup(name);
+                if (!mdef->name)
+                        goto err_1;
+        } else {
+                errno = EINVAL;
+                goto err_1;
+        }
+        if (unit != NULL) {
+                mdef->unit = strdup(unit);
+                if (!mdef->unit)
+                        goto err_2;
+        }
 	mdef->type = type;
 	mdef->count = count;
 

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -1360,8 +1360,8 @@ void ldms_record_delete(ldms_record_t rec_def);
  * Add a metric member into the record.
  *
  * \param rec_def   The handle returned by \c ldms_record_create().
- * \param name      The name of the metric.
- * \param unit      The unit of the metric.
+ * \param name      The name of the metric. (May not be NULL)
+ * \param unit      The unit of the metric. (May be NULL)
  * \param type      The type of the metric. Only support char, basic number
  *                  types and their arrays: LDMS_V_CHAR, LDMS_V_CHAR_ARRAY,
  *                  LDMS_V_U8, LDMS_V_S8, LDMS_V_U8_ARRAY, LDMS_V_S8_ARRAY,


### PR DESCRIPTION
The examples explicitly show the units parameter of ldms_record_metric_add() being NULL, but there are no tests for NULL, which allows for segfaults. We add tests before using the usage and name pointers.