### PR TITLE
Add LDMS_V_TIMESTAMP accessor functions

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -3176,6 +3176,11 @@ double ldms_mval_get_double(ldms_mval_t mv)
 #endif
 }
 
+struct ldms_timestamp ldms_mval_get_ts(ldms_mval_t mv)
+{
+	return mv->v_ts;
+}
+
 const char *ldms_mval_array_get_str(ldms_mval_t mv)
 {
 	return mv->a_char;
@@ -3244,6 +3249,11 @@ double ldms_mval_array_get_double(ldms_mval_t mv, int idx)
 	uint64_t tmp = __le64_to_cpu(*(uint64_t*)&mv->a_d[idx]);
 	return *(double *)&tmp;
 #endif
+}
+
+struct ldms_timestamp ldms_mval_array_get_ts(ldms_mval_t mv, int idx)
+{
+	return mv->a_ts[idx];
 }
 
 void __list_append(ldms_heap_t heap, ldms_mval_t lh, ldms_mval_t le)

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -2584,7 +2584,7 @@ void ldms_mval_set_s32(ldms_mval_t mv, int32_t v);
 void ldms_mval_set_s64(ldms_mval_t mv, int64_t v);
 void ldms_mval_set_float(ldms_mval_t mv, float v);
 void ldms_mval_set_double(ldms_mval_t mv, double v);
-
+void ldms_mval_set_ts(ldms_mval_t mv, struct ldms_timestamp v);
 void ldms_mval_array_set_str(ldms_mval_t mv, const char *str, size_t count);
 void ldms_mval_array_set_char(ldms_mval_t mv, int idx, char v);
 void ldms_mval_array_set_u8(ldms_mval_t mv, int idx, uint8_t v);
@@ -2597,6 +2597,7 @@ void ldms_mval_array_set_s32(ldms_mval_t mv, int idx, int32_t v);
 void ldms_mval_array_set_s64(ldms_mval_t mv, int idx, int64_t v);
 void ldms_mval_array_set_float(ldms_mval_t mv, int idx, float v);
 void ldms_mval_array_set_double(ldms_mval_t mv, int idx, double v);
+void ldms_mval_array_set_ts(ldms_mval_t mv, int idx, struct ldms_timestamp v);
 
 /**
  * \brief Get the value from a metric value
@@ -2617,7 +2618,7 @@ int32_t ldms_mval_get_s32(ldms_mval_t mv);
 int64_t ldms_mval_get_s64(ldms_mval_t mv);
 float ldms_mval_get_float(ldms_mval_t mv);
 double ldms_mval_get_double(ldms_mval_t mv);
-
+struct ldms_timestamp ldms_mval_get_ts(ldms_mval_t mv);
 const char *ldms_mval_array_get_str(ldms_mval_t mv);
 char ldms_mval_array_get_char(ldms_mval_t mv, int idx);
 uint8_t ldms_mval_array_get_u8(ldms_mval_t mv, int idx);
@@ -2630,7 +2631,7 @@ int32_t ldms_mval_array_get_s32(ldms_mval_t mv, int idx);
 int64_t ldms_mval_array_get_s64(ldms_mval_t mv, int idx);
 float ldms_mval_array_get_float(ldms_mval_t mv, int idx);
 double ldms_mval_array_get_double(ldms_mval_t mv, int idx);
-
+struct ldms_timestamp ldms_mval_array_get_ts(ldms_mval_t mv, int idx);
 
 /**
  * \brief Append a new value to a list

--- a/ldms/src/core/ldms_core.h
+++ b/ldms/src/core/ldms_core.h
@@ -329,6 +329,7 @@ typedef union ldms_value {
 	int64_t v_s64;
 	float v_f;
 	double v_d;
+	struct ldms_timestamp v_ts;
 	struct ldms_list v_lh;
 	struct ldms_list_entry v_le;
 	struct ldms_record_inst v_rec_inst;
@@ -345,8 +346,7 @@ typedef union ldms_value {
 	int64_t a_s64[OVIS_FLEX_UNION];
 	float a_f[OVIS_FLEX_UNION];
 	double a_d[OVIS_FLEX_UNION];
-
-	struct ldms_timestamp v_ts;
+	struct ldms_timestamp a_ts[OVIS_FLEX_UNION];
 } *ldms_mval_t;
 
 typedef struct ldms_name {


### PR DESCRIPTION
The LDMS_V_TIMESTAMP was added as part of the
decomposition support, but the accessor functions
were never added.