### PR TITLE
Fix missing free on a config string for blob_stream_writer.

### DIFF
--- a/ldms/src/sampler/blob_stream/blob_stream_writer.c
+++ b/ldms/src/sampler/blob_stream/blob_stream_writer.c
@@ -550,6 +550,8 @@ static void stream_data_close( stream_data_t sd )
 		fclose(sd->offsetfile);
 		sd->offsetfile = NULL;
 	}
+	free(sd->typefile_name);
+	sd->typefile_name = NULL;
 	free(sd->streamfile_name);
 	sd->streamfile_name = NULL;
 	free(sd->offsetfile_name);


### PR DESCRIPTION
the leak fixed is a path name leaked once per stream configured.