### PR TITLE
Add class variable recv_timeout to Communicator class

### DIFF
--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -857,7 +857,7 @@ class Communicator(object):
     CTRL_STATES = [ INIT, CONNECTED, CLOSED ]
     CFG_CNTR = 0
 
-    def __init__(self, xprt, host, port, auth=None, auth_opt=None):
+    def __init__(self, xprt, host, port, auth=None, auth_opt=None, recv_timeout=5):
         """Create a communicator interface with an LDMS Daemon (LDMSD)
 
         Parameters:
@@ -878,6 +878,7 @@ class Communicator(object):
         self.state = self.INIT
         self.auth = auth
         self.auth_opt = auth_opt
+        self.recv_timeout = recv_timeout
         self.ldms = None
         self.ldms = ldms.Xprt(name=self.xprt, auth=auth, auth_opts=auth_opt)
 
@@ -962,7 +963,7 @@ class Communicator(object):
         if self.state != self.CONNECTED:
             raise RuntimeError("Transport is not connected.")
         try:
-            rsp = self.ldms.recv(timeout=5)
+            rsp = self.ldms.recv(timeout=self.recv_timeout)
         except Exception as e:
             self.close()
             raise ConnectionError(str(e))

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -85,15 +85,23 @@ def cvt_intrvl_off_to_str(interval_us, offset_us):
 
 class LdmsdCmdParser(cmd.Cmd):
     def __init__(self, host = None, port = None, xprt = None, infile=None,
-                 auth=None, auth_opt=None):
+                 auth=None, auth_opt=None, debug=False):
         self.msg_no = 1
 
         if host and port:
-            self.comm = Communicator(xprt,
-                                     host,
-                                     port,
-                                     auth,
-                                     auth_opt)
+            if debug:
+                self.comm = Communicator(xprt,
+                                         host,
+                                         port,
+                                         auth,
+                                         auth_opt,
+                                         recv_timeout=None)
+            else:
+                self.comm = Communicator(xprt,
+                                         host,
+                                         port,
+                                         auth,
+                                         auth_opt)
             self.comm.connect()
             self.prompt = "{0}:{1}:{2}> ".format(xprt, host, port)
         else:
@@ -2168,7 +2176,8 @@ if __name__ == "__main__":
                                    port = args.port,
                                    xprt = args.xprt,
                                    auth = args.auth,
-                                   auth_opt = auth_opt)
+                                   auth_opt = auth_opt,
+                                   debug = args.debug)
 
         if args.source is not None or args.script is not None or args.cmd is not None:
             if args.source is not None:


### PR DESCRIPTION
recv_timeout sets the timeout for a receive_response request.
recv_timeout can be manually set on instantiation of Communicator class, otherwise defaults to 5 seconds.
If ldmsd_controller is called in debug mode, receive_response becomes blocking.