### PR TITLE
Update GitHub workflows

### DIFF
--- a/.github/workflows/4.3.3-compat-test.yaml
+++ b/.github/workflows/4.3.3-compat-test.yaml
@@ -326,7 +326,7 @@ jobs:
         for V in 4.3.{3..6}; do
           diff -u /test/${V}.enum /test/HEAD-${V}.enum > /test/enum-${V}.diff
         done
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         path: /test/

--- a/.github/workflows/4.3.3-compat-test.yaml
+++ b/.github/workflows/4.3.3-compat-test.yaml
@@ -35,7 +35,7 @@ jobs:
     container:
         image: ovishpc/ovis-compat-centos7
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sh autogen.sh
     - name: build and install
       run: |

--- a/.github/workflows/build-ddebug-centos7.yaml
+++ b/.github/workflows/build-ddebug-centos7.yaml
@@ -15,7 +15,7 @@ jobs:
     container:
         image: ovishpc/ovis-centos-build:latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sh autogen.sh
     - run: |
         _CFLAGS_=(

--- a/.github/workflows/build-test-centos7.yaml
+++ b/.github/workflows/build-test-centos7.yaml
@@ -12,7 +12,7 @@ jobs:
     container:
         image: ovishpc/ovis-centos-build
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sh autogen.sh
     - run: ./configure CFLAGS="-Wall -Werror"
     - run: make
@@ -22,7 +22,7 @@ jobs:
     container:
         image: ovishpc/ovis-centos-build
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sh autogen.sh
     - run: ./configure
     - run: make distcheck
@@ -32,7 +32,7 @@ jobs:
     container:
         image: ovishpc/ovis-centos-build
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sh autogen.sh
     - run: ./configure --enable-rdma CFLAGS="-Wall -Werror"
     - run: make

--- a/.github/workflows/build-test-ubuntu-22.04.yaml
+++ b/.github/workflows/build-test-ubuntu-22.04.yaml
@@ -12,7 +12,7 @@ jobs:
     container:
         image: ovishpc/ovis-ubuntu-build
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sh autogen.sh
     - run: ./configure CFLAGS="-Wall -Werror"
     - run: make
@@ -22,7 +22,7 @@ jobs:
     container:
         image: ovishpc/ovis-ubuntu-build
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sh autogen.sh
     - run: ./configure
     - run: make distcheck
@@ -32,7 +32,7 @@ jobs:
     container:
         image: ovishpc/ovis-ubuntu-build
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sh autogen.sh
     - run: ./configure --enable-rdma CFLAGS="-Wall -Werror"
     - run: make

--- a/.github/workflows/build-test-ubuntu.yaml
+++ b/.github/workflows/build-test-ubuntu.yaml
@@ -12,7 +12,7 @@ jobs:
     container:
         image: ovishpc/ovis-ubuntu-build
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sh autogen.sh
     - run: ./configure CFLAGS="-Wall -Werror"
     - run: make
@@ -22,7 +22,7 @@ jobs:
     container:
         image: ovishpc/ovis-ubuntu-build
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sh autogen.sh
     - run: ./configure
     - run: make distcheck
@@ -32,7 +32,7 @@ jobs:
     container:
         image: ovishpc/ovis-ubuntu-build
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sh autogen.sh
     - run: ./configure --enable-rdma CFLAGS="-Wall -Werror"
     - run: make

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -15,8 +15,8 @@ jobs:
         image: ovishpc/ovis-ubuntu-build
 
     steps:
-    - uses: actions/checkout@v2
-    # actions/checkout@v2 breaks annotated tags by converting them into
+    - uses: actions/checkout@v3
+    # actions/checkout breaks annotated tags by converting them into
     # lightweight tags, so we need to force fetch the tag again
     # See: https://github.com/actions/checkout/issues/290
     - name: Repair tag

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -31,23 +31,8 @@ jobs:
       run: |
         make dist
         echo TARBALL_NAME=$(ls *.tar.gz | head -1) >> $GITHUB_ENV
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Release
+      uses: softprops/action-gh-release@v1
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
-    - name: Upload Release Asset
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a pload_url See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: ./${{ env.TARBALL_NAME }}
-        asset_name: ${{ env.TARBALL_NAME }}
-        asset_content_type: application/gzip
+        files: |
+          ./${{ env.TARBALL_NAME }}

--- a/.github/workflows/ldms-test-build.yaml
+++ b/.github/workflows/ldms-test-build.yaml
@@ -25,7 +25,7 @@ jobs:
         ../configure --prefix=/opt/ovis
         make
         make install
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sh autogen.sh
     - name: build-ovis
       shell: bash

--- a/.github/workflows/space-check.yaml
+++ b/.github/workflows/space-check.yaml
@@ -8,7 +8,7 @@ jobs:
   space_check:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: |
         set -e
         test -n "${GITHUB_BASE_REF}"

--- a/.github/workflows/test-make-dist.yaml
+++ b/.github/workflows/test-make-dist.yaml
@@ -15,7 +15,7 @@ jobs:
         image: ovishpc/ovis-ubuntu-build
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: autogen
       run: sh autogen.sh
     - name: configure


### PR DESCRIPTION
Github actions are warning about:

>Create Release
>Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/create-release@v1, >actions/upload-release-asset@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Updating to newer versions of actions/checkout and actions/upload-artifact help with that.

Also, we replace actions/upload-release-asset with softprops/action-gh-release. Github has abandoned work on actions/upload-release-asset, and softprops/actions-gh-release is one of the suggested replacements. It seems to do what we need.
