### PR TITLE
Slingshot samplers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1023,6 +1023,7 @@ ldms/src/sampler/ibm_occ/Makefile
 ldms/src/sampler/syspapi/Makefile
 ldms/src/sampler/app_sampler/Makefile
 ldms/src/sampler/slingshot_metrics/Makefile
+ldms/src/sampler/slingshot_info/Makefile
 ldms/src/contrib/sampler/Makefile
 ldms/src/contrib/sampler/daos/Makefile
 ldms/src/contrib/sampler/daos/test/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -849,6 +849,22 @@ AM_CONDITIONAL([HAVE_DCGM], [test x$have_dcgm = xtrue])
 
 AM_CONDITIONAL([SYSCONFDIR_NOT_ETC], [test "${sysconfdir}" != "/etc"])
 
+AC_LIB_HAVE_LINKFLAGS([cxi], [], [
+#include <stddef.h> /* libcxi.h fails to include this */
+#include <libcxi/libcxi.h>
+])
+AM_CONDITIONAL([HAVE_LIBCXI], [test "x$HAVE_LIBCXI" = xyes])
+
+AC_ARG_ENABLE([slingshot],
+    [AS_HELP_STRING([--enable-slingshot], [require the slinghost related plugins @<:@default=check@:>@])],
+    [],
+    [enable_slingshot="check"])
+AS_IF([test "x$enable_slingshot" = xyes],[
+    AS_IF([test "x$HAVE_LIBCXI" = xno],
+        [AC_MSG_ERROR([libcxi or its headers not found])])
+])
+AM_CONDITIONAL([ENABLE_SLINGSHOT], [test "xenable_slingshot" != xno])
+
 # define substitutions for configvars and other sed-generated files.
 # note carefully the escapes.
 OVIS_DO_SUBST([LDMS_SUBST_RULE], ["sed \
@@ -1006,6 +1022,7 @@ ldms/src/sampler/examples/record_sampler/Makefile
 ldms/src/sampler/ibm_occ/Makefile
 ldms/src/sampler/syspapi/Makefile
 ldms/src/sampler/app_sampler/Makefile
+ldms/src/sampler/slingshot_metrics/Makefile
 ldms/src/contrib/sampler/Makefile
 ldms/src/contrib/sampler/daos/Makefile
 ldms/src/contrib/sampler/daos/test/Makefile

--- a/ldms/src/sampler/Makefile.am
+++ b/ldms/src/sampler/Makefile.am
@@ -315,3 +315,9 @@ endif
 if ENABLE_BLOB_STREAM
 SUBDIRS += blob_stream
 endif
+
+if ENABLE_SLINGSHOT
+if HAVE_LIBCXI
+SUBDIRS += slingshot_metrics
+endif
+endif

--- a/ldms/src/sampler/Makefile.am
+++ b/ldms/src/sampler/Makefile.am
@@ -319,5 +319,6 @@ endif
 if ENABLE_SLINGSHOT
 if HAVE_LIBCXI
 SUBDIRS += slingshot_metrics
+SUBDIRS += slingshot_info
 endif
 endif

--- a/ldms/src/sampler/slingshot_info/Makefile.am
+++ b/ldms/src/sampler/slingshot_info/Makefile.am
@@ -1,0 +1,15 @@
+libslingshot_info_la_SOURCES = \
+        slingshot_info.c
+libslingshot_info_la_LIBADD = \
+	$(top_builddir)/ldms/src/core/libldms.la \
+	$(top_builddir)/lib/src/coll/libcoll.la \
+        $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+	$(LTLIBCXI)
+libslingshot_info_la_LDFLAGS = \
+	-no-undefined \
+        -export-symbols-regex 'get_plugin'
+libslingshot_info_la_CPPFLAGS = @OVIS_INCLUDE_ABS@
+
+pkglib_LTLIBRARIES = libslingshot_info.la
+
+dist_man7_MANS = Plugin_slingshot_info.man

--- a/ldms/src/sampler/slingshot_info/Plugin_slingshot_info.man
+++ b/ldms/src/sampler/slingshot_info/Plugin_slingshot_info.man
@@ -1,0 +1,53 @@
+.TH man 7 "1 May 2022" "LDMS Plugin" "Plugin for LDMS"
+
+.SH NAME
+Plugin_slingshot_info - man page for the LDMS slingshot_info plugin
+
+.SH SYNOPSIS
+Within ldmsd_controller or a configuration file:
+.br
+config name=slingshot_info [ <attr> = <value> ]
+
+.SH DESCRIPTION
+With LDMS (Lightweight Distributed Metric Service), plugins for the ldmsd (ldms
+aemon) are configured via ldmsd_controller or a configuration file. The
+slingshot_info plugin provides a single metric set that contains a list of
+records. Each record contains all of the informational fields for a single
+slingshot NIC.
+
+The slingshot_info sampler plugin provides a fairly small set of general information
+about each slingshot NIC, including FRU description, serial number, etc. Likely
+users will want to sample this plugin relatively infrequently. For detailed
+slingshot NIC counter data, see the slingshot_metrics sampler plugin.
+
+The schema is named "slingshot_info" by default.
+
+.SH CONFIGURATION ATTRIBUTE SYNTAX
+The slingshot_info plugin uses the sampler_base base class. This man page covers
+only the configuration attributes, or those with default values, specific to the
+this plugin; see ldms_sampler_base.man for the attributes of the base class.
+
+.TP
+.BR config
+name=<plugin_name> [counters=<COUNTER NAMES>] [counters_file=<path to counters file>]
+.br
+configuration line
+.RS
+.TP
+name=<plugin_name>
+.br
+This MUST be slingshot_info.
+.RE
+
+.SH EXAMPLES
+.PP
+Within ldmsd_conteroller or a configuration file:
+.nf
+load name=slingshot_info
+config name=slingshot_info producer=host1 instance=host1/slingshot_info
+start name=slingshot_info interval=1000000 offset=0
+.fi
+
+.SH SEE ALSO
+ldmsd(8), ldms_quickstart(7), ldmsd_controller(8), ldms_sampler_base(7),
+Plugin_slingshot_metrics(7)

--- a/ldms/src/sampler/slingshot_info/slingshot_info.c
+++ b/ldms/src/sampler/slingshot_info/slingshot_info.c
@@ -1,0 +1,422 @@
+/* -*- c-basic-offset: 8 -*- */
+/* Copyright 2022 Lawrence Livermore National Security, LLC
+ * See the top-level COPYING file for details.
+ *
+ * SPDX-License-Identifier: (GPL-2.0 OR BSD-3-Clause)
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <glob.h>
+#include "ldms.h"
+#include "ldmsd.h"
+#include "config.h"
+#include "sampler_base.h"
+
+#include <stddef.h> /* libcxi.h neglects to include this */
+#include <libcxi/libcxi.h>
+
+#define SAMP "slingshot_info"
+#define MAX_LINE_LEN 256
+
+#ifndef ARRAY_LEN
+#define ARRAY_LEN(a) (sizeof(a) / sizeof(*a))
+#endif
+
+#ifndef IFNAMSIZ
+/* from "linux/if.h" */
+#define IFNAMSIZ 16
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 1024
+#endif
+
+#define DEFAULT_ARRAY_LEN 32
+
+static ldmsd_msg_log_f log_fn;
+static base_data_t sampler_base;
+static ldms_record_t rec_def; /* a pointer */
+
+static struct {
+        int nic_record;
+        int nic_list;
+} index_store;
+
+struct ldms_metric_template_s rec_metrics[] = {
+	{ "name"             , 0,    LDMS_V_CHAR_ARRAY , ""        , CXIL_DEVNAME_MAX+1 } ,
+	{ "interface"        , 0,    LDMS_V_CHAR_ARRAY , ""        , IFNAMSIZ } ,
+	{ "fru_description"  , 0,    LDMS_V_CHAR_ARRAY , ""        , CXIL_FRUDESC_MAX+1 } ,
+	{ "part_number"      , 0,    LDMS_V_CHAR_ARRAY , ""        , DEFAULT_ARRAY_LEN } ,
+	{ "serial_number"    , 0,    LDMS_V_CHAR_ARRAY , ""        , DEFAULT_ARRAY_LEN } ,
+	{ "firmware_version" , 0,    LDMS_V_CHAR_ARRAY , ""        , DEFAULT_ARRAY_LEN } ,
+	{ "mac"              , 0,    LDMS_V_CHAR_ARRAY , ""        , DEFAULT_ARRAY_LEN } ,
+	{ "nid"              , 0,    LDMS_V_U32        , ""        , 1  } ,
+	{ "pid_granule"      , 0,    LDMS_V_U32        , ""        , 1  } ,
+	{ "pcie_speed"       , 0,    LDMS_V_CHAR_ARRAY , ""        , DEFAULT_ARRAY_LEN } ,
+	{ "pcie_slot"        , 0,    LDMS_V_CHAR_ARRAY , ""        , DEFAULT_ARRAY_LEN } ,
+	{ "link_layer_retry" , 0,    LDMS_V_CHAR_ARRAY , ""        , DEFAULT_ARRAY_LEN } ,
+	{ "link_loopback"    , 0,    LDMS_V_CHAR_ARRAY , ""        , DEFAULT_ARRAY_LEN } ,
+	{ "link_media"       , 0,    LDMS_V_CHAR_ARRAY , ""        , DEFAULT_ARRAY_LEN } ,
+	{ "link_mtu"         , 0,    LDMS_V_U32        , ""        , 1  } ,
+	{ "link_speed"       , 0,    LDMS_V_CHAR_ARRAY , ""        , DEFAULT_ARRAY_LEN } ,
+	{ "link_state"       , 0,    LDMS_V_CHAR_ARRAY , ""        , DEFAULT_ARRAY_LEN } ,
+	{0},
+};
+#define REC_METRICS_LEN (ARRAY_LEN(rec_metrics) - 1)
+int rec_metric_ids[REC_METRICS_LEN];
+size_t rec_heap_sz;
+
+static int initialize_ldms_structs()
+{
+        int rc;
+
+        log_fn(LDMSD_LDEBUG, SAMP" initialize()\n");
+
+        /* Create the per-nic record definition */
+        rec_def = ldms_record_from_template("slingshot", rec_metrics, rec_metric_ids);
+        rec_heap_sz = ldms_record_heap_size_get(rec_def);
+
+        /* Create the schema */
+        base_schema_new(sampler_base);
+        if (sampler_base->schema == NULL)
+                goto err2;
+        rc = ldms_schema_record_add(sampler_base->schema, rec_def);
+        if (rc < 0)
+                goto err3;
+        index_store.nic_record = rc;
+        rc = ldms_schema_metric_list_add(sampler_base->schema, "nics", NULL, 1024);
+        if (rc < 0) {
+                goto err3;
+        }
+        index_store.nic_list = rc;
+
+        /* Create the metric set */
+        base_set_new(sampler_base);
+        if (sampler_base->set == NULL)
+                goto err3;
+
+        return 0;
+err3:
+        base_del(sampler_base);
+err2:
+        ldms_record_delete(rec_def);
+err1:
+        log_fn(LDMSD_LERROR, SAMP" initialization failed\n");
+        return -1;
+}
+
+static int config(struct ldmsd_plugin *self,
+                  struct attr_value_list *kwl, struct attr_value_list *avl)
+{
+        int rc = 0;
+        char *value;
+
+        log_fn(LDMSD_LDEBUG, SAMP" config() called\n");
+
+        sampler_base = base_config(avl, SAMP, "slingshot_metrics", log_fn);
+
+        rc = initialize_ldms_structs();
+
+        return rc;
+}
+
+static void resize_metric_set(int expected_remaining_nics)
+{
+        size_t previous_heap_size;
+        size_t new_heap_size;
+
+        previous_heap_size = ldms_set_heap_size_get(sampler_base->set);
+        base_set_delete(sampler_base);
+
+        new_heap_size = previous_heap_size;
+        new_heap_size += ldms_record_heap_size_get(rec_def) * expected_remaining_nics;
+        new_heap_size += ldms_list_heap_size_get(LDMS_V_RECORD_ARRAY, expected_remaining_nics, 1);
+
+        base_set_new_heap(sampler_base, new_heap_size);
+        if (sampler_base->set == NULL) {
+                ldmsd_log(LDMSD_LERROR,
+                          SAMP" : Failed to resize metric set heap: %d\n", errno);
+        }
+}
+
+/* strip leading and trailing whitespace */
+static void strip_whitespace(char **start)
+{
+        /* strip leading whitespace */
+        while (isspace(**start)) {
+                (*start)++;
+        }
+
+        /* strip trailing whitespace */
+        char * last;
+        last = *start + strlen(*start) - 1;
+        while (last > *start) {
+                if (isspace(last[0])) {
+                        last--;
+                } else {
+                        break;
+                }
+        }
+        last[1] = '\0';
+}
+
+
+static void set_pcie_speed(ldms_mval_t record_instance, int index, const char *device_name)
+{
+        char path[PATH_MAX];
+        char buf1[PATH_MAX];
+        char buf2[PATH_MAX];
+        char *speed = buf1;
+        char *width = buf2;
+        FILE *fp;
+        char *rc;
+
+        snprintf(path, PATH_MAX, "/sys/class/cxi/%s/device/current_link_speed",
+                 device_name);
+        fp = fopen(path, "r");
+        if (fp == NULL) {
+                log_fn(LDMSD_LWARNING, SAMP" unable to open \"%s\"\n", path);
+                return;
+        }
+        rc = fgets(speed, PATH_MAX, fp);
+        fclose(fp);
+        if (rc == NULL) {
+                return;
+        }
+        strip_whitespace(&speed);
+
+        snprintf(path, PATH_MAX, "/sys/class/cxi/%s/device/current_link_width",
+                 device_name);
+        fp = fopen(path, "r");
+        if (fp == NULL) {
+                log_fn(LDMSD_LWARNING, SAMP" unable to open \"%s\"\n", path);
+                return;
+        }
+        rc = fgets(width, PATH_MAX, fp);
+        fclose(fp);
+        if (rc == NULL) {
+                return;
+        }
+        strip_whitespace(&width);
+
+        snprintf(path, PATH_MAX, "%s x%s", speed, width);
+        ldms_record_array_set_str(record_instance, index, path);
+}
+
+static void set_pcie_slot(ldms_mval_t record_instance, int index,
+                          struct cxil_devinfo *dev_info)
+{
+        char buf[DEFAULT_ARRAY_LEN];
+
+        snprintf(buf, sizeof(buf), "%.4x:%.2x:%.2x:%x",
+                 dev_info->pci_domain,
+                 dev_info->pci_bus,
+                 dev_info->pci_device,
+                 dev_info->pci_function);
+
+        ldms_record_array_set_str(record_instance, index, buf);
+}
+
+
+static void set_metric_from_sys(ldms_mval_t record_instance, int index,
+                                const char *device_name, const char *subpath)
+{
+        char path[PATH_MAX];
+        char buf[PATH_MAX];
+        char *value = buf;
+        FILE *fp;
+        char *rc;
+
+        snprintf(path, PATH_MAX, "/sys/class/cxi/%s/%s", device_name, subpath);
+        fp = fopen(path, "r");
+        if (fp == NULL) {
+                log_fn(LDMSD_LWARNING, SAMP" unable to open \"%s\"\n", path);
+                return;
+        }
+        rc = fgets(value, PATH_MAX, fp);
+        fclose(fp);
+        if (rc == NULL) {
+                return;
+        }
+        strip_whitespace(&value);
+        ldms_record_array_set_str(record_instance, index, value);
+}
+
+static void get_interface_name(const char *device_name, char *interface, int len)
+{
+        glob_t globbuf;
+        char pattern[PATH_MAX];
+        char *ptr;
+        char *tmp;
+        int rc;
+
+        snprintf(pattern, PATH_MAX,
+                 "/sys/class/net/*/device/cxi/%s", device_name);
+        glob(pattern, GLOB_NOSORT, NULL, &globbuf);
+        if (rc != 0) {
+                return;
+        }
+        ptr = globbuf.gl_pathv[0];
+        ptr += strlen("/sys/class/net/");
+        for (tmp = ptr; *tmp != '/' && *tmp != '\0'; tmp++) {
+        }
+        *tmp = '\0';
+        strncpy(interface, ptr, len);
+        globfree(&globbuf);
+}
+
+static void get_mac_address(const char *interface, char *mac_address, int len)
+{
+        char path[PATH_MAX];
+        char buf[PATH_MAX];
+        char *value = buf;
+        FILE *fp;
+        char *rc;
+
+        snprintf(path, PATH_MAX, "/sys/class/net/%s/address", interface);
+        fp = fopen(path, "r");
+        if (fp == NULL) {
+                log_fn(LDMSD_LWARNING, SAMP" unable to open \"%s\"\n", path);
+                return;
+        }
+        rc = fgets(value, PATH_MAX, fp);
+        fclose(fp);
+        if (rc == NULL) {
+                return;
+        }
+        strip_whitespace(&value);
+        strncpy(mac_address, value, len);
+}
+
+static int sample(struct ldmsd_sampler *self)
+{
+        struct cxil_device_list *device_list;
+        ldms_mval_t list_handle;
+        int i;
+        int j;
+        int rc = 0;
+
+        base_sample_begin(sampler_base);
+        rc = cxil_get_device_list(&device_list);
+        if (rc != 0) {
+                log_fn(LDMSD_LERROR, SAMP" sample(): cxil_get_device_list() failed: %d\n", rc);
+                base_sample_end(sampler_base);
+        }
+        log_fn(LDMSD_LDEBUG, SAMP" sample(): # slingshot nics: %u\n", device_list->count);
+
+        list_handle = ldms_metric_get(sampler_base->set, index_store.nic_list);
+        ldms_list_purge(sampler_base->set, list_handle);
+        for (i = 0; i < device_list->count; i++) {
+                struct cxil_devinfo *dev_info = &device_list->info[i];
+                ldms_mval_t record_instance;
+                char interface[IFNAMSIZ];
+                char mac_address[DEFAULT_ARRAY_LEN];
+
+                interface[0] = '\0';
+                record_instance = ldms_record_alloc(sampler_base->set,
+                                                    index_store.nic_record);
+                if (record_instance == NULL) {
+                        log_fn(LDMSD_LDEBUG, SAMP": ldms_record_alloc() failed, resizing metric set\n");
+                        resize_metric_set(device_list->count - i);
+                        break;
+                }
+                rc = ldms_list_append_record(sampler_base->set, list_handle,
+                                             record_instance);
+
+                /* name 0 */
+                ldms_record_array_set_str(record_instance, rec_metric_ids[0],
+                                          dev_info->device_name);
+                /* interface 1 */
+                get_interface_name(dev_info->device_name, interface, sizeof(interface));
+                ldms_record_array_set_str(record_instance, rec_metric_ids[1],
+                                          interface);
+                /* fru_description 2 */
+                ldms_record_array_set_str(record_instance, rec_metric_ids[2],
+                                          dev_info->fru_description);
+                /* part_number 3 */
+                set_metric_from_sys(record_instance, rec_metric_ids[3],
+                                    dev_info->device_name, "device/fru/part_number");
+                /* serial_number 4 */
+                set_metric_from_sys(record_instance, rec_metric_ids[4],
+                                    dev_info->device_name, "device/fru/serial_number");
+                /* firmware_version 5 */
+                set_metric_from_sys(record_instance, rec_metric_ids[5],
+                                    dev_info->device_name, "device/uc/qspi_blob_version");
+                /* mac 6 */
+                get_mac_address(interface, mac_address, sizeof(mac_address));
+                ldms_record_array_set_str(record_instance, rec_metric_ids[6],
+                                          mac_address);
+                /* nid 7 */
+                ldms_record_set_u32(record_instance, rec_metric_ids[7], dev_info->nid);
+                /* pid_granule 8 */
+                ldms_record_set_u32(record_instance, rec_metric_ids[8], dev_info->pid_granule);
+                /* pcie_speed 9 */
+                set_pcie_speed(record_instance, rec_metric_ids[9], dev_info->device_name);
+                /* pcie_slot 10 */
+                set_pcie_slot(record_instance, rec_metric_ids[10], dev_info);
+                /* link_layer_retry 11 */
+                set_metric_from_sys(record_instance, rec_metric_ids[11],
+                                    dev_info->device_name, "device/port/link_layer_retry");
+                /* link_loopback 12 */
+                set_metric_from_sys(record_instance, rec_metric_ids[12],
+                                    dev_info->device_name, "device/port/loopback");
+                /* link_media 13 */
+                set_metric_from_sys(record_instance, rec_metric_ids[13],
+                                    dev_info->device_name, "device/port/media");
+                /* link_mtu 14 */
+                ldms_record_set_u32(record_instance, rec_metric_ids[14], dev_info->link_mtu);
+                /* link_speed 15 */
+                set_metric_from_sys(record_instance, rec_metric_ids[15],
+                                    dev_info->device_name, "device/port/speed");
+                /* link_state 16 */
+                set_metric_from_sys(record_instance, rec_metric_ids[16],
+                                    dev_info->device_name, "device/port/link");
+        }
+        base_sample_end(sampler_base);
+
+        cxil_free_device_list(device_list);
+
+        return rc;
+}
+
+static void term(struct ldmsd_plugin *self)
+{
+        log_fn(LDMSD_LDEBUG, SAMP" term() called\n");
+}
+
+static ldms_set_t get_set(struct ldmsd_sampler *self)
+{
+	return NULL;
+}
+
+static const char *usage(struct ldmsd_plugin *self)
+{
+        log_fn(LDMSD_LDEBUG, SAMP" usage() called\n");
+	return  "config name=" SAMP " " BASE_CONFIG_SYNOPSIS
+                BASE_CONFIG_DESC
+                ;
+}
+
+struct ldmsd_plugin *get_plugin(ldmsd_msg_log_f pf)
+{
+        static struct ldmsd_sampler plugin = {
+                .base = {
+                        .name = SAMP,
+                        .type = LDMSD_PLUGIN_SAMPLER,
+                        .term = term,
+                        .config = config,
+                        .usage = usage,
+                },
+                .get_set = get_set,
+                .sample = sample,
+        };
+
+        log_fn = pf;
+        log_fn(LDMSD_LDEBUG, SAMP" get_plugin() called ("PACKAGE_STRING")\n");
+
+        return &plugin.base;
+}

--- a/ldms/src/sampler/slingshot_metrics/Makefile.am
+++ b/ldms/src/sampler/slingshot_metrics/Makefile.am
@@ -1,0 +1,15 @@
+libslingshot_metrics_la_SOURCES = \
+        slingshot_metrics.c
+libslingshot_metrics_la_LIBADD = \
+	$(top_builddir)/ldms/src/core/libldms.la \
+	$(top_builddir)/lib/src/coll/libcoll.la \
+        $(top_builddir)/ldms/src/sampler/libsampler_base.la \
+	$(LTLIBCXI)
+libslingshot_metrics_la_LDFLAGS = \
+	-no-undefined \
+        -export-symbols-regex 'get_plugin'
+libslingshot_metrics_la_CPPFLAGS = @OVIS_INCLUDE_ABS@
+
+pkglib_LTLIBRARIES = libslingshot_metrics.la
+
+dist_man7_MANS = Plugin_slingshot_metrics.man

--- a/ldms/src/sampler/slingshot_metrics/Plugin_slingshot_metrics.man
+++ b/ldms/src/sampler/slingshot_metrics/Plugin_slingshot_metrics.man
@@ -1,0 +1,82 @@
+.TH man 7 "1 May 2022" "LDMS Plugin" "Plugin for LDMS"
+
+.SH NAME
+Plugin_slingshot_metrics - man page for the LDMS slingshot_metrics plugin
+
+.SH SYNOPSIS
+Within ldmsd_controller or a configuration file:
+.br
+config name=slingshot_metrics [ <attr> = <value> ]
+
+.SH DESCRIPTION
+With LDMS (Lightweight Distributed Metric Service), plugins for the ldmsd (ldms
+aemon) are configured via ldmsd_controller or a configuration file. The
+slingshot_metrics plugin provides a single metric set that contains a list of
+records. Each record contains all of the metrics for a single slingshot NIC.
+
+The slingshot_metrics sampler plugin provides detailed counter metrics for
+each slignshot NIC.
+
+The schema is named "slingshot_metrics" by default.
+
+.SH CONFIGURATION ATTRIBUTE SYNTAX
+The slingshot_metrics plugin uses the sampler_base base class. This man page covers
+only the configuration attributes, or those with default values, specific to the
+this plugin; see ldms_sampler_base.man for the attributes of the base class.
+
+.TP
+.BR config
+name=<plugin_name> [counters=<COUNTER NAMES>] [counters_file=<path to counters file>]
+.br
+configuration line
+.RS
+.TP
+name=<plugin_name>
+.br
+This MUST be slingshot_metrics.
+.TP
+counters=<COUNTER NAMES>
+.br
+(Optional) A CSV list of names of slingshot counter names. See Section
+COUTNER NAMES for details. If neither this option nor counters_file are
+specified, a default set of counters will be used.
+.TP
+counters_files=<path to counters file>
+.br
+(Optional) A path to a file that contains a list of counter names, one
+per line. See Section COUNTER NAMES for details. A line will be consider
+a comment if the character on the line is a "#". If neither this option
+nor counters are specified, a default set of counters will be used.
+.TP
+refresh_interval_sec=<seconds>
+.br
+(Optional) The sampler caches the list of slinghost devices, and that
+cache is refreshed at the beginning of a sample cycle if the refresh
+interval time has been exceeded. refresh_interval_sec sets
+the minimum number of seconds between refreshes of the device cache.
+The default refresh interval is 600 seconds.
+.RE
+
+.SH COUNTER NAMES
+The names of the counters can be found in the slingshot/cassini header
+file cassini_cntr_def.h in the array c1_cntr_defs (specifically the strings
+in the "name" field of said array entries).
+
+In addition to the individual counter names, this plugin allows specifying
+entire groups of counters by using the counter name pattern "group:<group name>",
+for insance, "group:hni". The available groups are: ext, pi_ipd, mb, cq, lpe,
+hni, ext2. These groups correspond with the enum c_cntr_group in the
+cassini_cntr_def.h file. Additionally, one may use "group:all", which
+simply includes all available counters.
+
+.SH EXAMPLES
+.PP
+Within ldmsd_conteroller or a configuration file:
+.nf
+load name=slingshot_metrics
+config name=slingshot_metrics producer=host1 instance=host1/slingshot_metrics counters=ixe_rx_tcp_pkt,group:hni refresh_interval_sec=3600
+start name=slingshot_metrics interval=1000000 offset=0
+.fi
+
+.SH SEE ALSO
+ldmsd(8), ldms_quickstart(7), ldmsd_controller(8), ldms_sampler_base(7)

--- a/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
+++ b/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
@@ -1,0 +1,641 @@
+/* -*- c-basic-offset: 8 -*- */
+/* Copyright 2022 Lawrence Livermore National Security, LLC
+ * See the top-level COPYING file for details.
+ *
+ * SPDX-License-Identifier: (GPL-2.0 OR BSD-3-Clause)
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <time.h>
+#include "ldms.h"
+#include "ldmsd.h"
+#include "config.h"
+#include "sampler_base.h"
+
+#include <stddef.h> /* libcxi.h neglects to include this */
+#include <libcxi/libcxi.h>
+#define _GNU_SOURCE
+
+#define SAMP "slingshot_metrics"
+#define MAX_LINE_LEN 256
+#define MAX_DEVICES 64
+
+static ldmsd_msg_log_f log_fn;
+static base_data_t sampler_base;
+static ldms_record_t nic_record; /* a pointer */
+
+static struct {
+        int name; /* name of the slingshot interface */
+        int nic_record;
+        int nic_list;
+} index_store;
+
+static struct {
+        int num_counters;
+        int ldms_index[C1_CNTR_COUNT];
+        enum c_cntr_type slingshot_index[C1_CNTR_COUNT];
+        uint64_t value[C1_CNTR_COUNT];
+} counters;
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(*a))
+#endif
+
+/* we will look up the counter names in the c1_cntr_descs array */
+static const char * const default_counter_names[] = {
+        "ixe_mem_cor_err_cntr",
+        "ixe_mem_ucor_err_cntr",
+        "ixe_port_dfa_mismatch",
+        "ixe_hdr_checksum_errors",
+        "ixe_ipv4_checksum_errors",
+        "ixe_hrp_req_errors",
+        "ixe_ip_options_errors",
+        "ixe_get_len_errors",
+        "ixe_roce_icrc_error",
+        "ixe_parser_par_errors",
+        "ixe_pbuf_rd_errors",
+        "ixe_hdr_ecc_errors",
+        "ixe_rx_udp_pkt",
+        "ixe_rx_tcp_pkt",
+        "ixe_rx_ipv4_pkt",
+        "ixe_rx_ipv6_pkt",
+        "ixe_rx_roce_pkt",
+        "ixe_rx_ptl_gen_pkt",
+        "ixe_rx_ptl_sml_pkt",
+        "ixe_rx_ptl_unrestricted_pkt",
+        "ixe_rx_ptl_smallmsg_pkt",
+        "ixe_rx_ptl_continuation_pkt",
+        "ixe_rx_ptl_restricted_pkt",
+        "ixe_rx_ptl_connmgmt_pkt",
+        "ixe_rx_ptl_response_pkt",
+        "ixe_rx_unrecognized_pkt",
+        "ixe_rx_ptl_sml_amo_pkt",
+        "ixe_rx_ptl_msgs",
+        "ixe_rx_ptl_multi_msgs",
+        "ixe_rx_ptl_mr_msgs",
+        "ixe_rx_pkt_drop_pct",
+        "ixe_rx_pkt_drop_rmu_norsp",
+        "ixe_rx_pkt_drop_rmu_wrsp",
+        "ixe_rx_pkt_drop_ixe_parser",
+        "ixe_rx_pkt_ipv4_options",
+        "ixe_rx_pkt_ipv6_options",
+        "ixe_rx_eth_seg",
+        "ixe_rx_roce_seg",
+        "ixe_rx_roce_spseg",
+};
+
+static struct cxil_device_list *cache_cxil_device_list;
+static time_t cache_cxil_device_list_refresh_interval;
+static struct cxil_dev *cache_cxil_dev[MAX_DEVICES];
+
+static int cache_cxil_dev_get(uint32_t dev_id, struct cxil_dev **dev)
+{
+        if (dev_id >= MAX_DEVICES) {
+                return -1;
+        }
+
+        if (cache_cxil_dev[dev_id] == NULL) {
+                int rc;
+
+                rc = cxil_open_device(dev_id, &cache_cxil_dev[dev_id]);
+                if (rc != 0) {
+                        *dev = NULL;
+                        return rc;
+                }
+        }
+
+        *dev = cache_cxil_dev[dev_id];
+
+        return 0;
+}
+
+static void cache_cxil_dev_close(struct cxil_dev *dev)
+{
+        int i;
+
+        for (i = 0; i < MAX_DEVICES; i++) {
+                if (cache_cxil_dev[i] == NULL) {
+                        continue;
+                } else if (cache_cxil_dev[i] == dev) {
+                        cxil_close_device(cache_cxil_dev[i]);
+                        cache_cxil_dev[i] = NULL;
+                        break;
+                }
+        }
+}
+
+static void cache_cxil_dev_close_all()
+{
+        int i;
+
+        for (i = 0; i < MAX_DEVICES; i++) {
+                if (cache_cxil_dev[i] == NULL) {
+                        continue;
+                }
+                cxil_close_device(cache_cxil_dev[i]);
+                cache_cxil_dev[i] = NULL;
+        }
+}
+
+static void cache_cxil_dev_refresh_all()
+{
+        int i;
+        int j;
+        bool missing;
+
+        for (i = 0; i < MAX_DEVICES; i++) {
+                missing = true;
+                for (j = 0; j < cache_cxil_device_list->count; j++) {
+                        if (i == cache_cxil_device_list->info[j].dev_id) {
+                                missing = false;
+                                break;
+                        }
+                }
+                if (missing && cache_cxil_dev[i] != NULL) {
+                        log_fn(LDMSD_LDEBUG, SAMP" refresh_all: removing dev_id %d\n", i);
+                        cxil_close_device(cache_cxil_dev[i]);
+                        cache_cxil_dev[i] = NULL;
+                } else if (!missing && cache_cxil_dev[i] == NULL) {
+                        log_fn(LDMSD_LDEBUG, SAMP" refresh_all: opening dev_id %d\n", i);
+                        cxil_open_device(i, &cache_cxil_dev[i]);
+                }
+        }
+}
+
+static int cache_cxil_device_list_get(struct cxil_device_list **dev_list)
+{
+        static time_t last_refresh = 0;
+        time_t current_time;
+        int rc = 0;
+
+        current_time = time(NULL);
+        if (current_time >= last_refresh + cache_cxil_device_list_refresh_interval) {
+                struct cxil_device_list *tmp_list;
+
+                log_fn(LDMSD_LDEBUG, SAMP" updating device list cache\n");
+                tmp_list = cache_cxil_device_list;
+                cache_cxil_device_list = NULL;
+                cxil_free_device_list(tmp_list);
+
+                rc = cxil_get_device_list(&tmp_list);
+                if (rc == 0) {
+                        cache_cxil_device_list = tmp_list;
+                        last_refresh = current_time;
+                }
+
+                cache_cxil_dev_refresh_all();
+        }
+
+        *dev_list = cache_cxil_device_list;
+        return rc;
+}
+
+static void cache_cxil_device_list_free()
+{
+        if (cache_cxil_device_list != NULL) {
+                struct cxil_device_list *tmp_list;
+
+                tmp_list = cache_cxil_device_list;
+                cache_cxil_device_list = NULL;
+                cxil_free_device_list(tmp_list);
+        }
+}
+
+static void initialize_ldms_record_metrics() {
+        int i;
+        int index;
+
+        for (i = 0; i < counters.num_counters; i++) {
+                int rc;
+                char const * const_name;
+
+                const_name = c1_cntr_descs[counters.slingshot_index[i]].name;
+                /* log_fn(LDMSD_LDEBUG, SAMP" counter name = %s\n", const_name); */
+                index = ldms_record_metric_add(nic_record, const_name, NULL,
+                                               LDMS_V_U64, 0);
+                counters.ldms_index[i] = index;
+        }
+}
+
+static int initialize_ldms_structs()
+{
+        int rc;
+
+        log_fn(LDMSD_LDEBUG, SAMP" initialize()\n");
+
+        /* Create the per-nic record definition */
+        nic_record = ldms_record_create("slingshot_nic");
+        if (nic_record == NULL)
+                goto err1;
+        rc = ldms_record_metric_add(nic_record, "name", NULL,
+                                    LDMS_V_CHAR_ARRAY, CXIL_DEVNAME_MAX+1);
+        if (rc < 0)
+                goto err2;
+        index_store.name = rc;
+        initialize_ldms_record_metrics();
+
+        /* Create the schema */
+        base_schema_new(sampler_base);
+        if (sampler_base->schema == NULL)
+                goto err2;
+        rc = ldms_schema_record_add(sampler_base->schema, nic_record);
+        if (rc < 0)
+                goto err3;
+        index_store.nic_record = rc;
+        rc = ldms_schema_metric_list_add(sampler_base->schema, "nics", NULL, 1024);
+        if (rc < 0) {
+                goto err3;
+        }
+        index_store.nic_list = rc;
+
+        /* Create the metric set */
+        base_set_new(sampler_base);
+        if (sampler_base->set == NULL)
+                goto err3;
+
+        return 0;
+err3:
+        base_del(sampler_base);
+err2:
+        ldms_record_delete(nic_record);
+err1:
+        log_fn(LDMSD_LERROR, SAMP" initialization failed\n");
+        return -1;
+}
+
+static int find_slingshot_index(const char counter_name[]) {
+        int i;
+
+        for (i = 0; i < C1_CNTR_SIZE; i++) {
+                if (c1_cntr_descs[i].name == NULL) {
+                        continue;
+                }
+                if (!strcmp(counter_name, c1_cntr_descs[i].name)) {
+                        return i;
+                }
+        }
+
+        return -1;
+}
+
+static int use_counter(const char * const counter_name);
+
+static int use_counter_group(const char * const counter_group)
+{
+        int i;
+        bool all_counters = false;
+        enum c_cntr_group group;
+        int rc;
+
+        if (!strcmp(counter_group, "all")) {
+                all_counters = true;
+        } else if (!strcmp(counter_group, "ext")) {
+                group = C_CNTR_GROUP_EXT;
+        } else if (!strcmp(counter_group, "pi_ipd")) {
+                group = C_CNTR_GROUP_PI_IPD;
+        } else if (!strcmp(counter_group, "mb")) {
+                group = C_CNTR_GROUP_MB;
+        } else if (!strcmp(counter_group, "cq")) {
+                group = C_CNTR_GROUP_CQ;
+        } else if (!strcmp(counter_group, "lpe")) {
+                group = C_CNTR_GROUP_LPE;
+        } else if (!strcmp(counter_group, "hni")) {
+                group = C_CNTR_GROUP_HNI;
+        } else if (!strcmp(counter_group, "ext2")) {
+                group = C_CNTR_GROUP_EXT2;
+        } else {
+                log_fn(LDMSD_LERROR, SAMP" unrecognized counter group \"%s\"\n",
+                       counter_group);
+                return -1;
+        }
+
+        for (int i = 0; i < C1_CNTR_SIZE; i++) {
+                if (c1_cntr_descs[i].name == NULL) {
+                        /* there are holes in the slingshot counters array
+                           due to grouping, and leaving space for future new
+                           counters */
+                        continue;
+                } else if (all_counters || c1_cntr_descs[i].group == group) {
+                        rc = use_counter(c1_cntr_descs[i].name);
+                        if (rc != 0) {
+                                return rc;
+                        }
+                }
+        }
+        return 0;
+}
+
+static int use_counter(const char * const counter_name)
+{
+        int counter_num;
+        int slingshot_index;
+        int i;
+        const char * const group_prefix = "group:";
+
+        if (!strncmp(counter_name, group_prefix, strlen(group_prefix))) {
+                return use_counter_group(counter_name+strlen(group_prefix));
+        }
+
+        slingshot_index = find_slingshot_index(counter_name);
+        if (slingshot_index == -1) {
+                log_fn(LDMSD_LERROR, SAMP" counter not found \"%s\"\n",
+                       counter_name);
+                return -1;
+        }
+
+        /* check to for duplicate */
+        for (int i; i < counters.num_counters; i++) {
+                if (counters.slingshot_index[i] == slingshot_index) {
+                        /* just a warning, not fatal */
+                        log_fn(LDMSD_LWARNING, SAMP" skipping duplicate counter \"%s\"\n",
+                               counter_name);
+                        return 0;
+                }
+        }
+
+        /* record the slingshot counter index for this counter name */
+        counter_num = counters.num_counters;
+        counters.slingshot_index[counter_num] = slingshot_index;
+        counters.num_counters = counter_num + 1;
+
+        return 0;
+}
+
+static int parse_counters_string(const char * const counters_string)
+{
+        char *working_string;
+        char *saveptr;
+        char *tmp;
+        char *token;
+        int rc = 0;
+
+        working_string = strdup(counters_string);
+        if (working_string == NULL) {
+                log_fn(LDMSD_LERROR, SAMP" parse_counters_string() strdup failed: %d", errno);
+                rc = -1;
+                goto err0;
+        }
+
+        for (tmp = working_string; (token = strtok_r(tmp, ",", &saveptr)) != NULL; tmp = NULL) {
+                rc = use_counter(token);
+                if (rc != 0) {
+                        goto err1;
+                }
+        }
+err1:
+        free(working_string);
+err0:
+        return rc;
+}
+
+/* strip leading and trailing whitespace */
+static void strip_whitespace(char **start)
+{
+        /* strip leading whitespace */
+        while (isspace(**start)) {
+                (*start)++;
+        }
+
+        /* strip trailing whitespace */
+        char * last;
+        last = *start + strlen(*start) - 1;
+        while (last > *start) {
+                if (isspace(last[0])) {
+                        last--;
+                } else {
+                        break;
+                }
+        }
+        last[1] = '\0';
+}
+
+static int parse_counters_file(const char * const counters_file)
+{
+        FILE *fp;
+        char buf[MAX_LINE_LEN];
+        int rc = 0;
+
+        fp = fopen(counters_file, "r");
+        if (fp == NULL) {
+                log_fn(LDMSD_LERROR, SAMP" parse_counters_file() failed fopen of \"%s\": %d\n",
+                       counters_file, errno);
+                return -1;
+        }
+
+        while (fgets(buf, MAX_LINE_LEN, fp) != NULL) {
+                char *tmp = buf;
+                strip_whitespace(&tmp);
+                if (tmp[0] == '#') {
+                        continue;
+                }
+                rc = use_counter(tmp);
+                if (rc != 0) {
+                        break;
+                }
+        }
+        fclose(fp);
+
+        return rc;
+}
+
+static int use_default_counters()
+{
+        int i;
+        int rc = 0;
+
+        for (i = 0; i < ARRAY_SIZE(default_counter_names); i++) {
+                rc = use_counter(default_counter_names[i]);
+                if (rc != 0) {
+                        break;
+                }
+        }
+
+        return rc;
+}
+
+static int config(struct ldmsd_plugin *self,
+                  struct attr_value_list *kwl, struct attr_value_list *avl)
+{
+        int rc = 0;
+        char *value;
+
+        log_fn(LDMSD_LDEBUG, SAMP" config() called\n");
+
+        sampler_base = base_config(avl, SAMP, "slingshot_metrics", log_fn);
+
+        value = av_value(avl, "counters");
+        if (value != NULL) {
+                rc = parse_counters_string(value);
+                if (rc != 0) {
+                        goto err;
+                }
+        }
+
+        value = av_value(avl, "counters_file");
+        if (value != NULL) {
+                rc = parse_counters_file(value);
+                if (rc != 0) {
+                        goto err;
+                }
+        }
+
+        if (counters.num_counters == 0) {
+                rc = use_default_counters();
+                if (rc != 0) {
+                        goto err;
+                }
+        }
+
+        value = av_value(avl, "refresh_interval_sec");
+        if (value != NULL) {
+                char *end;
+                long val;
+
+                strip_whitespace(&value);
+                val = strtol(value, &end, 10);
+                if (*end != '\0') {
+                        log_fn(LDMSD_LERROR, SAMP" refresh_interval must be a decimal number\n");
+                        rc = EINVAL;
+                        return rc;
+                }
+                cache_cxil_device_list_refresh_interval = (time_t)val;
+        } else {
+                cache_cxil_device_list_refresh_interval = (time_t)600;
+        }
+
+        rc = initialize_ldms_structs();
+        if (rc != 0) {
+                goto err;
+        }
+
+        return 0;
+err:
+        base_del(sampler_base);
+        return rc;
+}
+
+static void resize_metric_set(int expected_remaining_nics)
+{
+        size_t previous_heap_size;
+        size_t new_heap_size;
+
+        previous_heap_size = ldms_set_heap_size_get(sampler_base->set);
+        base_set_delete(sampler_base);
+
+        new_heap_size = previous_heap_size;
+        new_heap_size += ldms_record_heap_size_get(nic_record) * expected_remaining_nics;
+        new_heap_size += ldms_list_heap_size_get(LDMS_V_RECORD_ARRAY, expected_remaining_nics, 1);
+
+        base_set_new_heap(sampler_base, new_heap_size);
+        if (sampler_base->set == NULL) {
+                ldmsd_log(LDMSD_LERROR,
+                          SAMP" : Failed to resize metric set heap: %d\n", errno);
+        }
+}
+
+static int sample(struct ldmsd_sampler *self)
+{
+        struct cxil_device_list *device_list;
+        ldms_mval_t list_handle;
+        int i;
+        int j;
+        int rc = 0;
+
+        base_sample_begin(sampler_base);
+        rc = cache_cxil_device_list_get(&device_list);
+        if (rc != 0) {
+                log_fn(LDMSD_LERROR, SAMP" sample(): cache_cxil_device_list_get() failed: %d\n", rc);
+                base_sample_end(sampler_base);
+                return -1;
+        }
+        log_fn(LDMSD_LDEBUG, SAMP" sample(): # slingshot nics: %u\n", device_list->count);
+
+        list_handle = ldms_metric_get(sampler_base->set, index_store.nic_list);
+        ldms_list_purge(sampler_base->set, list_handle);
+        for (i = 0; i < device_list->count; i++) {
+                struct cxil_devinfo *dev_info = &device_list->info[i];
+                struct cxil_dev *dev;
+                ldms_mval_t record_instance;
+
+                rc = cache_cxil_dev_get(dev_info->dev_id, &dev);
+                if (rc != 0) {
+                        continue;
+                }
+
+                record_instance = ldms_record_alloc(sampler_base->set,
+                                                    index_store.nic_record);
+                if (record_instance == NULL) {
+                        log_fn(LDMSD_LDEBUG, SAMP": ldms_record_alloc() failed, resizing metric set\n");
+                        resize_metric_set(device_list->count - i);
+                        break;
+                }
+                ldms_list_append_record(sampler_base->set, list_handle,
+                                        record_instance);
+
+                ldms_record_array_set_str(record_instance, index_store.name,
+                                          dev_info->device_name);
+
+                for (j = 0; j < counters.num_counters; j++) {
+                        /* cxil_read_n_cntrs was no faster here in testing */
+                        rc = cxil_read_cntr(dev,
+                                            counters.slingshot_index[j],
+                                            &counters.value[j],
+                                            NULL);
+                        if (rc != 0) {
+                                cache_cxil_dev_close(dev);
+                                /* FIXME - we should really free the record here,
+                                   and avoid adding it to the list, but there is
+                                   currently no ldms_record_free() function */
+                                break;
+                        }
+                        ldms_record_set_u64(record_instance,
+                                            counters.ldms_index[j],
+                                            counters.value[j]);
+                }
+        }
+        base_sample_end(sampler_base);
+
+        return rc;
+}
+
+static void term(struct ldmsd_plugin *self)
+{
+        cache_cxil_device_list_free();
+        cache_cxil_dev_close_all();
+        log_fn(LDMSD_LDEBUG, SAMP" term() called\n");
+}
+
+static ldms_set_t get_set(struct ldmsd_sampler *self)
+{
+	return NULL;
+}
+
+static const char *usage(struct ldmsd_plugin *self)
+{
+        log_fn(LDMSD_LDEBUG, SAMP" usage() called\n");
+	return  "config name=" SAMP " " BASE_CONFIG_SYNOPSIS
+                BASE_CONFIG_DESC
+                ;
+}
+
+struct ldmsd_plugin *get_plugin(ldmsd_msg_log_f pf)
+{
+        static struct ldmsd_sampler plugin = {
+                .base = {
+                        .name = SAMP,
+                        .type = LDMSD_PLUGIN_SAMPLER,
+                        .term = term,
+                        .config = config,
+                        .usage = usage,
+                },
+                .get_set = get_set,
+                .sample = sample,
+        };
+
+        log_fn = pf;
+        log_fn(LDMSD_LDEBUG, SAMP" get_plugin() called ("PACKAGE_STRING")\n");
+
+        return &plugin.base;
+}


### PR DESCRIPTION
Introduce two sampler plugins for slingshot NICs: slibgshot_metrics and slingshot_info. The former is intended for high-frequency detailed counters, and the latter for lower-frequency general information.
