### PR TITLE
Fix ldmsd_stream_publish bug: missing auth_opt

### DIFF
--- a/ldms/src/ldmsd/test/ldmsd_stream_publish.c
+++ b/ldms/src/ldmsd/test/ldmsd_stream_publish.c
@@ -177,7 +177,7 @@ int main(int argc, char **argv)
 	ldms_t ldms = NULL;
 
 	/* Create a transport endpoint */
-	ldms = ldms_xprt_new_with_auth(xprt, auth, NULL);
+	ldms = ldms_xprt_new_with_auth(xprt, auth, auth_opt);
 	if (!ldms) {
 		rc = errno;
 		printf("Failed to create the LDMS transport endpoint.\n");


### PR DESCRIPTION
`ldmsd_stream_publish` processed '-A ...' option into `auth_opt` but forgot to apply `auth_opt` to `ldms_xprt_new_with_auth()`.