### PR TITLE
Fix ENOSPC when ldms_ls over rdma

### DIFF
--- a/lib/src/zap/rdma/zap_rdma.h
+++ b/lib/src/zap/rdma/zap_rdma.h
@@ -167,7 +167,7 @@ struct z_rdma_conn_data {
 };
 #pragma pack(pop)
 
-#define RDMA_CONN_DATA_MAX (56)
+#define RDMA_CONN_DATA_MAX (196)
 #define ZAP_RDMA_CONN_DATA_MAX (RDMA_CONN_DATA_MAX - sizeof(struct z_rdma_conn_data))
 
 #define RDMA_ACCEPT_DATA_MAX (196)


### PR DESCRIPTION
The LDMS connect message got bigger when RAIL was introduced. The ZAP RDMA connect message limit was not updated to support it, causing ENOSPC when the active side zap-rdma-connect to the peer.