### PR TITLE
Add sq_sz and n_eps to zap thread stat

### DIFF
--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1303,10 +1303,15 @@ class LdmsdCmdParser(cmd.Cmd):
         return self.__complete_attr_list('set_info', text)
 
     def display_thread_stats(self, stats):
-        print(f"{'Name':16} {'Samples':12} {'Sample Rate':12} {'Utilization':12}")
-        print("---------------- ------------ ------------ ------------")
+        print(f"{'Name':16} {'Samples':12} {'Sample Rate':12} " \
+              f"{'Utilization':12} {'Send Queue Size':16} " \
+              f"{'Num of EPs':12}")
+        print("---------------- ------------ ------------ ------------ "\
+              "---------------- ------------")
         for e in stats['entries']:
-            print(f"{e['name']:16} {e['sample_count']:12.0f} {e['sample_rate']:12.2f} {e['utilization'] * 100:12.2f}")
+            print(f"{e['name']:16} {e['sample_count']:12.0f} " \
+                  f"{e['sample_rate']:12.2f} {e['utilization'] * 100:12.2f} " \
+                  f"{e['sq_sz']:16} {e['n_eps']:12}")
 
     def do_thread_stats(self, arg):
         """

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -6377,7 +6377,9 @@ static char * __thread_stats_as_json(size_t *json_sz)
 		__APPEND("   \"name\": \"%s\",\n", res->entries[i].name);
 		__APPEND("   \"sample_count\": %g,\n", res->entries[i].sample_count);
 		__APPEND("   \"sample_rate\": %g,\n", res->entries[i].sample_rate);
-		__APPEND("   \"utilization\": %g\n", res->entries[i].utilization);
+		__APPEND("   \"utilization\": %g,\n", res->entries[i].utilization);
+		__APPEND("   \"sq_sz\": %lu,\n", res->entries[i].sq_sz);
+		__APPEND("   \"n_eps\": %lu\n", res->entries[i].n_eps);
 		if (i < res->count - 1)
 			__APPEND("  },\n");
 		else

--- a/lib/src/zap/rdma/zap_rdma.c
+++ b/lib/src/zap/rdma/zap_rdma.c
@@ -758,6 +758,8 @@ static void _rdma_context_free(struct z_rdma_context *ctxt)
 static int queue_io(struct z_rdma_ep *rep, struct z_rdma_context *ctxt)
 {
 	TAILQ_INSERT_TAIL(&rep->io_q, ctxt, pending_link);
+	__atomic_fetch_add(&rep->ep.sq_sz, 1, __ATOMIC_SEQ_CST);
+	__atomic_fetch_add(&rep->ep.thread->stat->sq_sz, 1, __ATOMIC_SEQ_CST);
 	ctxt->is_pending = 1;
 	return 0;
 }
@@ -774,6 +776,8 @@ static void flush_io_q(struct z_rdma_ep *rep)
 	while (!TAILQ_EMPTY(&rep->io_q)) {
 		ctxt = TAILQ_FIRST(&rep->io_q);
 		TAILQ_REMOVE(&rep->io_q, ctxt, pending_link);
+		__atomic_fetch_sub(&rep->ep.thread->stat->sq_sz, 1, __ATOMIC_SEQ_CST);
+		__atomic_fetch_sub(&rep->ep.sq_sz, 1, __ATOMIC_SEQ_CST);
 		ctxt->is_pending = 0;
 		switch (ctxt->op) {
 		case IBV_WC_SEND:
@@ -947,6 +951,8 @@ static void submit_pending(struct z_rdma_ep *rep)
 			goto out;
 
 		TAILQ_REMOVE(&rep->io_q, ctxt, pending_link);
+		__atomic_fetch_sub(&rep->ep.sq_sz, 1, __ATOMIC_SEQ_CST);
+		__atomic_fetch_sub(&rep->ep.thread->stat->sq_sz, 1, __ATOMIC_SEQ_CST);
 		ctxt->is_pending = 0;
 
 		rc = post_send(rep, ctxt, &badwr, is_rdma);

--- a/lib/src/zap/sock/zap_sock.c
+++ b/lib/src/zap/sock/zap_sock.c
@@ -1256,6 +1256,8 @@ static void sock_write(struct epoll_event *ev)
 	assert(0 == wr->data_len);
 	assert(0 == wr->msg_len);
 	TAILQ_REMOVE(&sep->sq, wr, link);
+	__atomic_fetch_sub(&sep->ep.thread->stat->sq_sz, 1, __ATOMIC_SEQ_CST);
+	__atomic_fetch_sub(&sep->ep.sq_sz, 1, __ATOMIC_SEQ_CST);
 	if (wr->flags & Z_SOCK_WR_COMPLETION) {
 		/* right now we have only SEND_COMPLETE delivering by WR */
 		assert(ntohs(wr->msg.hdr.msg_type) == SOCK_MSG_SENDRECV);
@@ -1484,6 +1486,8 @@ static void __wr_post(struct z_sock_ep *sep, z_sock_send_wr_t wr)
 {
 	struct epoll_event ev = { .events = EPOLLOUT, .data.ptr = sep };
 	TAILQ_INSERT_TAIL(&sep->sq, wr, link);
+	__atomic_fetch_add(&sep->ep.sq_sz, 1, __ATOMIC_SEQ_CST);
+	__atomic_fetch_add(&sep->ep.thread->stat->sq_sz, 1, __ATOMIC_SEQ_CST);
 	sock_write(&ev);
 }
 

--- a/lib/src/zap/zap.h
+++ b/lib/src/zap/zap.h
@@ -833,6 +833,8 @@ struct zap_thrstat_result_entry {
 	double sample_count;	/*< The number of sample periods */
 	double sample_rate;		/*< Samples per second */
 	double utilization;		/*< The thread utilization */
+	uint64_t n_eps;			/*< Number of endpoints */
+	uint64_t sq_sz;			/*< Send queue size */
 };
 
 struct zap_thrstat_result {

--- a/lib/src/zap/zap_priv.h
+++ b/lib/src/zap/zap_priv.h
@@ -183,6 +183,7 @@ struct zap_ep {
 #endif
 	/** (private to libzap) for thread->ep_list */
 	LIST_ENTRY(zap_ep) _entry;
+	uint64_t sq_sz; /* send queue size of the endpoint */
 };
 
 struct zap {
@@ -491,6 +492,8 @@ struct zap_thrstat {
 	uint64_t wait_sum;
 	uint64_t *wait_window;
 	uint64_t *proc_window;
+	uint64_t sq_sz; /* send queue size (in entries) */
+	uint64_t n_eps; /* number of endpoints */
 	LIST_ENTRY(zap_thrstat) entry;
 };
 #define ZAP_THRSTAT_WINDOW 4096	/*< default window size */


### PR DESCRIPTION
For example:
```sh
$ ldmsd_controller --port 10000 --host cygnus-06-iw --xprt rdma
Welcome to the LDMSD control processor
rdma:cygnus-06-iw:10000> thread_stats
Name             Samples      Sample Rate  Utilization  Send Queue Size  Num of EPs
---------------- ------------ ------------ ------------ ---------------- ------------
zap_rdma_io                64         2.33         0.03                0            4
zap_rdma_io                76         2.75         0.03                0            4
zap_rdma_io                74         2.68         0.04                0            5
zap_rdma_io                56         2.02         0.03                0            4
zap_rdma_io                 1         0.04         0.00                0            1
rdma:cygnus-06-iw:10000>
```

This has been tested on sock and rdma. I don't have a chance to test on ugni yet. @valleydlr could you please give this a try? 