### PR TITLE
rdc_sampler: Remove rdc.h hack, change configure options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,22 +138,21 @@ m4_ifndef([PKG_CHECK_MODULES],
       [m4_fatal([pkg.m4 not found. Please install pkg-config (Ubuntu) or pkgconfig (RHEL) package])])
 PKG_PROG_PKG_CONFIG
 
-dnl RDC defaults to no instead of search because amd currently recommends
-dnl multiple non-default path installations (/opt).
+AC_LIB_HAVE_LINKFLAGS([rdc_bootstrap], [], [
+#include <rdc/rdc.h>
+])
+AM_CONDITIONAL([HAVE_LIBRDC_BOOTSTRAP], [test "x$HAVE_LIBRDC_BOOTSTRAP" = xyes])
+
 AC_ARG_ENABLE([rdc],
-	[AS_HELP_STRING([--enable-rdc], [attempt components that depend upon AMD rdc tooling @<:@default=no@:>@ for GPUs. Set RDC_CFLAGS=-I$rdcinclude and RDC_LIBS=-L$rdclibdir])],
+	[AS_HELP_STRING([--enable-rdc], [Include components that depend upon AMD rdc tooling. @<:@default=no@:>@ for GPUs.])],
 	[],
-	[enable_rdc="no"])
-if test "$enable_rdc" != "no"; then
-    PKG_CHECK_MODULES([RDC], [rdc],
-		      [AC_DEFINE([HAVE_RDC],[1],[if AMD rdc module present.])],
-		      AC_MSG_ERROR([pkg-config rdc failed])
-		      )
-    AC_MSG_RESULT([rdc include: $RDC_CFLAGS])
-    AC_MSG_RESULT([rdc lib: $RDC_LIBS])
-    HAVE_RDC=yes
-fi
-AM_CONDITIONAL([ENABLE_RDC], [test "x$HAVE_RDC" = xyes])
+	[enable_rdc="check"])
+AS_IF([test "x$enable_rdc" = xyes],[
+	AS_IF([test "x$HAVE_LIBRDC_BOOTSTRAP" = xno],[
+		AC_MSG_ERROR([librdc_bootstrap or rdc/rdc.h not found])
+	])
+])
+AM_CONDITIONAL([ENABLE_RDC], [test "x$enable_rdc" != xno -a "x$HAVE_LIBRDC_BOOTSTRAP" = xyes])
 
 have_zap=0
 

--- a/ldms/src/sampler/rdc_sampler/Makefile.am
+++ b/ldms/src/sampler/rdc_sampler/Makefile.am
@@ -1,47 +1,32 @@
 ACLOCAL_AMFLAGS = -I m4
-pkglib_LTLIBRARIES =
-lib_LTLIBRARIES =
-bin_SCRIPTS=
-bin_PROGRAMS=
-dist_man7_MANS =
-dist_man1_MANS =
-EXTRA_DIST =
-
-BUILT_SOURCES=rdc.h
-# at least for rocm 4.3 and 4.5, the rdc header is broken wrt gcc4 - gcc8
-# this patches it to a local copy.
-RDC_INC=$(subst -I,,$(RDC_CFLAGS))
-rdc.h: $(RDC_INC)/rdc/rdc.h
-	mkdir -p rdc
-	sed -e 's/^const uint32_t MAX_TEST_CASES =  RDC_DIAG_TEST_LAST - RDC_DIAG_TEST_FIRST + 1;/#define MAX_TEST_CASES (RDC_DIAG_TEST_LAST - RDC_DIAG_TEST_FIRST + 1)/' $(RDC_INC)/rdc/rdc.h > rdc/rdc.h
 
 AM_CPPFLAGS = @OVIS_INCLUDE_ABS@
 AM_LDFLAGS = @OVIS_LIB_ABS@
-COMMON_LIBADD = $(top_builddir)/ldms/src/sampler/libsampler_base.la \
-		$(top_builddir)/ldms/src/ldmsd/libldmsd_plugattr.la \
-		$(top_builddir)/ldms/src/core/libldms.la \
-		@LDFLAGS_GETTIME@ \
-		$(top_builddir)/lib/src/ovis_util/libovis_util.la \
-		$(top_builddir)/lib/src/coll/libcoll.la
 
-rdclib = -lrdc_bootstrap
-
+pkglib_LTLIBRARIES = librdc_sampler.la
 librdc_sampler_la_SOURCES = rdc_plugin.c rdcinfo.c rdcinfo.h
-librdc_sampler_la_CFLAGS  = $(AM_CFLAGS) $(RDC_CFLAGS)
-librdc_sampler_la_LDFLAGS = $(AM_LDFLAGS) $(RDC_LIBS)
-librdc_sampler_la_LIBADD  = $(COMMON_LIBADD) $(rdclib)
-pkglib_LTLIBRARIES += librdc_sampler.la
+librdc_sampler_la_CFLAGS  = $(AM_CFLAGS)
+librdc_sampler_la_LDFLAGS = $(AM_LDFLAGS)
+librdc_sampler_la_LIBADD  = \
+	$(LTLIBRDC_BOOTSTRAP) \
+	$(top_builddir)/ldms/src/sampler/libsampler_base.la \
+	$(top_builddir)/ldms/src/ldmsd/libldmsd_plugattr.la \
+	$(top_builddir)/ldms/src/core/libldms.la \
+	@LDFLAGS_GETTIME@ \
+	$(top_builddir)/lib/src/ovis_util/libovis_util.la \
+	$(top_builddir)/lib/src/coll/libcoll.la
 
 
-bin_PROGRAMS += ldms_rdc_schema_name
-dist_man7_MANS += Plugin_rdc_sampler.man
-dist_man1_MANS += ldms_rdc_schema_name.man
-
+bin_PROGRAMS = ldms_rdc_schema_name
 ldms_rdc_schema_name_SOURCES = rdcinfo.c
-ldms_rdc_schema_name_CFLAGS = $(AM_CFLAGS) -DMAIN $(RDC_CFLAGS)
-ldms_rdc_schema_name_LDFLAGS = $(AM_LDFLAGS) $(RDC_LIBS) $(rdclib)
+ldms_rdc_schema_name_CFLAGS = $(AM_CFLAGS) -DMAIN
+ldms_rdc_schema_name_LDFLAGS = $(AM_LDFLAG)
 ldms_rdc_schema_name_LDADD = \
+	$(LIBRDC_BOOTSTRAP) \
 	$(top_builddir)/ldms/src/ldmsd/libldmsd_plugattr.la \
 	$(top_builddir)/ldms/src/core/libldms.la \
 	$(top_builddir)/lib/src/ovis_util/libovis_util.la \
 	$(top_builddir)/lib/src/coll/libcoll.la
+
+dist_man7_MANS = Plugin_rdc_sampler.man
+dist_man1_MANS = ldms_rdc_schema_name.man


### PR DESCRIPTION
In ROCM 5.5.0, rdc.h has been fixed so that it compiles under gcc. As a result we can drop our hack to fix rdc.h on the fly during the build.

NOTE: This will require anyone using librdc_bootstrap to have ROCM 5.5.0 or later.

The ROCM source tree has seen movement towards a more standardized structure, so also convert to using the AC_LIB_HAVE_LINKFLAGS macro. If ROCM is not installed in the standard search path, the path to librdc_bootstrap can be specified with a single
--with-librdc_boostrap-prefix option. For instance:

  ./configure --enable-rdc --with-librdc_bootstrap-prefix=/opt/rocm-5.5.0