### PR TITLE
Fix `ldms_xprt_listen_by_name()` for wildcard address

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -3845,7 +3845,8 @@ int ldms_xprt_listen_by_name(ldms_t x, const char *host, const char *port_no,
 	struct addrinfo *ai;
 	struct addrinfo hints = {
 		.ai_family = AF_INET,
-		.ai_socktype = SOCK_STREAM
+		.ai_socktype = SOCK_STREAM,
+		.ai_flags = AI_PASSIVE,
 	};
 	if (host) {
 		rc = getaddrinfo(host, port_no, &hints, &ai);


### PR DESCRIPTION
When the caller provides '*' wild card address to
`ldms_xprt_listen_by_name()`, the expected behavior is to listen to all addresses (0.0.0.0). However, because the AI_PASSIVE has not been specified in the `ai_flags` hint, '*' is resolved to `127.0.0.1` instead of `0.0.0.0`. This patch specified `AI_PASSIVE` in `hint.ai_flags` to fix the issue.