### PR TITLE
add user and group names options for status_uid/gid

### DIFF
--- a/ldms/man/Makefile.am
+++ b/ldms/man/Makefile.am
@@ -46,7 +46,6 @@ Plugin_slurm_sampler.man \
 Plugin_store_papi.man \
 Plugin_store_slurm.man \
 Plugin_syspapi_sampler.man \
-Plugin_app_sampler.man \
 Plugin_store_app.man \
 ldmsd_decomposition.man \
 Plugin_store_kafka.man

--- a/ldms/scripts/examples/app_sampler
+++ b/ldms/scripts/examples/app_sampler
@@ -2,7 +2,7 @@ export plugname=app_sampler
 export dsname=$(ldms_dstat_schema_name mmalloc=1 io=1 fd=1 auto-schema=1)
 export dstat_schema=$dsname
 portbase=61060
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --retry=1 -D 15 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 15 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
 VGARGS="--leak-check=full --track-origins=yes --trace-children=yes"
 vgon
 LDMSD 1

--- a/ldms/scripts/examples/blob_writer
+++ b/ldms/scripts/examples/blob_writer
@@ -4,7 +4,7 @@ export dstat_schema=$dsname
 portbase=61060
 VGARGS="--trace-children=yes --track-origins=yes --leak-check=full --show-leak-kinds=all"
 # track everything notifier config:
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --retry=1 -D 10 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 10 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
 #vgon
 LDMSD 1 2
 #vgoff

--- a/ldms/scripts/examples/linux_proc_sampler
+++ b/ldms/scripts/examples/linux_proc_sampler
@@ -44,6 +44,7 @@ cat << EOF > $LDMSD_RUN/metrics.input
         "^/usr/share/",
         "^/opt/ness"
     ],
+  "published_pid_dir" : "${LDMSD_RUN}/ldms-netlink-tracked",
   "metrics" : [
     "status_real_user",
     "status_eff_user",
@@ -61,12 +62,13 @@ cat << EOF > $LDMSD_RUN/metrics.input
 }
 EOF
 rm -f $LOGDIR/json*.log
-# valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.txt ${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+#valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.txt ${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked &
+#valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.txt ${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked &
 # uncomment next one to test duplicate handling
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
 VGARGS="--tool=drd --suppressions=/scratch1/baallan/ovis/ldms/scripts/examples/linux_proc_sampler.drd.supp"
-VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=definite --time-stamp=yes --keep-debuginfo=yes"
+VGARGS="--leak-check=full --track-origins=yes --trace-children=yes --show-leak-kinds=definite --time-stamp=yes --keep-debuginfo=yes --malloc-fill=3b"
 #vgon
 LDMSD 1
 vgoff
@@ -75,19 +77,19 @@ LDMSD 3
 vgoff
 SLEEP 2
 MESSAGE ldms_ls on host 1:
-LDMS_LS 1 -v
+#LDMS_LS 1 -v
 MESSAGE ldms_ls on host 2:
 SLEEP 1
 LDMS_LS 2 -v
 SLEEP 5
-MESSAGE stream_client_dump on sampler daemon 1
-for lc in $(seq 1); do
-	ldmsd_controller --auth none --port 61061 --cmd stream_client_dump
-	SLEEP 1
-done
+#MESSAGE stream_client_dump on sampler daemon 1
+#for lc in $(seq 1); do
+#ldmsd_controller --auth none --port 61061 --cmd stream_client_dump
+#	SLEEP 1
+#done
 SLEEP 5
 for lc in $(seq 1); do
-	LDMS_LS 1 -v
+#LDMS_LS 1 -v
 	SLEEP 2
 done
 SLEEP 2

--- a/ldms/scripts/examples/linux_proc_sampler
+++ b/ldms/scripts/examples/linux_proc_sampler
@@ -45,6 +45,10 @@ cat << EOF > $LDMSD_RUN/metrics.input
         "^/opt/ness"
     ],
   "metrics" : [
+    "status_real_user",
+    "status_eff_user",
+    "status_real_group",
+    "status_eff_group",
     "stat_pid" ,
     "stat_state",
     "stat_rss",

--- a/ldms/src/sampler/app_sampler/Makefile.am
+++ b/ldms/src/sampler/app_sampler/Makefile.am
@@ -8,6 +8,7 @@ libapp_sampler_la_SOURCES = app_sampler.c
 libapp_sampler_la_CFLAGS  = @OVIS_INCLUDE_ABS@
 libapp_sampler_la_LIBADD  =  $(COMMON_LIBS)
 libapp_sampler_la_LDFLAGS = @OVIS_LIB_ABS@
+dist_man7_MANS += Plugin_app_sampler.man
 
 pkglib_LTLIBRARIES += liblinux_proc_sampler.la
 

--- a/ldms/src/sampler/app_sampler/Plugin_app_sampler.man
+++ b/ldms/src/sampler/app_sampler/Plugin_app_sampler.man
@@ -160,7 +160,15 @@ status_pid,
 status_ppid,
 status_tracerpid,
 status_uid,
+status_real_user,
+status_eff_user,
+status_sav_user,
+status_fs_user,
 status_gid,
+status_real_group,
+status_eff_group,
+status_sav_group,
+status_fs_group,
 status_fdsize,
 status_groups,
 status_nstgid,
@@ -278,9 +286,18 @@ config name=app_sampler cfg_file=cfg\&.json
 .RE
 .PP
 .PP
+.SH NOTES
+
+Some of the optionally collected data might be security sensitive.
+
+The status_uid and status_gid values can alternatively be collected as "status_real_user", "status_eff_user", "status_sav_user", "status_fs_user", "status_real_group", "status_eff_group", "status_sav_group", "status_fs_group". These string values are most efficiently collected if both the string value and the numeric values are collected.
+
 .SH SEE ALSO
 .nh
 .BR ldmsd (8),
 .BR ldms_quickstart (7),
 .BR ldmsd_controller (8),
-.BR ldms_sampler_base (7).
+.BR ldms_sampler_base (7),
+.BR proc(5),
+.BR sysconf(3),
+.BR environ(3).

--- a/ldms/src/sampler/app_sampler/Plugin_linux_proc_sampler.man
+++ b/ldms/src/sampler/app_sampler/Plugin_linux_proc_sampler.man
@@ -293,6 +293,7 @@ The publication of environment and cmdline (argv) stream data is done once at th
 
 The publication of file information via fd_msg information may be effectively made one-shot-per-process by setting fd_msg=2147483647. This will cause late-loaded plugin library dependencies to be missed, however.
 
-The status_uid and status_gid values can alternatively be collected as "status_real_user", "status_eff_user", "status_sav_user", "status_fs_user", "status_real_group", "status_eff_group", "status_sav_group", "status_fs_group".
+The status_uid and status_gid values can alternatively be collected as "status_real_user", "status_eff_user", "status_sav_user", "status_fs_user", "status_real_group", "status_eff_group", "status_sav_group", "status_fs_group". These string values are most efficiently collected if both the string value and the numeric values are collected.
+
 .SH SEE ALSO
 syscalls(2), ldmsd(8), ldms_quickstart(7), ldmsd_controller(8), ldms_sampler_base(7), proc(5), sysconf(3), environ(3).

--- a/ldms/src/sampler/app_sampler/Plugin_linux_proc_sampler.man
+++ b/ldms/src/sampler/app_sampler/Plugin_linux_proc_sampler.man
@@ -293,5 +293,6 @@ The publication of environment and cmdline (argv) stream data is done once at th
 
 The publication of file information via fd_msg information may be effectively made one-shot-per-process by setting fd_msg=2147483647. This will cause late-loaded plugin library dependencies to be missed, however.
 
+The status_uid and status_gid values can alternatively be collected as "status_real_user", "status_eff_user", "status_sav_user", "status_fs_user", "status_real_group", "status_eff_group", "status_sav_group", "status_fs_group".
 .SH SEE ALSO
 syscalls(2), ldmsd(8), ldms_quickstart(7), ldmsd_controller(8), ldms_sampler_base(7), proc(5), sysconf(3), environ(3).

--- a/ldms/src/sampler/app_sampler/Plugin_linux_proc_sampler.man
+++ b/ldms/src/sampler/app_sampler/Plugin_linux_proc_sampler.man
@@ -99,6 +99,17 @@ of expression strings as shown in EXAMPLES.
 fd_msg=N
 .br
 Publish new /proc/pid/fd scan data to the <SCHEMA>_files stream every N-th sample, where if the schema is not specified, the default SCHEMA is linux_proc_sampler. (Default: fd_msg=0; no publication of the file details). A downstream daemon will need to subscribe to linux_proc_sampler_files to receive the published messages and store them. Files that are not opened long enough to be caught in a scan of fds will be missed. Files will be reported as 'opened' the first time seen and as 'closed' when they are no longer seen.  A file both no longer seen and no longer existing will be reported as 'deleted'. Only regular files (not sockets, etc) are reported, and additionally files matching the fd_expressions are ignored. Use a larger N to reduce the scan overhead at the cost of missing short-access files. If a close-reopen of the same file occurs between scans, no corresponding events are generated.
+.TP
+published_pid_dir=<path>
+.br
+Name of the directory where netlink-notifier or other notifier pids of interest may be found.
+This directory is scanned at sampler startup only, so that pids which were the
+subject of events published before the sampler started can be tracked.
+If not specified, the default directory is /var/run/ldms-netlink-tracked.
+Absence of this directory is not a sampler configuration error, as ldmsd may start
+before the notifier process. When starting, the sampler will clean up any stale
+pid references found in this directory.
+Any pid not appearing in this directory is not being tracked.
 .RE
 
 .SH INPUT STREAM FORMAT
@@ -282,6 +293,14 @@ The fd_msg option can have its output filtered by json or a text file, e.g.:
 /usr/lib64/
 /usr/lib/
 .fi
+
+.PP
+The files defined with published_pid_dir appear in (for example)
+.nf
+/var/run/ldms-netlink-tracked/[0-9]*
+.fi
+and each contains the JSON message sent by the publisher.
+Publishers, not ldmsd, populate this directory to allow asynchronous startup.
 
 .SH NOTES
 

--- a/ldms/src/sampler/app_sampler/linux_proc_sampler.c
+++ b/ldms/src/sampler/app_sampler/linux_proc_sampler.c
@@ -2840,7 +2840,7 @@ static int string_send_state(linux_proc_sampler_inst_t inst, struct linux_proc_s
 		"\"st_ino\":%ld,"
 		"\"st_mode\":%o,"
 		"\"st_size\":%zu,"
-		"\"mtime\":%ld.%09ld,"
+		"\"mtime\":\"%ld.%09ld\","
 		"\"state\":\"%s\"}]}";
 	static size_t stat_format_sz;
 	if (!stat_format_sz)

--- a/ldms/src/sampler/app_sampler/linux_proc_sampler.c
+++ b/ldms/src/sampler/app_sampler/linux_proc_sampler.c
@@ -1,8 +1,8 @@
 /* -*- c-basic-offset: 8 -*-
- * Copyright (c) 2020-2021 National Technology & Engineering Solutions
+ * Copyright (c) 2020-2022 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS). Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
- * Copyright (c) 2020-2021 Open Grid Computing, Inc. All rights reserved.
+ * Copyright (c) 2020-2022 Open Grid Computing, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/ldms/src/sampler/netlink/ldms-notify.service
+++ b/ldms/src/sampler/netlink/ldms-notify.service
@@ -8,6 +8,7 @@ EnvironmentFile=-/etc/sysconfig/ldms-netlink-notifier.conf
 # one can ignore root owned processes by including -u 1
 # ExecStart=/usr/sbin/ldms-netlink-notifier -u 1 -x -e exec,clone,exit -r
 # get the path defaults from the code or from the environment file.
+ExecStartPre=-/usr/bin/rm -f /var/run/ldms-netlink-tracked/[0-9]*
 ExecStart=/usr/sbin/ldms-netlink-notifier -x -e exec,clone,exit -r
 
 [Install]

--- a/ldms/src/sampler/netlink/netlink-notifier.man
+++ b/ldms/src/sampler/netlink/netlink-notifier.man
@@ -76,6 +76,11 @@ The 'short' options do not override the exclude entirely options.
 --timeout[=]<val>	 change the default value of timeout.
 	 If repeated, the last value given wins.
 	 The default 1 is used if env NOTIFIER_LDMS_TIMEOUT is not set.
+--track-dir[=]<path>     change the pids published directory.
+	 The default is used if env NOTIFIER_TRACK_DIR is not set.
+	 The path given should be on a RAM-based file system for efficiency,
+	 and it should not contain any files except those created by
+	 this daemon.
 .fi
 
 .SH ENVIRONMENT
@@ -85,6 +90,7 @@ NOTIFIER_EXCLUDE_PROGRAMS="(nullexe):<unknown>"
 NOTIFIER_EXCLUDE_DIRS=/sbin
 NOTIFIER_EXCLUDE_SHORT_PATH=/bin:/usr
 NOTIFIER_EXCLUDE_SHORT_TIME=1
+NOTIFIER_TRACK_DIR=/var/run/ldms-netlink-tracked
 NOTIFIER_LDMS_RECONNECT=600
 NOTIFIER_LDMS_TIMEOUT=1
 NOTIFIER_LDMS_STREAM=slurm
@@ -95,6 +101,23 @@ NOTIFIER_LDMS_AUTH=munge
 .fi
 Omitting (nullexe):<unknown> from NOTIFIER_EXCLUDE_PROGRAMS may cause incomplete output
 related to processes no longer present. In exotic circumstances, this may be desirable anyway.
+
+.SH FILES
+
+Users or other processes may discover which processes are the subject of notifications
+by examining the files in
+
+/NOTIFIER_TRACK_DIR/*
+
+For each pid started event which would be emitted to an LDMS stream, a temporary
+file with the name of the pid is created in NOTIFIER_TRACK_DIR. The file
+will contain the json event attempted. The temporary file will
+be removed when the corresponding pid stopped event is sent.
+These files are not removed when the notifier daemon exits.
+Client applications may validate a file by checking the contents
+against the /proc/$pid/stat content, if it exists.
+Invalid files may be removed by clients or system scripts.
+
 
 .SH NOTES
 .PP


### PR DESCRIPTION
This adds the ability to optionally collect names corresponding to uid and gid values, enabling analyses based on user or group name.
The library call(s) to lookup username/groupname are not repeated so long as the paired uid/gid value does not change.