### PR TITLE
Add ldms_list_tail API

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -3306,6 +3306,21 @@ ldms_mval_t ldms_list_first(ldms_set_t s, ldms_mval_t lh, enum ldms_value_type *
 	return (ldms_mval_t)le->v_le.value;
 }
 
+ldms_mval_t ldms_list_last(ldms_set_t s, ldms_mval_t lh, enum ldms_value_type *typ, size_t *count)
+{
+	ldms_mval_t le;
+	if (!lh->v_lh.head)
+		return NULL;
+	if (!s->heap)
+		return NULL;
+	le = ldms_heap_ptr(s->heap, lh->v_lh.tail);
+	if (typ)
+		*typ = le->v_le.type;
+	if (count)
+		*count = le->v_le.count;
+	return (ldms_mval_t)le->v_le.value;
+}
+
 ldms_mval_t ldms_list_next(ldms_set_t s, ldms_mval_t v, enum ldms_value_type *typ, size_t *count)
 {
 	ldms_mval_t le;

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -2673,12 +2673,29 @@ ldms_mval_t ldms_list_append_item(ldms_set_t s, ldms_mval_t lh, enum ldms_value_
  * \param [in]  lh    The list handle.
  * \param [out] typ   If not NULL, \c *typ value is set to the type of the first entry of the list.
  * \param [out] count If not NULL, \c *count is set to the array length if the
- *                    first entry is an array, or 1 if it is not.
+ *                    entry is an array.
  *
  * \retval mval The metric handle of the first entry, or
  * \retval NULL if the list is empty.
  */
 ldms_mval_t ldms_list_first(ldms_set_t s, ldms_mval_t lh, enum ldms_value_type *typ, size_t *count);
+
+/**
+ * \brief Get the last list entry.
+ *
+ * \c lh must be a list. If \c lh is not a list, the function call results in
+ * a garbage value returned or a segmentation fault.
+ *
+ * \param [in]  s     The ldms set handle.
+ * \param [in]  lh    The list handle.
+ * \param [out] typ   If not NULL, \c *typ value is set to the type of the first entry of the list.
+ * \param [out] count If not NULL, \c *count is set to the array length if the
+ *                    entry is an array.
+ *
+ * \retval mval The metric handle of the first entry, or
+ * \retval NULL if the list is empty.
+ */
+ldms_mval_t ldms_list_last(ldms_set_t s, ldms_mval_t lh, enum ldms_value_type *typ, size_t *count);
 
 /**
  * \brief Get the next list entry.


### PR DESCRIPTION
This change adds a function, ldms_list_last(), that returns the tail of a list.