### PR TITLE
Fix wrong rail_gn size in rail connect message

### DIFF
--- a/ldms/src/core/ldms_rail.c
+++ b/ldms/src/core/ldms_rail.c
@@ -517,7 +517,7 @@ void __rail_conn_msg_ntoh(struct ldms_rail_conn_msg_s *m)
 	m->idx = ntohl(m->idx);
 	m->n_eps = ntohl(m->n_eps);
 	m->pid = ntohl(m->pid);
-	m->rail_gn = ntohl(m->rail_gn);
+	m->rail_gn = be64toh(m->rail_gn);
 	m->rate_limit = ntohl(m->rate_limit);
 	m->recv_limit = be64toh(m->recv_limit);
 }

--- a/ldms/src/core/ldms_rail.h
+++ b/ldms/src/core/ldms_rail.h
@@ -85,7 +85,7 @@ struct ldms_rail_conn_msg_s {
 	int n_eps; /* number of endpoints */
 	uint32_t idx; /* endpoint index in the rail */
 	int pid;
-	int rail_gn;
+	uint64_t rail_gn;
 
 };
 #pragma pack(pop)


### PR DESCRIPTION
The bug prevented the passive side of LDMS to accept multiple rail connections from the same source due to wrong `rail_gn` in the connect message. The size of `rail_gn` in the message was incorrectly being 32-bit, too small to receive the actual 64-bit rail_gn, resulting in `msg.rail_gn` being 0 in the network-byte order + bit reduction.