### PR TITLE
thread_stats parameter for daemon_status

### DIFF
--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -135,7 +135,7 @@ LDMSD_CTRL_CMD_MAP = {'usage': {'req_attr': [], 'opt_attr': ['name']},
                       'stream_client_dump': {'req_attr': [], 'opt_attr': []},
                       'stream_status' : {'req_attr': [], 'opt_attr': []},
                       ##### Daemon #####
-                      'daemon_status': {'req_attr': [], 'opt_attr': []},
+                      'daemon_status': {'req_attr': [], 'opt_attr': ['thread_stats']},
                       ##### Misc. #####
                       'greeting': {'req_attr': [], 'opt_attr': ['name', 'offset', 'level', 'test', 'path']},
                       'example': {'req_attr': [], 'opt_attr': []},
@@ -2939,9 +2939,22 @@ class Communicator(object):
         except Exception as e:
             return errno.ENOTCONN, str(e)
 
-    def daemon_status(self):
-        """Query the daemon's status"""
-        req = LDMSD_Request(command_id=LDMSD_Request.DAEMON_STATUS)
+    def daemon_status(self, thread_stats=None):
+        """
+        Query the daemon's status
+        Parameters:
+        - True/False boolean that returns thread statistics in response if True
+        Returns:
+        A tuple of status, data
+        - status is an errno from the errno module
+        - data is the daemon's current status. if thread_stats is True, it
+               also returns the daemon's thread statistics
+        """
+        attr_list = None
+        if thread_stats:
+            attr_list = [ LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.STRING, value='true') ]
+        req = LDMSD_Request(command_id=LDMSD_Request.DAEMON_STATUS,
+                            attrs=attr_list)
         try:
             req.send(self)
             resp = req.receive(self)

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -851,13 +851,17 @@ class LdmsdCmdParser(cmd.Cmd):
     def do_daemon_status(self, arg):
         """
         Report the daemon status
-        Parameters: NONE
+        Keyword Parameter:
+        thread_stats - Keyword to return daemon thread status along with
+                       current daemon status
         """
-        rc, msg = self.comm.daemon_status()
+        arg = self.handle_args('daemon_status', arg)
+        rc, msg = self.comm.daemon_status(arg['thread_stats'])
         if rc == 0:
             msg = fmt_status(msg)
             print(f"Deamon State: {msg['state']}\n")
-            self.display_thread_stats(msg['thread_stats'])
+            if arg['thread_stats']:
+                self.display_thread_stats(msg['thread_stats'])
         else:
             print(f'Error getting daemon status')
 

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -5476,16 +5476,22 @@ out:
 int __daemon_status_json_obj(ldmsd_req_ctxt_t reqc)
 {
 	int rc;
+	char *thread_stats = NULL;
 	char *json_s;
 	size_t json_sz;
 
-	rc = linebuf_printf(reqc, "{\"state\":\"ready\",\n");
+	rc = linebuf_printf(reqc, "{\"state\":\"ready\"");
 	if (rc)
 		return rc;
+	thread_stats = ldmsd_req_attr_str_value_get_by_id(reqc, LDMSD_ATTR_STRING);
+	if (!thread_stats) {
+		rc = linebuf_printf(reqc, "}");
+		return rc;
+	}
 	json_s = __thread_stats_as_json(&json_sz);
 	if (!json_s)
 		return ENOMEM;
-	rc = linebuf_printf(reqc, "\"thread_stats\":%s\n", json_s);
+	rc = linebuf_printf(reqc, ",\n\"thread_stats\":%s\n", json_s);
 	free(json_s);
 	if (rc)
 		return rc;


### PR DESCRIPTION
Add True/False parameter 'thread_stats' to daemon_status to optionally return the daemon's thread statistics in daemon_status response. This reduces the request load for users only seeking the daemon's status