### PR TITLE
Fix `as_is` decomposition SEGV when there are no indices

### DIFF
--- a/ldms/src/decomp/as_is/decomp_as_is.c
+++ b/ldms/src/decomp/as_is/decomp_as_is.c
@@ -250,6 +250,8 @@ __decomp_as_is_config(ldmsd_strgp_t strgp, json_entity_t jcfg,
 	rbt_init(&dcfg->row_cfg_rbt, __row_cfg_cmp);
 	dcfg->decomp = __decomp_as_is;
 	dcfg->idx_count = n_idx;
+	if (!n_idx)
+		goto out;
 
 	/* foreach index */
 	j = 0;
@@ -299,6 +301,7 @@ __decomp_as_is_config(ldmsd_strgp_t strgp, json_entity_t jcfg,
 		j++;
 	}
 	assert(j == jidxs->item_count);
+ out:
 
 	return &dcfg->decomp;
 


### PR DESCRIPTION
This has been tested with 1 sampler damon - 1 aggregator daemon with the following config:

- *samp.conf*
```conf
# samp.conf
env HOST=$(hostname)
listen xprt=sock port=10000

load name=meminfo
config name=meminfo instance=${HOST}/meminfo producer=${HOST}
start name=meminfo interval=2000000 offset=0

load name=vmstat
config name=vmstat instance=${HOST}/vmstat producer=${HOST}
start name=vmstat interval=2000000 offset=0
```

- *agg.conf*
```conf
# agg.conf
listen xprt=sock port=10001

load name=store_csv
config name=store_csv path=store buffer=0

prdcr_add name=local host=localhost xprt=sock port=10000 type=active interval=2000000
prdcr_start name=local

strgp_add name=any plugin=store_csv container=any regex=.* decomposition=decomp.json
strgp_start name=any

updtr_add name=all interval=2000000 offset=100000
updtr_prdcr_add name=all regex=.*
updtr_start name=all
```

- *decomp.json*
```json
{
    "type": "flex",
    "decomposition": {
        "the_default": {
            "type": "as_is"
        }
    },
    "digest": {
        "*": "the_default"
    }

}
```

The aggregator successfully produced CSV files for `meminfo` and `vmstat`.