### PR TITLE
Take a store plugin's reference when ldmsd links it to a strgp

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -2506,6 +2506,7 @@ static int strgp_add_handler(ldmsd_req_ctxt_t reqc)
 			goto enomem;
 	}
 
+	__atomic_add_fetch(&store->ref_count, 1, __ATOMIC_SEQ_CST); /* Release in strgp_del */
 	strgp->store = store->store;
 	strgp->plugin_name = strdup(plugin);
 	if (!strgp->plugin_name)

--- a/ldms/src/ldmsd/ldmsd_strgp.c
+++ b/ldms/src/ldmsd/ldmsd_strgp.c
@@ -792,6 +792,7 @@ int ldmsd_strgp_del(const char *strgp_name, ldmsd_sec_ctxt_t ctxt)
 {
 	int rc = 0;
 	ldmsd_strgp_t strgp;
+	struct ldmsd_plugin_cfg *pi;
 
 	pthread_mutex_lock(cfgobj_locks[LDMSD_CFGOBJ_STRGP]);
 	strgp = (ldmsd_strgp_t)__cfgobj_find(strgp_name, LDMSD_CFGOBJ_STRGP);
@@ -812,6 +813,9 @@ int ldmsd_strgp_del(const char *strgp_name, ldmsd_sec_ctxt_t ctxt)
 		rc = EBUSY;
 		goto out_1;
 	}
+
+	pi = container_of(strgp->store, struct ldmsd_plugin_cfg, store);
+	__atomic_sub_fetch(&pi->ref_count, 1, __ATOMIC_SEQ_CST);
 
 	rbt_del(cfgobj_trees[LDMSD_CFGOBJ_STRGP], &strgp->obj.rbn);
 	ldmsd_strgp_put(strgp); /* tree reference */


### PR DESCRIPTION
Without the patch, whenever LDMSD receives a term request for a store plugin, the store plugin's resources will be freed, and the plugin will be unloaded. LDMSD will, then, segfault if the store links to a running storage policy.