### PR TITLE
Updates for ibmad_records_sampler

### DIFF
--- a/ldms/src/sampler/ibmad_records_sampler/Plugin_ibmad_records_sampler.man
+++ b/ldms/src/sampler/ibmad_records_sampler/Plugin_ibmad_records_sampler.man
@@ -53,6 +53,14 @@ exclude=PORTLIST
 .br
 Collect all devices and ports discovered and active that are not matched by PORTLIST. See PORTLIST below.
 Cannot be combined with the include option.
+.TP
+refresh_interval_sec=<seconds>
+.br
+(Optional) The sampler caches the list of infiniband devices, and that
+cache is refreshed at the beginning of a sample cycle if the refresh
+interval time has been exceeded. refresh_interval_sec sets
+the minimum number of seconds between refreshes of the device cache.
+The default refresh interval is 600 seconds.
 .RE
 
 .SH PORTLIST

--- a/ldms/src/sampler/ibmad_records_sampler/ibmad_records_sampler.c
+++ b/ldms/src/sampler/ibmad_records_sampler/ibmad_records_sampler.c
@@ -440,33 +440,34 @@ static void interfaces_tree_refresh()
 			char name_and_port[UMAD_CA_NAME_LEN+128];
 			struct rbn *rbn;
 			struct interface_data *data;
+                        umad_port_t *port = ca.ports[j];
 
-			if (ca.ports[j] == NULL)
+			if (port == NULL)
 				continue;
 			else
 				cnt++;
 
-			if (!collect_ca_port(ca_names[i], ca.ports[j]->portnum)) {
+			if (!collect_ca_port(ca_names[i], port->portnum)) {
 				continue;
 			}
-			if (ca.ports[j]->state != PORT_STATE_ACTIVE) {
+			if (port->state != PORT_STATE_ACTIVE) {
                                 log_fn(LDMSD_LDEBUG, SAMP" metric_tree_refresh() skipping non-active ca %s port %d\n",
-                                       ca.ports[j]->ca_name, ca.ports[j]->portnum);
+                                       port->ca_name, port->portnum);
 				continue;
 			}
 
 			snprintf(name_and_port, sizeof(name_and_port), "%s.%d",
-				 ca.ports[j]->ca_name,
-				 ca.ports[j]->portnum);
+				 port->ca_name,
+				 port->portnum);
 			rbn = rbt_find(&interfaces_tree, name_and_port);
 			if (rbn) {
 				data = container_of(rbn, struct interface_data,
 						    interface_rbn);
 				rbt_del(&interfaces_tree, &data->interface_rbn);
 			} else {
-				data = interface_create(ca.ports[j]->ca_name,
-							ca.ports[j]->portnum,
-							ca.ports[j]->base_lid);
+				data = interface_create(port->ca_name,
+							port->portnum,
+							port->base_lid);
 			}
 			if (data == NULL)
 				continue;

--- a/ldms/src/sampler/ibmad_records_sampler/ibmad_records_sampler.c
+++ b/ldms/src/sampler/ibmad_records_sampler/ibmad_records_sampler.c
@@ -455,6 +455,18 @@ static void interfaces_tree_refresh()
                                        port->ca_name, port->portnum);
 				continue;
 			}
+                        /* There are at least two known link_layer types:
+                           InfiniBand, Ethernet. In particular, a RoCE implmentation,
+                           the "Broadcom NetXtreme-C/E RoCE Driver HCA", reports
+                           as having a link_layer of "Ethernet". mdc_rpc_open_port()
+                           will fail for those ports. Thus we skip anything that is
+                           not using link_layer "InfiniBand". */
+                        if (port->link_layer != NULL &&
+                            strncmp(port->link_layer, "InfiniBand", 10) != 0) {
+                                log_fn(LDMSD_LDEBUG, SAMP" metric_tree_refresh() skipping ca %s port %d link_layer \"%s\" (link_layer is not \"InfiniBand\")\n",
+                                       port->ca_name, port->portnum, port->link_layer);
+                                continue;
+                        }
 
 			snprintf(name_and_port, sizeof(name_and_port), "%s.%d",
 				 port->ca_name,


### PR DESCRIPTION
We came across a system where there are RoCE devices on a node. Those device show up in the umad device listing, but connections to the devices for sampling always fail. Also, the device lookup seems to be especially long on that system, and my suspicion is that the RoCE device(s) may be to blame there as well.

First, we add a check to skip over device ports with a link_layer that is no InfiniBand (the RoCE ones where link_layer Ethernet).

Next we add a refresh_interval_sec configuration option so we can refresh the list of available devices on a longer interval so we can avoid the high cost of device lookup on most sampling intervals.
