### PR TITLE
Add the log_level cmd as a replacement of the loglevel command

### DIFF
--- a/ldms/man/ldmsctl.man
+++ b/ldms/man/ldmsctl.man
@@ -649,6 +649,9 @@ The stream name
 .SH LDMS DAEMON COMMAND SYNTAX
 .SS Changing the log levels of LDMSD infrastructures
 .BR loglevel
+attr=<value> (deprecated)
+
+.BR log_level
 attr=<value>
 .TP
 .BI level " string"

--- a/ldms/man/ldmsd_controller.man
+++ b/ldms/man/ldmsd_controller.man
@@ -714,6 +714,9 @@ The stream name
 .SH LDMS DAEMON COMMAND SYNTAX
 .SS Changing the log levels of LDMSD infrastructures
 .BR loglevel
+attr=<value> (deprecated)
+
+.BR log_level
 attr=<value>
 .TP
 .BI level " string"

--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -76,7 +76,7 @@ LDMSD_CTRL_CMD_MAP = {'usage': {'req_attr': [], 'opt_attr': ['name']},
                       'udata_regex': {'req_attr': ['instance', 'regex', 'base'],
                                       'opt_attr': ['incr']},
                       'version': {'req_attr': [], 'opt_attr': []},
-                      'loglevel': {'req_attr': ['level'],
+                      'log_level': {'req_attr': ['level'],
                                    'opt_attr': ['name', 'regex']},
                       'include': {'req_attr': ['path'] },
                       'env': {'req_attr': []},
@@ -613,7 +613,7 @@ class LDMSD_Request(object):
 
             'udata': {'id': SET_UDATA},
             'udata_regex': {'id': SET_UDATA_REGEX},
-            'loglevel': {'id': VERBOSITY_CHANGE},
+            'log_level': {'id': VERBOSITY_CHANGE},
             'daemon_status': {'id': DAEMON_STATUS},
             'version': {'id': VERSION},
             'env': {'id': ENV},
@@ -1741,7 +1741,7 @@ class Communicator(object):
             self.close()
             return errno.ENOTCONN, str(e)
 
-    def loglevel(self, level, name = None, regex = None):
+    def log_level(self, level, name = None, regex = None):
         """
         Change the verbosity level of ldmsd
 

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -1344,6 +1344,13 @@ class LdmsdCmdParser(cmd.Cmd):
     def complete_udata_regex(self, text, line, begidx, endidx):
         return self.__complete_attr_list('udata_regex', text)
 
+    def __log_level(self, arg):
+        arg = self.handle_args('log_level', arg)
+        if arg:
+            rc, msg = self.comm.log_level(arg['level'], arg['name'], arg['regex'])
+            if rc:
+                print(f'Error changing log level: {msg}')
+
     def do_loglevel(self, arg):
         """
         Changing the verbosity level of ldmsd loggers
@@ -1364,14 +1371,36 @@ class LdmsdCmdParser(cmd.Cmd):
            [regex=]  A regular expression matching logger names,
                      e.g., xprt.* to change the transport-related log levels.
         """
-        arg = self.handle_args('loglevel', arg)
-        if arg:
-            rc, msg = self.comm.loglevel(arg['level'], arg['name'], arg['regex'])
-            if rc:
-                print(f'Error changing log level: {msg}')
+        print(f'`loglevel` is being deprecated. Please use `log_level` in the future.')
+        self.__log_level(arg)
 
     def complete_loglevel(self, text, line, begidx, endidx):
-        return self.__complete_attr_list('loglevel', text)
+        return self.__complete_attr_list('log_level', text)
+
+    def do_log_level(self, arg):
+        """
+        Changing the verbosity level of ldmsd loggers
+
+        If neither 'name' or 'regex' is given, the command will change the default log level.
+
+        Parameters:
+           level=    The choices are "default", "quiet",
+                     a comma-separated list of DEBUG, INFO, WARN, ERROR, and CRITICAL.
+                    It is case insensitive.
+
+                     Note that "<level>," and "<level>" give different results.
+                     "<level>" -- a single level name -- set the log level
+                     to the given level and all the more severity levels.
+                     In contrast, "<level>," -- a level name followed by a comma --
+                     set the log level to only the given level.
+           [name=]   A logger name
+           [regex=]  A regular expression matching logger names,
+                     e.g., xprt.* to change the transport-related log levels.
+        """
+        self.__log_level(arg)
+
+    def complete_log_level(self, text, line, begidx, endidx):
+        return self.__complete_attr_list('log_level', text)
 
     def do_logrotate(self, arg):
         """

--- a/ldms/src/ldmsd/ldmsctl.c
+++ b/ldms/src/ldmsd/ldmsctl.c
@@ -411,7 +411,7 @@ static void help_oneshot()
 		"                 the second= from now.\n");
 }
 
-static void help_loglevel()
+static void help_log_level()
 {
 	printf( "\nChange the verbosity level of ldmsd\n\n"
 		"Parameters:\n"
@@ -2503,8 +2503,9 @@ static struct command command_tbl[] = {
 	{ "help", LDMSCTL_HELP, handle_help, NULL, NULL },
 	{ "listen", LDMSD_LISTEN_REQ, NULL, help_listen, resp_generic },
 	{ "load", LDMSD_PLUGN_LOAD_REQ, NULL, help_load, resp_generic },
+	{ "log_level", LDMSD_VERBOSE_REQ, NULL, help_log_level, resp_generic },
 	{ "log_status", LDMSD_LOG_STATUS_REQ, NULL, help_log_status, resp_log_status },
-	{ "loglevel", LDMSD_VERBOSE_REQ, NULL, help_loglevel, resp_generic },
+	{ "loglevel", LDMSD_VERBOSE_REQ, NULL, help_log_level, resp_generic }, /* It is being deprecated. */
 	{ "metric_sets_default_authz", LDMSD_SET_DEFAULT_AUTHZ_REQ, NULL,
 			help_metric_sets_default_authz, resp_generic },
 	{ "oneshot", LDMSD_ONESHOT_REQ, NULL, help_oneshot, resp_generic },
@@ -2670,6 +2671,10 @@ static int __handle_cmd(struct ldmsctl_ctrl *ctrl, char *cmd_str)
 		printf("Unrecognized command '%s'\n", key.token);
 		free(dummy);
 		return 0;
+	}
+
+	if (0 == strcasecmp("loglevel", key.token)) {
+		printf("`loglevel` is being depreated. Please use `log_level` in the future.\n");
 	}
 
 	if (cmd->action) {

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -5660,7 +5660,7 @@ static int verbosity_change_handler(ldmsd_req_ctxt_t reqc)
 	if (ldmsd_req_attr_keyword_exist_by_id(reqc->req_buf, LDMSD_ATTR_TEST))
 		is_test = 1;
 
-	__dlog(DLOG_CFGOK, "loglevel level=%s%s%s%s%s%s\n", level_s,
+	__dlog(DLOG_CFGOK, "log_level level=%s%s%s%s%s%s\n", level_s,
 		is_test ? " test" : "",
 		subsys ? " name=" : "",
 		subsys ? subsys : NULL,

--- a/ldms/src/ldmsd/ldmsd_request_util.c
+++ b/ldms/src/ldmsd/ldmsd_request_util.c
@@ -82,8 +82,9 @@ const struct req_str_id req_str_id_table[] = {
 	{  "include",            LDMSD_INCLUDE_REQ  },
 	{  "listen",             LDMSD_LISTEN_REQ },
 	{  "load",               LDMSD_PLUGN_LOAD_REQ  },
+	{  "log_level",          LDMSD_VERBOSE_REQ  },
 	{  "log_status",         LDMSD_LOG_STATUS_REQ  },
-	{  "loglevel",           LDMSD_VERBOSE_REQ  },
+	{  "loglevel",          LDMSD_VERBOSE_REQ  }, /* It is being deprecated. */
 	{  "logrotate",          LDMSD_LOGROTATE_REQ  },
 	{  "metric_sets_default_authz", LDMSD_SET_DEFAULT_AUTHZ_REQ  },
 	{  "oneshot",            LDMSD_ONESHOT_REQ  },


### PR DESCRIPTION
The loglevel command works, but it is being deprecated. It will be removed, eventually.