### PR TITLE
Netlink toss changes

### DIFF
--- a/ldms/scripts/examples/linux_proc_sampler
+++ b/ldms/scripts/examples/linux_proc_sampler
@@ -28,6 +28,7 @@ cat << EOF > $LDMSD_RUN/metrics.input
   "argv_sep":"\t",
   "syscalls": "${LDMSD_RUN}/syscalls.map",
   "argv_msg": 1,
+  "log_send": 1,
   "env_msg": 1,
   "env_exclude": "${LDMSD_RUN}/exclude_env",
   "fd_msg": 1,
@@ -39,10 +40,14 @@ cat << EOF > $LDMSD_RUN/metrics.input
         "^/sys/",
         "^/tmp/",
         "^/proc/",
+        "^/proc$",
         "^/ram/tmp/",
         "^/usr/lib",
         "^/usr/share/",
-        "^/opt/ness"
+        "^/opt/ness",
+        "^/ram/opt/ness",
+        "^/ram/var/",
+	"/.nfs0"
     ],
   "published_pid_dir" : "${LDMSD_RUN}/ldms-netlink-tracked",
   "metrics" : [
@@ -64,7 +69,7 @@ EOF
 rm -f $LOGDIR/json*.log
 #valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.txt ${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked &
 #valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.txt ${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked &
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit &
 # uncomment next one to test duplicate handling
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
 VGARGS="--tool=drd --suppressions=/scratch1/baallan/ovis/ldms/scripts/examples/linux_proc_sampler.drd.supp"
@@ -92,7 +97,7 @@ for lc in $(seq 1); do
 #LDMS_LS 1 -v
 	SLEEP 2
 done
-SLEEP 2
+SLEEP 20
 KILL_LDMSD 3 2 1
 file_created $STOREDIR/node/$testname
 file_created $STOREDIR/node/$dsname

--- a/ldms/src/sampler/app_sampler/get_stat_field.c
+++ b/ldms/src/sampler/app_sampler/get_stat_field.c
@@ -1,3 +1,13 @@
+static int64_t uptime()
+{
+	struct sysinfo s_info;
+	int error = sysinfo(&s_info);
+	if(error != 0)
+	{
+		return -1;
+	}
+	return (int64_t)s_info.uptime;
+}
 
 /*
  * Copyright (C) 2014-2018 Canonical Ltd.
@@ -70,7 +80,7 @@ static const char *get_proc_self_stat_field(const char *buf, const int num)
 static int get_timeval_from_tick(uint64_t starttime, struct timeval * const tv)
 {
 	/* from proc_info_get_timeval convert tick since boot to clock */
-	double uptime_secs = 0, secs = 0;
+	double uptime_secs = (double)uptime(), secs = 0;
 	long jiffies;
 	struct timeval now = {.tv_sec = 0, .tv_usec = 0};
 

--- a/ldms/src/sampler/netlink/Makefile.am
+++ b/ldms/src/sampler/netlink/Makefile.am
@@ -23,7 +23,7 @@ slpsinclude_HEADERS = simple_lps.h
 if HAVE_NETLINK
 # ldms-netlink-notifier does not use ldms headers except ovis json.
 sbin_PROGRAMS += ldms-netlink-notifier
-dist_man8_MANS += netlink-notifier.man
+dist_man8_MANS += netlink-notifier.man ldms-notify.man ldms-netlink-notifier.man
 ldms_netlink_notifier_CFLAGS = $(AM_CFLAGS)
 ldms_netlink_notifier_SOURCES = netlink-notifier.c
 ldms_netlink_notifier_LDADD = libsimple_lps.la $(COMMON_LIBADD) -lpthread -lm

--- a/ldms/src/sampler/netlink/ldms-netlink-notifier.man
+++ b/ldms/src/sampler/netlink/ldms-netlink-notifier.man
@@ -1,0 +1,1 @@
+.so man8/netlink-notifier.8

--- a/ldms/src/sampler/netlink/ldms-notify.man
+++ b/ldms/src/sampler/netlink/ldms-notify.man
@@ -1,0 +1,1 @@
+.so man8/netlink-notifier.8

--- a/ldms/src/sampler/netlink/ldms-notify.service
+++ b/ldms/src/sampler/netlink/ldms-notify.service
@@ -4,12 +4,21 @@ After=syslog.target network-online.target
 
 [Service]
 Type=simple
-EnvironmentFile=-/etc/sysconfig/ldms-netlink-notifier.conf
-# one can ignore root owned processes by including -u 1
-# ExecStart=/usr/sbin/ldms-netlink-notifier -u 1 -x -e exec,clone,exit -r
-# get the path defaults from the code or from the environment file.
-ExecStartPre=-/usr/bin/rm -f /var/run/ldms-netlink-tracked/[0-9]*
-ExecStart=/usr/sbin/ldms-netlink-notifier -x -e exec,clone,exit -r
+EnvironmentFile=-/etc/sysconfig/ldms.d/plugins-conf/ldms-netlink-notifier.conf
+
+# Defaults if unspecified: -u 1 -x -e exec,clone,exit -i 0.5 -q
+# may also be overridden by some values in ldms-netlink-notifier.conf.
+# ExecStart=/usr/sbin/ldms-netlink-notifier
+
+# Debugging version : big logs ; do not leave running
+# ExecStart=/usr/sbin/ldms-netlink-notifier -x -e exec,clone,exit -j /var/log/ldms-notify.json -L /var/log/ldms-notify.log -t --ProducerName=%H
+
+# one can ignore root owned processes but not daemons by including -u 1
+# ExecStart=/usr/sbin/ldms-netlink-notifier -x -e exec,clone,exit -u 1 --ProducerName=%H
+
+# get the path defaults from the env vars and ignore daemons
+ExecStart=/usr/sbin/ldms-netlink-notifier -x -e exec,clone,exit -u 1000 --ProducerName=%H
+
 
 [Install]
 WantedBy=multi-user.target

--- a/ldms/src/sampler/netlink/netlink-notifier.man
+++ b/ldms/src/sampler/netlink/netlink-notifier.man
@@ -5,6 +5,9 @@
 .SH NAME
 ldms-netlink-notifier  \- Transmit Linux kernel netlink process life messages to ldmsd streams.
 
+ldms-notify            \- systemd service
+
+
 .SH SYNOPSIS
 ldms-netlink-notifier [OPTION...]
 
@@ -26,8 +29,9 @@ Its messages are mostly compatible with those from the slurm spank based notifie
 -j file	 file to log json messages and transmission status.
 -l	force stdout line buffering.
 -L file	log to file instead of stdout.
--r	run with real time FIFO scheduler.
+-r	run with real time FIFO scheduler (available on some kernels).
 -s	show short process name in debugging.
+-S	suppress stream message publication.
 -t	show debugging trace messages.
 -u umin	ignore processes with uid < umin
 -v lvl  log level for stream library messages. Higher is quieter. Error messages are >= 3.
@@ -80,7 +84,12 @@ The 'short' options do not override the exclude entirely options.
 	 The default is used if env NOTIFIER_TRACK_DIR is not set.
 	 The path given should be on a RAM-based file system for efficiency,
 	 and it should not contain any files except those created by
-	 this daemon.
+	 this daemon. When enabled, track-dir will be populated even if
+	 -S is used to suppress the stream output.
+--component_id=<U64>     set the value of component_id.
+	 If not set, the component_id field is not included in the stream formats produced.
+--ProducerName=<name>    set the value of ProducerName
+	 If not set, the ProducerName field is not included in the stream formats produced.
 .fi
 
 .SH ENVIRONMENT
@@ -116,7 +125,7 @@ be removed when the corresponding pid stopped event is sent.
 These files are not removed when the notifier daemon exits.
 Client applications may validate a file by checking the contents
 against the /proc/$pid/stat content, if it exists.
-Invalid files may be removed by clients or system scripts.
+Invalid files should be removed by clients or system scripts.
 
 
 .SH NOTES
@@ -124,13 +133,17 @@ Invalid files may be removed by clients or system scripts.
 The core of this utility is derived from forkstat(8).
 .PP
 The output of this utility, if used to drive a sampler, usually needs to be consumed on the same node.
-
+.PP
+If not used with a sampler, the --component_id or --ProducerName options are needed
+to add a node identifier to the messages. Normally a process-following sampler that creates sets
+will add the node identifier automatically.
+.PP
 Options are still in development. Several options affect only the trace output.
 .SH EXAMPLES
 .PP
 Run for 30 seconds with screen and json.log test output connecting to the ldmsd from 'ldms-static-test.sh blobwriter' test:
 .nf
-netlink-notifier -t -D 30 -g -u 1 -x  -e exec,clone,exit -r  \\
+netlink-notifier -t -D 30 -g -u 1 -x  -e exec,clone,exit  \\
 	-j json.log --exclude-dir-path=/bin:/sbin:/usr \\
 	--port=61061 --auth=none --reconnect=1"
 .fi
@@ -143,13 +156,13 @@ netlink-notifier
 Run in a systemd .service wrapper, excluding root owned processes.
 .nf
 EnvironmentFile=-/etc/sysconfig/ldms-netlink-notifier.conf
-ExecStart=/usr/sbin/ldms-netlink-notifier -u 1 -x -e exec,clone,exit -r
+ExecStart=/usr/sbin/ldms-netlink-notifier -u 1 -x -e exec,clone,exit
 .fi
 .PP
 Run in a systemd .service wrapper, excluding root owned processes, with debugging files
 .nf
 EnvironmentFile=-/etc/sysconfig/ldms-netlink-notifier.conf
-ExecStart=/usr/sbin/ldms-netlink-notifier -u 1 -x -e exec,clone,exit -r -j /home/user/nl.json -L /home/user/nl.log -t
+ExecStart=/usr/sbin/ldms-netlink-notifier -u 1 -x -e exec,clone,exit -j /home/user/nl.json -L /home/user/nl.log -t --ProducerName=%H
 .fi
 
 

--- a/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ldms-functions.in
+++ b/util/sample_init_scripts/genders/systemd/etc/sysconfig/ldms.d/ldms-functions.in
@@ -634,6 +634,10 @@ start_ldmsd_plugins () {
 	echoq $LDMSD_METRIC_PLUGINS
 	echoq $out
 
+	if test -n "$LDMSD_METRIC_SETS_DEFAULT_AUTHZ";  then
+		echo "metric_sets_default_authz $LDMSD_METRIC_SETS_DEFAULT_AUTHZ" >> $out
+	fi
+
 	producer=$(gender_substitute $host $($NODEATTR $NODEATTRFILE -v $host ldmsd_producer 2>/dev/null))
 	if test -z $producer; then
 		producer=$host
@@ -818,6 +822,7 @@ start_add_hosts () {
 
 generate_aggregator_config () {
 	start_add_hosts $LDMSD_PLUGIN_CONFIG_FILE
+	sed -i -e  's/updtr_add /updtr_add auto_interval=true /' $LDMSD_PLUGIN_CONFIG_FILE
 	return 0
 }
 


### PR DESCRIPTION
Fix bugs, man pages, and options so that linux_proc_sampler +  ( spank and/or netlink pid publisher) works with pushing metric sets.

key bugs fixed:
- uptime was not initialized in computation of process start times.
- netlink messages could not be used for dashboarding process events (lacking node name)
- corner case hit at scale lead to sampler not deleting some sets ( this is not the same as #1141) .
- push sets needed genders-generated updtr to enable auto_interval for all other sets to be correct.
- man page for ldms-notify hard to find for admin.
 