### PR TITLE
Add the capability to reset the updater's counters thru updtr_status

### DIFF
--- a/ldms/python/ldmsd/ldmsd_config.py
+++ b/ldms/python/ldmsd/ldmsd_config.py
@@ -116,7 +116,7 @@ LDMSD_CTRL_CMD_MAP = {'usage': {'req_attr': [], 'opt_attr': ['name']},
                       'updtr_start': {'req_attr': ['name'],
                                       'opt_attr': ['interval', 'offset', 'auto_interval']},
                       'updtr_stop': {'req_attr': ['name']},
-                      'udptr_status': {'req_attr': [], 'opt_attr': ['name', 'summary']},
+                      'udptr_status': {'req_attr': [], 'opt_attr': ['name', 'summary', 'reset']},
                       'updtr_task': {'req_attr': ['name'], 'opt_attr': []},
                       'update_time_stats' : {'req_attr': [], 'opt_attr' : ['name']},
                       ##### Storage Policy #####

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -798,7 +798,13 @@ class LdmsdCmdParser(cmd.Cmd):
 
         Parameters:
         [name=]        updater name
-        [Summary]     not show updaters' producers
+        [summary]      not show updaters' producers
+        [reset=]       'false' for not resetting the counter after it reports the information.
+                       If it isn't given, the counters are not reset.
+
+        Counter descriptions:
+          Skipped      The number of times there exists an outstanding update request when the updater tries to schedule an update request.
+          Oversampled  The number of times the generation number of a set has not changed from the previous update complete.
         """
         resp = self.handle('updtr_status', arg)
         if resp['errcode'] == 0:


### PR DESCRIPTION
Users can do 'updtr_status reset=true' in ldmsd_controller to reset the updaters' counters.

The descriptions of the updaters' counters are provided in the command help. Do 'help updtr_status' in ldmsd_controller to see the descriptions.