### PR TITLE
Fix stats calc and lookup error path

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2593,6 +2593,7 @@ static void handle_rendezvous_lookup(zap_ep_t zep, zap_event_t ev,
 
 	if (lset) {
 		rc = EEXIST;
+		lset = NULL;	/* So error path won't try to delete it */
 		ref_put(&lset->ref, "__ldms_find_local_set");
 		/* unmap ev->map, it is not used */
 		zap_unmap(ev->map);

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -7195,7 +7195,10 @@ static char * __set_stats_as_json(size_t *json_sz)
 						rc = regexec(&match->regex, prd_set->inst_name, 0, NULL, 0);
 						if (rc)
 							continue;
-						freq = 1000000 / (double)prd_set->updt_interval;
+						if (prd_set->updt_interval)
+							freq = 1000000.0 / (double)prd_set->updt_interval;
+						else
+							freq = 0.0;
 						if (prd_set->set) {
 							data_sz = ldms_set_data_sz_get(prd_set->set);
 							set_load += data_sz * freq;
@@ -7212,7 +7215,10 @@ static char * __set_stats_as_json(size_t *json_sz)
 				ldmsd_prdcr_set_t prd_set;
 				for (prd_set = ldmsd_prdcr_set_first(ref->prdcr); prd_set;
 						prd_set = ldmsd_prdcr_set_next(prd_set)) {
-					freq = 1000000 / (double)prd_set->updt_interval;
+					if (prd_set->updt_interval)
+						freq = 1000000.0 / (double)prd_set->updt_interval;
+					else
+						freq = 0.0;
 					if (prd_set->set) {
 						data_sz = ldms_set_data_sz_get(prd_set->set);
 						set_load += data_sz * freq;


### PR DESCRIPTION
- If a set is not being updated, the set_stats command will get a divide by zero error

- The lookup error path may assert if a lookup completes for a set already present in the set tree.