### PR TITLE
Check for null val in __jdict_str

### DIFF
--- a/ldms/src/ldmsd/ldmsd_decomp.c
+++ b/ldms/src/ldmsd/ldmsd_decomp.c
@@ -98,7 +98,7 @@ static json_str_t __jdict_str(json_entity_t dict, const char *key)
 	json_entity_t val;
 
 	val = __jdict_ent(dict, key);
-	if (val->type != JSON_STRING_VALUE) {
+	if (!val || val->type != JSON_STRING_VALUE) {
 		errno = EINVAL;
 		return NULL;
 	}


### PR DESCRIPTION
Check for null before comparing dictionary value type.
Missing "type" attribute in decomposition json file will cause ldmsd to crash with segfault