### PR TITLE
Avro name mapping

### DIFF
--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -663,6 +663,20 @@ int ldmsd_row_to_json_object(ldmsd_row_t row, char **str, int *len);
 int ldmsd_row_to_json_avro_schema(ldmsd_row_t row, char **str, size_t *len);
 
 /**
+ * \brief ldmsd_avro_name_get
+ *
+ * Avro names may only contain the characters [A-Za-z0-9\\_\\-]. LDMS metric
+ * names by contrast may characters outside this set. When creating Avro
+ * schema, these LDMS names must be mapped a valid Avro name. The function
+ * returns malloc'd memory that should be freed by the caller when no
+ * long longer needed.
+ *
+ * \param ldms_name The LDMS metric name to be mapped to a valid Avro name
+ * \return char* Pointer to the allocated buffer or NULL if ENOMEM
+ */
+char *ldmsd_avro_name_get(const char *ldms_name);
+
+/**
  * Configure strgp decomposer.
  *
  * The decomposer shall use the \c strgp->decomp generic pointer

--- a/ldms/src/ldmsd/ldmsd_decomp.c
+++ b/ldms/src/ldmsd/ldmsd_decomp.c
@@ -784,7 +784,7 @@ static char get_avro_char(char c)
 {
 	if (isalnum(c))
 		return c;
-	if (c == '_' || c == '-')
+	if (c == '-')
 		return c;
 	return '_';
 }
@@ -796,7 +796,7 @@ char *ldmsd_avro_name_get(const char *ldms_name)
 	while (*ldms_name != '\0') {
 		*avro_name++ = get_avro_char(*ldms_name++);
 	}
-	if (*avro_name)
+	if (avro_name)
 		*avro_name = '\0';
 	return avro_name_buf;
 }

--- a/ldms/src/store/avro_kafka/Plugin_store_avro_kafka.man
+++ b/ldms/src/store/avro_kafka/Plugin_store_avro_kafka.man
@@ -189,6 +189,15 @@ row instance is used to search for a serdes schema. This name is first searched 
 in a local RBT and if not found, the Avro Schema Registry is consulted. If the
 schema is not present in the registry, a new Avro schema is constructed per the
 table above, registered with the schema registry and stored in the local cache.
+
+Note that Avro schema names must contain only the characters [a-zA-Z0-9\\._\\-],
+any characters in the row schema name that do not come from this set
+will be forced to '.'.
+
+A similar mapping is done for Avro value names, however, because these names
+cannot accept the character '.', all invalid characters are mapped to '_'.
+
+These change are made automatically and no errors are generated.
 .PP
 .SS "Encoding"
 .PP
@@ -233,6 +242,18 @@ serdes.schema.url=https://localhost:8081
 .RS 4
 .nf
 strgp_add name=aks plugin=store_avro_kafka container=kafka-broker.int:9092 decomposition=aks-decomp.conf
+strgp_start name=aks
+.fi
+.RE
+.PP
+.SS "Example strg_add command w/o container "
+.PP
+In this example, the strgp_add parameter, container, is set to be ignored by
+store_avro_kafka. In this case, either the default, localhost:9092, or the value
+specified in the rd_kafka_conf file is used.
+.RS 4
+.nf
+strgp_add name=aks plugin=store_avro_kafka container= decomposition=aks-decomp.conf
 strgp_start name=aks
 .fi
 .RE


### PR DESCRIPTION
These changes fix issues with store_avro_kafka that result from the fact the LDMS metric and schema names support many characters that are considered invalid by Avro. 

This change fixes #1136 as well as complaints about how container= is handled by the store.

@morrone, could you please try these out? It fixes the issue(s) for me.