### PR TITLE
Add ldms_schema_name_get API

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -66,6 +66,7 @@
 #include <mmalloc/mmalloc.h>
 #include <pthread.h>
 #include <asm/byteorder.h>
+#include <ctype.h>
 #include "ovis_util/os_util.h"
 #include "ldms.h"
 #include "ldms_xprt.h"
@@ -1193,34 +1194,6 @@ static unsigned char hex_int[] = {
 	[255] = 0,
 };
 
-static unsigned char hex_valid[] = {
-	['0'] = 1,
-	['1'] = 1,
-	['2'] = 1,
-	['3'] = 1,
-	['4'] = 1,
-	['5'] = 1,
-	['6'] = 1,
-	['7'] = 1,
-	['8'] = 1,
-	['9'] = 1,
-
-	['A'] = 1,
-	['a'] = 1,
-	['B'] = 1,
-	['b'] = 1,
-	['C'] = 1,
-	['c'] = 1,
-	['D'] = 1,
-	['d'] = 1,
-	['E'] = 1,
-	['e'] = 1,
-	['F'] = 1,
-	['f'] = 1,
-
-	[255] = 0,
-};
-
 int ldms_str_digest(const char *str, ldms_digest_t digest)
 {
 	int len = strlen(str);
@@ -1229,7 +1202,7 @@ int ldms_str_digest(const char *str, ldms_digest_t digest)
 	if (len != 2*sizeof(digest->digest))
 		return EINVAL;
 	for (c = (unsigned char*)str; *c; c += 2) {
-		if (!hex_valid[*c] || !hex_valid[*(c+1)])
+		if (!isxdigit(*c) && !isxdigit(*(c+1)))
 			return EINVAL;
 		*d = (hex_int[*c]<<4) | (hex_int[*(c+1)]);
 		d += 1;
@@ -1317,6 +1290,11 @@ void ldms_schema_delete(ldms_schema_t schema)
 		EVP_MD_CTX_destroy(schema->evp_ctx);
 	}
 	free(schema);
+}
+
+const char *ldms_schema_name_get(ldms_schema_t schema)
+{
+	return schema->name;
 }
 
 int ldms_schema_metric_count_get(ldms_schema_t schema)
@@ -1436,7 +1414,7 @@ int _ldms_set_ref_put(struct ldms_set *set, const char *name,
 
 /* in: name, schema;
  * out: set_array_card, meta_sz, array_data_sz assigned.
- * \return 0 on error, or size of set if allocated from name, schema.
+ * return 0 on error, or size of set if allocated from name, schema.
  * sets errno if error.
  */
 static size_t compute_set_sizes(const char *instance_name, ldms_schema_t schema,
@@ -1530,7 +1508,7 @@ void __init_rec_array(ldms_set_t set, ldms_schema_t schema)
 			for (j = 0; j < ra->mdef.count; j++) {
 				/* init each rec_inst in the array */
 				rec_inst = ldms_ptr_(void, rec_array->data, j*ra->inst_sz);
-				rec_inst->record_type = rec_array->rec_type;
+				rec_inst->rec_type = rec_array->rec_type;
 				rec_inst->set_data_off = __cpu_to_le32(ldms_off_(dh, rec_inst));
 				rec_inst->hdr.flags = LDMS_RECORD_F_INST;
 			}
@@ -1648,6 +1626,9 @@ ldms_set_t ldms_set_create(const char *instance_name,
 
 		/* Build the descriptor */
 		__make_mdesc(vd, md, &value_off);
+		if (vd->vd_type == LDMS_V_RECORD_ARRAY) {
+			value_off += (md->count * md->data_sz);
+		}
 
 		/* Advance to next descriptor */
 		metric_idx++;
@@ -1671,7 +1652,7 @@ ldms_set_t ldms_set_create(const char *instance_name,
 		vd->vd_data_offset = __cpu_to_le32(value_off);
 		if (vd->vd_type != LDMS_V_RECORD_TYPE) {
 			value_off += __ldms_value_size_get(vd->vd_type,
-					__le32_to_cpu(vd->vd_array_count));
+							   __le32_to_cpu(vd->vd_array_count));
 			goto next;
 		}
 		/* Making LDMS_V_RECORD_TYPE */
@@ -3319,7 +3300,8 @@ void __list_append(ldms_heap_t heap, ldms_mval_t lh, ldms_mval_t le)
 	le->v_le.next = 0;
 }
 
-ldms_mval_t ldms_list_append_item(ldms_set_t s, ldms_mval_t lh, enum ldms_value_type typ, size_t count)
+ldms_mval_t ldms_list_append_item(ldms_set_t s, ldms_mval_t lh,
+				  enum ldms_value_type typ, size_t count)
 {
 	ldms_mval_t le;
 	size_t value_sz = __ldms_value_size_get(typ, count);
@@ -3979,7 +3961,7 @@ ldms_mval_t ldms_record_alloc(ldms_set_t set, int metric_id)
 	list_ent->count = __cpu_to_le32(1);
 	rec_inst = (void*)list_ent->value;
 	rec_inst->hdr.flags = __cpu_to_le32(LDMS_RECORD_F_INST);
-	rec_inst->record_type = __cpu_to_le32(metric_id);
+	rec_inst->rec_type = __cpu_to_le32(metric_id);
 	rec_inst->set_data_off = __cpu_to_le32(ldms_off_(set->data, rec_inst));
 	return (void*)rec_inst;
 
@@ -4001,7 +3983,7 @@ __rec_type(struct ldms_record_inst *rec_inst, ldms_mdesc_t *mdesc,
 	struct ldms_data_hdr *data;
 	ldms_mdesc_t vd;
 	struct ldms_record_type *rec_type;
-	int type_idx = __le32_to_cpu(rec_inst->record_type);
+	int type_idx = __le32_to_cpu(rec_inst->rec_type);
 
 	if (!rec_inst)
 		return NULL;
@@ -4050,7 +4032,7 @@ int ldms_record_type_get(ldms_mval_t mval)
 	rec_type = __rec_type(rec_inst, &mdesc, NULL, NULL);
 	if (!rec_type || mdesc->vd_type != LDMS_V_RECORD_TYPE)
 		return -EINVAL;
-	return __le32_to_cpu(rec_inst->record_type);
+	return __le32_to_cpu(rec_inst->rec_type);
 }
 
 int ldms_record_metric_find(ldms_mval_t mval, const char *name)
@@ -4121,13 +4103,13 @@ int ldms_schema_record_array_add(ldms_schema_t s, const char *name,
 	ra_def->mdef.type = LDMS_V_RECORD_ARRAY;
 	ra_def->mdef.flags = LDMS_MDESC_F_DATA;
 	ra_def->mdef.count = array_len;
-	/* this only calculate meta_sz (for name and mdesc) */
+	/* this only calculates meta_sz (for name and mdesc) */
 	__ldms_metric_size_get(name, NULL, LDMS_V_RECORD_ARRAY,
 			ra_def->mdef.count, &ra_def->mdef.meta_sz,
 			&ra_def->mdef.data_sz);
-	/* we need to re-calculate the data_sz as the info provided to the
+	/* We need to re-calculate the data_sz as the info provided to the
 	 * generic size calculation is not enough. */
-	data_sz = sizeof(struct ldms_record_array) + array_len*rec_def->inst_sz;
+	data_sz = sizeof(struct ldms_record_array) + array_len * rec_def->inst_sz;
 	ra_def->mdef.data_sz = roundup(data_sz, 8);
 	ra_def->inst_sz = rec_def->inst_sz;
 	ra_def->rec_type = rec_def->metric_id;
@@ -4186,19 +4168,19 @@ int ldms_record_metric_add(ldms_record_t rec_def, const char *name,
 	mdef = calloc(1, sizeof(*mdef));
 	if (!mdef)
 		return -ENOMEM;
-        if (name != NULL) {
-                mdef->name = strdup(name);
-                if (!mdef->name)
-                        goto err_1;
-        } else {
-                errno = EINVAL;
-                goto err_1;
-        }
-        if (unit != NULL) {
-                mdef->unit = strdup(unit);
-                if (!mdef->unit)
-                        goto err_2;
-        }
+	if (name != NULL) {
+		mdef->name = strdup(name);
+		if (!mdef->name)
+			goto err_1;
+	} else {
+		errno = EINVAL;
+		goto err_1;
+	}
+	if (unit != NULL) {
+		mdef->unit = strdup(unit);
+		if (!mdef->unit)
+			goto err_2;
+	}
 	mdef->type = type;
 	mdef->count = count;
 

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -343,33 +343,31 @@ typedef struct ldms_record *ldms_record_t;
  * \li \b const\ char\ *name=ldms_record_metric_unit_get(rec_inst, i) returns
  *     the unit of the i_th member of the record.
  *
- * To use the record, first the application needs to create a record definition
- * (\c rec_def) with \c ldms_record_create() and add members into the record
- * definition with \c ldms_record_metric_add(). Then, the \c rec_def must be
- * added into the schema with \c ldms_schema_record_add() so that the record
- * definition is stored in the LDMS schema and will be available to the set
- * created with the schema.
+ * To use the record, first the application needs to create a record
+ * definition (\c rec_def) with \c ldms_record_create() and add
+ * members into the record definition with \c ldms_record_metric_add().
+ * Once all record members are added, the \c rec_def must be added to
+ * the schema with \c ldms_schema_record_add().
  *
- * The instances of the record is dynamically created and reside in the heap
- * memory of the set and the peer can reach it through \c list iteration.
- * \c ldms_record_heap_size_get() determines the size of the LDMS heap memory
- * required for a given record. To support the maximum of \c N records, simply
- * multiply the recrod size with \c N and supply it to
- * \c ldms_schema_metric_list_add() when defining a list of the records in the
- * schema so that the schema will know the size of the heap required.
+ * An instance of a record is dynamically created and resides in \c set-heap
+ * memory. \c ldms_record_heap_size_get() returns the size of the record in
+ * the LDMS heap. This is useful when computing the appropriate \c heap-size
+ * value for the \c ldms_set_new_with_heap() function.
  *
  * \c ldms_record_alloc() allocate a new record instance (\c rec_inst).
- * The \c rec_inst must be appended into the list by calling
- * \c ldms_list_append_record() or the peer won't be able to reach it.
- * \c ldms_record_metric_get() returns the metric value pointer that
- * can be used to directly access the metric in the record. The caller must
- * handle data format conversion. \c ldms_record_get_XXX() and
- * \c ldms_record_array_get_XXX() are convenient record metric getters that
- * handle the data format conversion for you. \c ldms_record_set_XXX() and
- * \c ldms_record_array_set_XXX() are the convenient record metric setters that
- * handle data conversion and data generation number increment. If the
- * application decides to manipulate the metric value directly, it must call
- * \c ldms_metric_modify() to increment the data generation number.
+ * A \c rec_inst must be a member of a list, \c ldms_list_append_record()
+ * or an ldms_record_array.
+ *
+ * \c ldms_record_metric_get() returns an ldms_mval_t that can be used
+ * to access the metric in the record. A set of convenience functions
+ * \c ldms_record_get_XXX() and \c ldms_record_array_get_XXX() will
+ * return values from records.
+ *
+ * \c ldms_record_set_XXX() and \c ldms_record_array_set_XXX() are a
+ * set of record metric setters that handle data conversion and data
+ * generation number increment. If the application decides to
+ * manipulate the metric value directly, it must call \c
+ * ldms_metric_modify() to increment the data generation number.
  *
  * Example:
  * \code
@@ -383,29 +381,28 @@ typedef struct ldms_record *ldms_record_t;
  * int i_name = ldms_record_metric_add(rec_def, "name", NULL, LDMS_V_CHAR_ARRAY, 32);
  * int i_ctrs = ldms_record_metric_add(rec_def, "counters", NULL, * LDMS_V_U64_ARRAY, 4);
  *
- * // calculate required heap size to support 16 devices (records)
+ * // Calculate the required heap size to support 16 devices (records)
  * size_t heap_sz = 16 * ldms_record_heap_size_get(rec_def);
  *
- * // create schema
+ * // Create a schema
  * ldms_schema_t schema = ldms_schema_new("my_schema");
  *
- * // add record definition to the schema
+ * // Add a record definition to the schema
  * int rec_def_idx = ldms_schema_record_add(schema, rec_def);
  *
- * // add a list to the schema with the heap_sz calculated from above.
- * // The list will contain the records (max 16 records).
+ * // Add a list to the schema with the heap_sz calculated above.
  * int lh_idx = ldms_schema_metric_list_add(schema, "my_list", NULL, heap_sz);
  *
  * ldms_set_t set = ldms_set_new("my_set", schema);
  *
  * ldms_mval_t new_record(ldms_set_t set, const char *name)
  * {
- *     // allocate new record
+ *     // Allocate a record
  *     ldms_mval_t rec_inst = ldms_record_alloc(set, rec_def_idx);
  *
  *     ldms_mval_t nm = ldms_record_metric_get(rec_inst, i_name);
- *     // set the name
- *     strncpy(nm.a_char, name, strlen(name)+1);
+ *     // Set the name
+ *     strncpy(nm.a_char, name, strlen(name) + 1);
  *     return rec_inst;
  * }
  *
@@ -431,7 +428,7 @@ typedef struct ldms_record *ldms_record_t;
  * ldms_list_append_record(set, lh, rec0);
  * ldms_list_append_record(set, lh, rec1);
  *
- * // iterating through the records in the list and update the counters
+ * // Iterate through the records in the list and update the record contents
  * enum ldms_value_type type;
  * size_t array_len;
  * ldms_mval_t rec;
@@ -1738,6 +1735,14 @@ ldms_schema_t ldms_schema_from_template(const char *name,
 			int mid[]);
 
 /**
+ * \brief Return the schema name
+ *
+ * \param schema The schema handle
+ * \returns The schema name
+ */
+const char *ldms_schema_name_get(ldms_schema_t schema);
+
+/**
  * \brief Write a JSON representation of the schema to a file
  *
  * \param schema The schema handle
@@ -2372,8 +2377,8 @@ uint64_t ldms_set_data_gn_get(ldms_set_t s);
 /**
  * \brief Get the heap generation number.
  *
- * The heap generation number get incremented when \c ldms_heap_alloc() or
- * \c ldms_heap_free() is called.
+ * The heap generation number is incremented when \c ldms_heap_alloc() or
+ * \c ldms_heap_free() are called.
  *
  * \param s	The ldms_set_t handle.
  * \returns	The 64bit heap generation number.

--- a/ldms/src/core/ldms_core.h
+++ b/ldms/src/core/ldms_core.h
@@ -261,8 +261,6 @@ enum ldms_value_type {
 	LDMS_V_LAST = LDMS_V_TIMESTAMP
 };
 
-#define LDMS_RECORD_FIELD_INST 255
-
 #define LDMS_RECORD_F_TYPE 1
 #define LDMS_RECORD_F_INST 2
 typedef struct ldms_record_hdr {
@@ -293,21 +291,21 @@ typedef struct ldms_record_hdr {
  */
 typedef struct ldms_record_type {
 	struct ldms_record_hdr hdr;
-	int n; /* number of members */
-	int inst_sz; /* the size of the record instance */
-	int dict[OVIS_FLEX]; /* dict[i] is an offset to mdesc[i] */
+	int n;			/* number of members */
+	int inst_sz;		/* the size of the record instance */
+	int dict[OVIS_FLEX];	/* dict[i] is an offset to mdesc[i] */
 } *ldms_record_type_t;
 
 typedef struct ldms_record_inst {
 	struct ldms_record_hdr hdr;
-	uint32_t set_data_off; /* offset from data section */
-	uint32_t record_type; /* record type reference (set-metric index) */
+	uint32_t set_data_off;	/* offset from data section */
+	uint32_t rec_type;	/* index or record type */
 	char rec_data[OVIS_FLEX_UNION]; /* data of the record */
 } *ldms_record_inst_t;
 
 typedef struct ldms_record_array {
 	int inst_sz;
-	int rec_type; /* reference to rec_type */
+	int rec_type;		/* reference to rec_type */
 	int array_len;
 	char data[OVIS_FLEX];
 } *ldms_record_array_t;


### PR DESCRIPTION
- Add an API that returns an LDMS schema name given the ldms_schema_t structure.
- Remove unnecessary x-digit code that is part of libc in ctype.h
- Fix bug in LDMS_V_RECORD_ARRAY logic that miscalculates offset of next metric
- Tweak record and record-array documentation