### PR TITLE
add user_debug option to control user job logging of plugin handling messages in slurm_notifier

### DIFF
--- a/ldms/src/sampler/spank/Plugin_slurm_notifier.man
+++ b/ldms/src/sampler/spank/Plugin_slurm_notifier.man
@@ -1,4 +1,4 @@
-.\" Manpage for slurm_notifier
+.\" Man page for slurm_notifier
 .\" Contact ovis-help@ca.sandia.gov to correct errors or typos.
 .TH man 7 "30 Sep 2019" "v4" "SPANK Plugin slurm_notifier man page"
 
@@ -11,6 +11,7 @@ Within plugstack.conf:
 .IR OVIS_PREFIX / LIBDIR /ovis-ldms/libslurm_notifier.so
 .BI stream= STREAM_NAME
 .BI timeout= TIMEOUT_SEC
+.BI [user_debug]
 .BI client= XPRT : HOST : PORT : AUTH
 .RB ...
 .YS
@@ -20,9 +21,8 @@ Within plugstack.conf:
 \fBslurm_notifier\fR is a SPANK plugin that notifies \fBldmsd\fR about job
 events (e.g. job start, job termination) and related information (e.g. job_id,
 task_id, task process ID). The notification is done over \fBldmsd_stream\fR
-publish mechanism. \fBslurm_sampler\fR (see \fBPlugin_slurm_sampler\fR(7)) and
-\fBpapi_sampler\fR (see \fBPlugin_papi_sampler\fR) are known plugins that
-subscribe to the notification.
+publish mechanism. See SUBSCRIBERS below for plugins known to consume
+the spank plugin messages.
 
 .BI stream= STREAM_NAME
 specifies the name of publishing stream. The default value is \fIslurm\fR.
@@ -31,18 +31,28 @@ specifies the name of publishing stream. The default value is \fIslurm\fR.
 is the number of seconds determining the time-out of the LDMS connections
 (default \fI5\fR).
 
+.BI user_debug,
+if present, enables sending certain plugin management debugging messages to the user's
+slurm output.  (default: disabled -- slurm_debug2() receives the messages instead).
+
 .BI client= XPRT : HOST : PORT : AUTH
 specifies \fBldmsd\fR to which \fBslurm_notifier\fR publishes the data.
 The \fIXPRT\fR specifies the type of the transport, which includes
 .BR sock ", " rdma ", " ugni ", and " fabric .
 The \fIHOST\fR is the hostname or the IP address that \fBldmsd\fR resides. The
-\fIPORT\fR is the listeing port of the \fBldmsd\fR. The \fIAUTH\fR is the
+\fIPORT\fR is the listening port of the \fBldmsd\fR. The \fIAUTH\fR is the
 LDMS authentication method that the \fBldmsd\fR uses, which are
 .BR munge ", or " none .
-The \fBclient\fR option can be reapeted to specify multiple \fBldmsd\fR's.
+The \fBclient\fR option can be repeated to specify multiple \fBldmsd\fR's.
 
-.SH BUGS
-No known bugs.
+.SH SUBSCRIBERS
+The following plugins are known to process slurm_notifier messages:
+.nf
+slurm_sampler         (collects slurm job & task data)
+slurm_sampler2        (collects slurm job & task data)
+papi_sampler          (collects PAPI data from tasks identified)
+linux_proc_sampler    (collects /proc data from tasks identified)
+.fi
 
 .SH EXAMPLES
 /etc/slurm/plugstack.conf:
@@ -59,7 +69,8 @@ client=sock:node0:10000:munge
 .SH SEE ALSO
 .nh
 .BR spank (8),
-.BR Plugin_slurm_sampler (8),
-.BR Plugin_papi_sampler (8),
+.BR Plugin_slurm_sampler (7),
+.BR Plugin_papi_sampler (7),
+.BR Plugin_linux_proc_sampler (7),
 .BR ldmsd (8),
 .BR ldms_quickstart (7),

--- a/ldms/src/sampler/spank/slurm_notifier.c
+++ b/ldms/src/sampler/spank/slurm_notifier.c
@@ -74,10 +74,15 @@
 static char *stream;
 #define SLURM_NOTIFY_TIMEOUT 5
 static time_t io_timeout = SLURM_NOTIFY_TIMEOUT;
+static int user_debug = 0;
 
 static const char *stepd_event = "";
 #define DEBUG2(FMT, ...) do { \
+if (user_debug) \
 	printf("slurm_notifier: (%ld) [%s] %s:%d " FMT "\n", \
+	       (long)getpid(), stepd_event, __func__, __LINE__, ##__VA_ARGS__); \
+else \
+	slurm_debug2("slurm_notifier: (%ld) [%s] %s:%d " FMT "\n", \
 	       (long)getpid(), stepd_event, __func__, __LINE__, ##__VA_ARGS__); \
 } while (0)
 
@@ -430,6 +435,9 @@ void setup_clients(int argc, char *argv[], struct client_list *cl)
 	int rc;
 
 	for (rc = 0; rc < argc; rc++) {
+		if (0 == strcasecmp(argv[rc], "user_debug")) {
+			user_debug = 1;
+		}
 		if (0 == strncasecmp(argv[rc], "client", 6)) {
 			add_client(cl, get_arg_value(argv[rc]));
 		}


### PR DESCRIPTION
The output of the slurm notifier DEBUG2 macro is visible in user log files. This is not desired in normal operation. This patch adds the 'user_debug' option to the spank plugin to enable user's job log output when the slurm admin is debugging use of the plugin and to route these DEBUG2 messages to slurm_debug2() otherwise.