### PR TITLE
Fix SIGSEGV due to NULL zap thread

### DIFF
--- a/lib/src/zap/sock/zap_sock.c
+++ b/lib/src/zap/sock/zap_sock.c
@@ -1256,7 +1256,8 @@ static void sock_write(struct epoll_event *ev)
 	assert(0 == wr->data_len);
 	assert(0 == wr->msg_len);
 	TAILQ_REMOVE(&sep->sq, wr, link);
-	__atomic_fetch_sub(&sep->ep.thread->stat->sq_sz, 1, __ATOMIC_SEQ_CST);
+	if (sep->ep.thread)
+		__atomic_fetch_sub(&sep->ep.thread->stat->sq_sz, 1, __ATOMIC_SEQ_CST);
 	__atomic_fetch_sub(&sep->ep.sq_sz, 1, __ATOMIC_SEQ_CST);
 	if (wr->flags & Z_SOCK_WR_COMPLETION) {
 		/* right now we have only SEND_COMPLETE delivering by WR */
@@ -1487,7 +1488,8 @@ static void __wr_post(struct z_sock_ep *sep, z_sock_send_wr_t wr)
 	struct epoll_event ev = { .events = EPOLLOUT, .data.ptr = sep };
 	TAILQ_INSERT_TAIL(&sep->sq, wr, link);
 	__atomic_fetch_add(&sep->ep.sq_sz, 1, __ATOMIC_SEQ_CST);
-	__atomic_fetch_add(&sep->ep.thread->stat->sq_sz, 1, __ATOMIC_SEQ_CST);
+	if (sep->ep.thread)
+		__atomic_fetch_add(&sep->ep.thread->stat->sq_sz, 1, __ATOMIC_SEQ_CST);
 	sock_write(&ev);
 }
 

--- a/lib/src/zap/ugni/zap_ugni.c
+++ b/lib/src/zap/ugni/zap_ugni.c
@@ -1362,7 +1362,8 @@ static zap_err_t z_ugni_msg_send(struct z_ugni_ep *uep, zap_ugni_msg_t msg,
 	wr->state = Z_UGNI_WR_PENDING;
 	TAILQ_INSERT_TAIL(&uep->send_wrq, wr, entry);
 	__atomic_fetch_add(&uep->ep.sq_sz, 1, __ATOMIC_SEQ_CST);
-	__atomic_fetch_add(&uep->ep.thread->stat->sq_sz, 1, __ATOMIC_SEQ_CST);
+	if (uep->ep.thread)
+		__atomic_fetch_add(&uep->ep.thread->stat->sq_sz, 1, __ATOMIC_SEQ_CST);
 	ATOMIC_INC(&z_ugni_stat.active_send, 1);
 	z_ugni_sock_send(uep);
 	EP_THR_UNLOCK(uep);


### PR DESCRIPTION
Check the zap thread before manipulating endpoint-thread statistics.