### PR TITLE
Fix prdcr_stream_status's handler

### DIFF
--- a/ldms/src/ldmsd/ldmsd_stream.c
+++ b/ldms/src/ldmsd/ldmsd_stream.c
@@ -914,7 +914,7 @@ int __publisher_json(struct buf_s *buf, ldmsd_stream_publisher_t p)
 {
 	int rc;
 	rc = buf_printf(buf, "\"%s\":{"
-			      "\"info\":",
+			      "\"recv\":",
 			      p->p_name);
 	if (rc)
 		return rc;


### PR DESCRIPTION
- Remove a possible race between forwarding the stream_status request to the connected producer and receiving the response back. The race could cause LDMSD to free the forwarding request context before LDMSD receives all the responses.