### PR TITLE
Increment row count in store_csv commit_rows

### DIFF
--- a/ldms/src/store/store_csv.c
+++ b/ldms/src/store/store_csv.c
@@ -2308,6 +2308,7 @@ commit_rows(ldmsd_strgp_t strgp, ldms_set_t set,
 
 		/* write row */
 		store_row(strgp, set, rbn->s_handle, row);
+		rbn->s_handle->store_count++;
 	}
 	return 0;
 }


### PR DESCRIPTION
The commit_rows() function for decomposition did not increment the row count. This effectively disabled roll-over when using decomposition with the CSV store.