### PR TITLE
Rename the component_id and job_id metrics in slurm_sampler

### DIFF
--- a/ldms/src/sampler/slurm/slurm_sampler.c
+++ b/ldms/src/sampler/slurm/slurm_sampler.c
@@ -273,12 +273,12 @@ static int create_metric_set(void)
 	}
 
 	/* component_id */
-	comp_id_idx = ldms_schema_metric_array_add(job_schema, "component_id",
+	comp_id_idx = ldms_schema_metric_array_add(job_schema, "job_comp_id",
 						   LDMS_V_U64_ARRAY, job_list_len);
 	if (comp_id_idx < 0)
 		goto err;
 	/* job_id */
-	job_id_idx = ldms_schema_metric_array_add(job_schema, "job_id",
+	job_id_idx = ldms_schema_metric_array_add(job_schema, "slurm_job_id",
 						  LDMS_V_U64_ARRAY, job_list_len);
 	if (job_id_idx < 0)
 		goto err;


### PR DESCRIPTION
The 'component_id' metric, an uint64, is the component ID corresponding to the set. The 'job_id' metric, an uint64, is the job ID corresponding to the set at a timestamp. However, the 'component_id' metric in slurm_sampler, an uint64 array, contains the component IDs of each job in the job_id metric. Similarly, the 'job_id' metric in slurm_sampler, an uint64 array, contains the slurm job IDs on the system.

store_sos assumes that component_id and job_id are uint64 so that it can create the joined indices of component_id, job_id, and timestamps. store_sos hits an assert when it stores the slurm set because the component_id and job_id are not uint64.

The patch renames slurm_sampler's component_id and job_id metrics because they have different meanings from the other sampler plugins.