### PR TITLE
update metric types to signed for lustre_mdc sampler

### DIFF
--- a/ldms/src/sampler/lustre_mdc/Plugin_lustre_mdc.man
+++ b/ldms/src/sampler/lustre_mdc/Plugin_lustre_mdc.man
@@ -49,12 +49,21 @@ mdc_timing=0
 Optionally exclude timing data from /sys/kernel/debug/lustre/mdc/*/stats. If given,
 the sampler may be run by unprivileged users. If /sys/kernel/debug/ cannot be opened
 by the user, it is a configuration error unless mdc_timing=0 is given.
+.TP
+auto_reset=0
+.br
+Turn off the default behavior of resetting the counters when an overflow condition is detected.
+Reset is implemented by writing 0 to the corresponding /proc or /sys file.
 .RE
 
 .SH SCHEMA
 The default schema name is lustre_mdc_ops_timing with all the data described in DATA REPORTED below included. If mdc_timing=0 is given, only the operation counts from md_stats are reported and the default schema name changes to lustre_mdc_ops.
 
 .SH DATA REPORTED
+
+fs_name: The lustre file system name, e.g. xscratch.
+mdc: The mdc target that goes with the metrics, e.g. xscratch-MDT0000.
+last_reset: The time of the last reset performed by this sampler for any of its metric sets.
 
 Operation counts from /proc/fs/lustre/mdc/*/md_stats.
 See also kernel source lustre/lustre/obdclass/lprocfs_status.c and
@@ -101,16 +110,21 @@ The counters and file locations supported by this plugin are those present in Lu
 The fields labeled [reqs] are omitted. Data names not listed here are simply ignored.
 
 The minimum sample interval recommended for this sampler is 5-10 seconds, as the data volume may
-be substantial and the resolving shorter bursts of metadata activity is generally unnecessary.
+be substantial and resolving shorter bursts of metadata activity is generally unnecessary.
 
 The average and sample standard deviation can be computed from sum and sumsqs, but
-once these counters roll over on a high up-time client, they may be less useful.
+once these counters roll over to negative values on a high up-time client, they may be less useful. The counters can be manually reset with bash:
+.nf
+for i in /proc/fs/lustre/mdc/*/md_stats /sys/kernel/debug/lustre/mdc/*/stats; do
+	echo 0 $i;
+done
+.fi
 
 The lustre utility equivalent of this plugin is to inspect the output of
   lctl get_param -R mdc.*.stats
   lctl get_param -R mdc.*.md_stats
 
-specifying instance=xxx as an option will be ignored.
+Specifying instance=xxx as an option will be ignored.
 
 .SH BUGS
 No known bugs.

--- a/ldms/src/sampler/lustre_mdc/lustre_mdc.c
+++ b/ldms/src/sampler/lustre_mdc/lustre_mdc.c
@@ -228,6 +228,10 @@ static int config(struct ldmsd_plugin *self,
 			return EINVAL;
 		}
 	}
+	ival = av_value(avl, "auto_reset");
+	mdc_auto_reset = 1;
+	if (ival && ival[0] == '0')
+		mdc_auto_reset = 0;
 	ival = av_value(avl, "mdc_timing");
 	if (ival && ival[0] == '0')
 		mdc_timing = 0;

--- a/ldms/src/sampler/lustre_mdc/lustre_mdc_general.h
+++ b/ldms/src/sampler/lustre_mdc/lustre_mdc_general.h
@@ -13,6 +13,7 @@
 #include "comp_id_helper.h"
 #include "sampler_base.h"
 
+extern int mdc_auto_reset;
 int mdc_general_schema_is_initialized();
 int mdc_general_schema_init(const comp_id_t cid, int mdc_timing);
 void mdc_general_schema_fini();


### PR DESCRIPTION
This commit:
- changes the incorrectly typed (u64) metrics to s64 to match the lustre code producing them (schema change). 
- removes the "-mdc-$hexaddr" suffix from the "mdc" field; the hex part previously varied from node to node and made the "mdc" field useless as an index.
- adds the option (default enabled) that if rollover to negative values occurs the sampler resets the counters. The time (epoch seconds) of the most recent reset is reported in the "last_reset metric". If auto_reset=0 disables the reset process, a single log message occurs should the need for a reset occur.