### PR TITLE
Fix double free of serdes_conf in Avro-Kafka store

### DIFF
--- a/ldms/src/store/avro_kafka/Plugin_avro_kafka_store.man
+++ b/ldms/src/store/avro_kafka/Plugin_avro_kafka_store.man
@@ -96,7 +96,7 @@ be substituted with a '.'.
 The avro_kafka_store is used with a storage policy that specifies avro_kafka_store as the
 plugin parameter.
 .PP
-The \fIschema\fR, \fIinstance\fR, \fIproducer\fR and \fIflush\fR strgp_new parameters
+The \fIschema\fR, \fIinstance\fR, \fIproducer\fR and \fIflush\fR strgp_add parameters
 have no affect on how data is stored. If the \fIcontainer\fR parameter is set to any
 value other than an empty string, it will override the bootstrap.servers Kafka configuration
 parameter in the kafka_conf file if present.

--- a/ldms/src/store/avro_kafka/store_avro_kafka.c
+++ b/ldms/src/store/avro_kafka/store_avro_kafka.c
@@ -427,9 +427,6 @@ static void close_store(ldmsd_store_handle_t _sh)
 	if (sh->rd_conf) {
 		rd_kafka_conf_destroy(sh->rd_conf);
 	}
-	if (sh->serdes_conf) {
-		serdes_conf_destroy(sh->serdes_conf);
-	}
 	free(sh);
 }
 


### PR DESCRIPTION
As it turns out serdes_new() frees the associated
configuration context. Freeing again in close()
resulted in a double free. This fixes issue #1146.
