### PR TITLE
Fix a possible deadlock caused by ldmsd_stream_publish()

### DIFF
--- a/ldms/src/ldmsd/ldmsd_stream.c
+++ b/ldms/src/ldmsd/ldmsd_stream.c
@@ -526,6 +526,7 @@ int ldmsd_stream_publish(ldms_t xprt,
 	s->s_pub_info.count += 1;
 	s->s_pub_info.last_ts = now;
 	s->s_pub_info.total_bytes += data_len;
+	pthread_mutex_unlock(&s->s_lock);
 
  err:
 	if (buf)


### PR DESCRIPTION
The deadlock occurs when applications publishes data on the same stream multiple times by calling ldmsd_stream_publish().