### PR TITLE
Change munge authentication message

### DIFF
--- a/.github/workflows/4.3.3-compat-test.yaml
+++ b/.github/workflows/4.3.3-compat-test.yaml
@@ -153,12 +153,12 @@ jobs:
         echo -n "ldms_ls agg-4 ... "
         D1=$( ./ldms_ls.sh -x sock -p 10002 )
         echo "result: ${D1}"
-        [[ "${D0}" = "ovis-4.3.3/meminfo" ]] || error "unexpected ldms_ls agg-4.3.3 result"
-        [[ "${D1}" = "ovis-4.3.3/meminfo" ]] || error "unexpected ldms_ls agg-4 result"
         # ldms_ls-4.3.3 to agg-4
         echo -n "ldms_ls(4.3.3) agg-4 ... "
         D2=$( ./ldms_ls-4.3.3.sh -x sock -p 10002 )
         echo "result: ${D2}"
+        [[ "${D0}" = "ovis-4.3.3/meminfo" ]] || error "unexpected ldms_ls agg-4.3.3 result"
+        [[ "${D1}" = "ovis-4.3.3/meminfo" ]] || error "unexpected ldms_ls agg-4 result"
         [[ "${D2}" = "ovis-4.3.3/meminfo" ]] || error "unexpected ldms_ls(4.3.3) agg-4 result"
         # ldms_ls-4 to agg-4.3.3 -l
         echo -n "ldms_ls -l agg-4.3.3 ... "

--- a/ldms/man/ldms_auth_munge.man
+++ b/ldms/man/ldms_auth_munge.man
@@ -10,15 +10,16 @@ ldms_auth_munge \- LDMS authentication using munge
 .SH SYNOPSIS
 .HP
 .I ldms_app
-.BI "-a munge [-A socket=" PATH ]
+.BI "-a munge [-A socket=PATH ]"
 
 
 .SH DESCRIPTION
-\fBldms_auth_munge\fR relies on \fBmunge\fR service (see \fBmunge\fR(7)) to
-authenticate users. Munge daemon (\fBmunged\fR) must be up and running. The
-optional \fBsocket\fR option can be used to specify the path to munged unix
-domain socket in the case that munged wasn't using the default path.
+\fBldms_auth_munge\fR relies on the \fBmunge\fR service (see \fBmunge\fR(7)) to
+authenticate users. The munge daemon (\fBmunged\fR) must be up and running.
 
+The optional \fBsocket\fR option can be used to specify the path to
+the munged unix domain socket in the case that munged wasn't using the
+default path or there are multiple munge domains configured.
 
 .SH SEE ALSO
 \fBmunge\fR(7), \fBmunged\fR(8)

--- a/ldms/src/auth/ldms_auth_naive.c
+++ b/ldms/src/auth/ldms_auth_naive.c
@@ -102,7 +102,7 @@ struct ldms_auth_naive {
 ldms_auth_plugin_t __ldms_auth_plugin_get()
 {
 	if (!nlog) {
-		nlog = ovis_log_register("auth_naive", "Messages for auth_naive");
+		nlog = ovis_log_register("auth.naive", "Messages for auth_naive");
 		if (!nlog) {
 			LOG_ERROR("Failed to register the auth_naive log.\n");
 		}

--- a/ldms/src/auth/ldms_auth_ovis.c
+++ b/ldms/src/auth/ldms_auth_ovis.c
@@ -119,7 +119,7 @@ struct ldms_auth_ovis {
 ldms_auth_plugin_t __ldms_auth_plugin_get()
 {
 	if (!aolog) {
-		aolog = ovis_log_register("auth_ovis", "Messages for ldms_auth_ovis");
+		aolog = ovis_log_register("auth.ovis", "Messages for ldms_auth_ovis");
 		if (!aolog) {
 			LOG_ERROR("Failed to register %s's log. Error %d\n",
 					__FILE__, errno);


### PR DESCRIPTION
Change munge error message to info

The munge authentication message consists of the
local and remote addresses of the transport between
the two peers. This message presumes that both peers see
the same addresses (albeit swapped). This assumption is
false in many routed and NAT'd environments.

This change replaces the error with an informational message
so that administrators will be aware of this difference
and can make a determination whether or not this difference
is expected.
