### PR TITLE
add spool-on-close option to simplify db ingest from blob_stream_writer

### DIFF
--- a/ldms/scripts/examples/blob_writer
+++ b/ldms/scripts/examples/blob_writer
@@ -2,9 +2,12 @@ export plugname=dstat
 export dsname=$(ldms_dstat_schema_name mmalloc=1 io=1 fd=1 auto-schema=1)
 export dstat_schema=$dsname
 portbase=61060
+# memcheck
 VGARGS="--trace-children=yes --track-origins=yes --leak-check=full --show-leak-kinds=all"
+# drd
+#VGARGS="--trace-children=yes  --tool=drd --trace-mutex=yes"
 # track everything notifier config:
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 10 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 20 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
 #vgon
 LDMSD 1 2
 #vgoff
@@ -18,12 +21,15 @@ SLEEP 1
 SLEEP 1
 SLEEP 1
 SLEEP 1
+MESSAGE "trying rollover via reconfig: $(date +%s)"
+echo "config name=blob_stream_writer path=${STOREDIR} container=blobs stream=slurm timing=1 types=1 spool=1" | \
+ldmsctl -p 61062 -a none -x sock -h localhost
 SLEEP 1
-SLEEP 1
-SLEEP 1
-SLEEP 1
+SLEEP 2
+SLEEP 2
+SLEEP 2
 SLEEP 1
 KILL_LDMSD 1 2
-file_created $STOREDIR/blobs/slurm.TIMING.1*
-file_created $STOREDIR/blobs/slurm.DAT.1*
-file_created $STOREDIR/blobs/slurm.OFFSET.1*
+file_created $STOREDIR/blobs/spool/slurm.TIMING.1*
+file_created $STOREDIR/blobs/spool/slurm.DAT.1*
+file_created $STOREDIR/blobs/spool/slurm.OFFSET.1*

--- a/ldms/scripts/examples/blob_writer.2
+++ b/ldms/scripts/examples/blob_writer.2
@@ -1,5 +1,5 @@
 load name=blob_stream_writer plugin=blob_stream_writer
-config name=blob_stream_writer path=${STOREDIR} container=blobs stream=slurm timing=1 types=1
+config name=blob_stream_writer path=${STOREDIR} container=blobs stream=slurm timing=1 types=1 spool=1
 
 prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
 prdcr_subscribe regex=.* stream=slurm

--- a/ldms/src/sampler/blob_stream/Plugin_blob_stream_writer.man
+++ b/ldms/src/sampler/blob_stream/Plugin_blob_stream_writer.man
@@ -48,6 +48,11 @@ timing=1
 .br
 Enable writing timestamps to a separate file.
 .RE
+.TP
+spool=1
+.br
+Move closed files to the directory <path>/<container>/spool/.
+.RE
 
 .SH OUTPUT FORMAT
 .PP


### PR DESCRIPTION
this also updates the usage string for previously added arguments and simplifies repetitive cleanup code.