### PR TITLE
Refactor the lookup error path

### DIFF
--- a/ldms/src/core/ldms_private.h
+++ b/ldms/src/core/ldms_private.h
@@ -236,5 +236,6 @@ int rbn_ptr_cmp(void *tk, const void *k)
 
 void __ldms_xprt_on_set_del(ldms_t xprt, ldms_set_t set);
 void __ldms_set_on_xprt_term(ldms_set_t set, ldms_t xprt);
+void __ldms_set_delete(ldms_set_t s, int notify);
 
 #endif

--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2383,7 +2383,7 @@ static void __handle_lookup(ldms_t x, struct ldms_context *ctxt,
 		 * it, but that will be dropped when the ctxt is
 		 * freed.
 		 */
-		ldms_set_delete(ctxt->lu_read.s);
+		__ldms_set_delete(ctxt->lu_read.s, 0);
 	} else {
 		ldms_set_publish(ctxt->lu_read.s);
 	}
@@ -2630,6 +2630,10 @@ static void handle_rendezvous_lookup(zap_ep_t zep, zap_event_t ev,
 	       x->zap_ep, x->active_lookup);
 #endif /* DEBUG */
 	pthread_mutex_unlock(&x->lock);
+
+	/* If there was a lookup error, destroy the local set */
+	if (lset && rc)
+		__ldms_set_delete(lset, 0);
 }
 
 static void handle_rendezvous_push(zap_ep_t zep, zap_event_t ev,


### PR DESCRIPTION
The lookup error path will call ldms_set_delete which in turn will call ldms_xprt_set_delete which informs downstream aggregators of the deleted set. However, in the error path the downstream peer has never received a dir_add because the set was never published. This results in the downstream reporting an error that a dir_delete was received for a set that was never added.

It also fixes the case where the set is created in the local tree, but an error occurs in the RDMA of the meta data into the local set. In this case, the set was not being removed from the set tree which would cause all subsequent lookup requests to fail synchronously because the set was already present in the tree.