### PR TITLE
Include procnetdev2 man page, and clean up Makefile.am

### DIFF
--- a/ldms/src/sampler/procnetdev2/Makefile.am
+++ b/ldms/src/sampler/procnetdev2/Makefile.am
@@ -1,15 +1,9 @@
-pkglib_LTLIBRARIES =
-lib_LTLIBRARIES =
-dist_man7_MANS =
-dist_man1_MANS =
-
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
 COMMON_LIBADD = -lsampler_base -lldms -lovis_util -lcoll \
 		@LDFLAGS_GETTIME@
 
-if ENABLE_PROCNETDEV
 libprocnetdev2_la_SOURCES = procnetdev2.c
 libprocnetdev2_la_LIBADD = $(COMMON_LIBADD)
-pkglib_LTLIBRARIES += libprocnetdev2.la
-endif
+pkglib_LTLIBRARIES = libprocnetdev2.la
+dist_man7_MANS = Plugin_procnetdev2.man


### PR DESCRIPTION
Include procnetdev2 man page, and clean up Makefile.am

The "if ENABLE_PROCNETDEV" conditional is redundant. It is handled one level up.