### PR TITLE
Make LDMSD support interval strings

### DIFF
--- a/ldms/man/ldmsctl.man
+++ b/ldms/man/ldmsctl.man
@@ -166,11 +166,20 @@ The plugin name.
 .TP
 .BI interval " interval"
 .br
-The sample interval in microseconds.
+The sample interval, which is a float followed by a unit string.
+If no unit string is given, the default unit is microseconds.
+A unit string is one of the followings:
+  us -- microseconds
+  ms -- milliseconds
+  s  -- seconds
+  m  -- minutes
+  h  -- hours
+  d  -- days
 .TP
 .BI [offset " offset"]
 .br
-Offset (shift) from the sample mark in microseconds.
+Offset (shift) from the sample mark. The value is an integer,
+followed by a unit string.
 Offset can be positive or negative with magnitude up to 1/2
 the sample interval. If this offset is specified, including 0,
 collection will be synchronous; if the offset is not specified,
@@ -214,7 +223,15 @@ The connection type [active, passive]
 .TP
 .BI reconnect " interval"
 .br
-The connection retry interval
+The connection retry interval, which is a float followed by a unit string.
+If no unit string is given, the default unit is microseconds.
+A unit string is one of the followings:
+  us -- microseconds
+  ms -- milliseconds
+  s  -- seconds
+  m  -- minutes
+  h  -- hours
+  d  -- days
 .TP
 .BI interval " interval"
 .br
@@ -248,8 +265,16 @@ The producer name
 .TP
 .BI [interval " interval"]
 .br
-The connection retry interval in microsec. If unspecified,
-the previously configured value will be used. Optional.
+The connection retry interval, which is a float followed by a unit string.
+If no unit string is given, the default unit is microseconds.
+A unit string is one of the followings:
+  us -- microseconds
+  ms -- milliseconds
+  s  -- seconds
+  m  -- minutes
+  h  -- hours
+  d  -- days
+If unspecified, the previously configured value will be used. Optional.
 .RE
 
 .SS Start all producers matching a regular expression
@@ -263,8 +288,16 @@ A regular expression
 .TP
 .BI [interval " interval"]
 .br
-The connection retry interval in microsec. If unspecified,
-the previously configured value will be used. Optional.
+The connection retry interval, which is a float followed by a unit string.
+If no unit string is given, the default unit is microseconds.
+A unit string is one of the followings:
+  us -- microseconds
+  ms -- milliseconds
+  s  -- seconds
+  m  -- minutes
+  h  -- hours
+  d  -- days
+If unspecified, the previously configured value will be used. Optional.
 .RE
 
 .SS Stop a producer
@@ -325,7 +358,15 @@ any attributes specified for the metric sets or hosts.
 .TP
 .BI interval " interval"
 .br
-The update/collect interval
+The update/collect interval, which is a float followed by a unit string.
+If no unit string is given, the default unit is microseconds.
+A unit string is one of the followings:
+  us -- microseconds
+  ms -- milliseconds
+  s  -- seconds
+  m  -- minutes
+  h  -- hours
+  d  -- days
 .TP
 .BI [offset " offset"]
 .br
@@ -442,8 +483,16 @@ The update policy name
 .TP
 .BI [interval " interval"]
 .br
-The update interval in micro-seconds. If this is not
-specified, the previously configured value will be used. Optional.
+The update interval, which is a float followed by a unit string.
+If no unit string is given, the default unit is microseconds.
+A unit string is one of the followings:
+  us -- microseconds
+  ms -- milliseconds
+  s  -- seconds
+  m  -- minutes
+  h  -- hours
+  d  -- days
+If this is not specified, the previously configured value will be used. Optional.
 .TP
 .BI [offset " offset"]
 .br

--- a/ldms/man/ldmsd_controller.man
+++ b/ldms/man/ldmsd_controller.man
@@ -166,15 +166,22 @@ The plugin name.
 .TP
 .BI interval " interval"
 .br
-The sample interval in microseconds.
+The sample interval, which is a float followed by a unit string.
+If no unit string is given, the default unit is microseconds.
+A unit string is one of the followings:
+  us -- microseconds
+  ms -- milliseconds
+  s  -- seconds
+  m  -- minutes
+  h  -- hours
+  d  -- days
 .TP
 .BI [offset " offset"]
 .br
-Offset (shift) from the sample mark in microseconds.
+Offset (shift) from the sample mark in the same format as intervals.
 Offset can be positive or negative with magnitude up to 1/2
-the sample interval. If this offset is specified, including 0,
-collection will be synchronous; if the offset is not specified,
-collection will be asynchronous. Optional.
+the sample interval. The default offset is 0. Collection is always synchronous.
+
 .RE
 
 
@@ -269,7 +276,15 @@ The connection type [active, passive]
 .TP
 .BI reconnect " interval"
 .br
-The connection retry interval
+The connection retry interval, which is a float followed by a unit string.
+If no unit string is given, the default unit is microseconds.
+A unit string is one of the followings:
+  us -- microseconds
+  ms -- milliseconds
+  s  -- seconds
+  m  -- minutes
+  h  -- hours
+  d  -- days
 .TP
 .BI interval " interval"
 .br
@@ -321,8 +336,16 @@ The producer name
 .TP
 .BI [interval " interval"]
 .br
-The connection retry interval in microsec. If unspecified,
-the previously configured value will be used. Optional.
+The connection retry interval, which is a float followed by a unit string.
+If no unit string is given, the default unit is microseconds.
+A unit string is one of the followings:
+  us -- microseconds
+  ms -- milliseconds
+  s  -- seconds
+  m  -- minutes
+  h  -- hours
+  d  -- days
+If unspecified, the previously configured value will be used. Optional.
 .RE
 
 .SS Start all producers matching a regular expression
@@ -336,8 +359,16 @@ A regular expression
 .TP
 .BI [interval " interval"]
 .br
-The connection retry interval in microsec. If unspecified,
-the previously configured value will be used. Optional.
+The connection retry interval, which is a float followed by a unit stirng.
+If no unit string is given, the default unit is microseconds.
+A unit string is one of the followings:
+  us -- microseconds
+  ms -- milliseconds
+  s  -- seconds
+  m  -- minutes
+  h  -- hours
+  d  -- days
+If unspecified, the previously configured value will be used. Optional.
 .RE
 
 .SS Stop a producer
@@ -397,7 +428,15 @@ any attributes specified for the metric sets or hosts.
 .TP
 .BI interval " interval"
 .br
-The update/collect interval
+The update/collect interval, which is a float followed by a unit string.
+If no unit string is given, the default unit is microseconds.
+A unit string is one of the followings:
+  us -- microseconds
+  ms -- milliseconds
+  s  -- seconds
+  m  -- minutes
+  h  -- hours
+  d  -- days
 .TP
 .BI [offset " offset"]
 .br
@@ -514,8 +553,16 @@ The update policy name
 .TP
 .BI [interval " interval"]
 .br
-The update interval in micro-seconds. If this is not
-specified, the previously configured value will be used. Optional.
+The update interval, which is a float followed by a unit string.
+If no unit string is given, the default unit is microseconds.
+A unit string is one of the followings:
+  us -- microseconds
+  ms -- milliseconds
+  s  -- seconds
+  m  -- minutes
+  h  -- hours
+  d  -- days
+If this is not specified, the previously configured value will be used. Optional.
 .TP
 .BI [offset " offset"]
 .br

--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -204,17 +204,6 @@ LDMSD_CTRL_CMD_MAP = {'usage': {'req_attr': [], 'opt_attr': ['name']},
                       'auth_add': {'req_attr': ['name', 'plugin'], 'opt_attr': []},
                       }
 
-def check_offset(interval_us, offset_us=None):
-    """
-    Ensure that offset provided is valid for ldmsd with given interval
-    """
-    if offset_us:
-        interval_us = int(interval_us)
-        offset_us = int(offset_us)
-        if offset_us/interval_us > .5:
-            offset_us = interval_us/2
-    return offset_us
-
 def fmt_status(msg):
     """
     Format communicator status response string into json object
@@ -2027,7 +2016,6 @@ class Communicator(object):
                       LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.INTERVAL, value=str(interval_us))
                     ]
         if offset_us != None:
-            offset_us = check_offset(interval_us, offset_us)
             req_attrs.append(LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.OFFSET, value=str(offset_us)))
         req = LDMSD_Request(
                 command_id = LDMSD_Request.PLUGN_START,
@@ -2406,7 +2394,6 @@ class Communicator(object):
         attrs += [
              LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.INTERVAL, value=str(interval))
         ]
-        offset = check_offset(interval, offset)
         if offset:
             attrs += [
                 LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.OFFSET, value=str(offset))
@@ -2510,7 +2497,6 @@ class Communicator(object):
             LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.NAME, value=name),
         ]
         if interval:
-            offset = check_offset(interval, offset)
             if auto_interval:
                 return errno.EINVAL, "'auto' is incompatible with 'interval'"
             attrs += [

--- a/ldms/src/ldmsd/ldmsd_prdcr.c
+++ b/ldms/src/ldmsd/ldmsd_prdcr.c
@@ -950,11 +950,18 @@ int ldmsd_prdcr_start(const char *name, const char *interval_str,
 		      ldmsd_sec_ctxt_t ctxt)
 {
 	int rc = 0;
+	long reconnect;
 	ldmsd_prdcr_t prdcr = ldmsd_prdcr_find(name);
 	if (!prdcr)
 		return ENOENT;
-	if (interval_str)
-		prdcr->conn_intrvl_us = strtol(interval_str, NULL, 0);
+	if (interval_str) {
+		rc = ovis_time_str2us(interval_str, &reconnect);
+		if (rc)
+			return EINVAL;
+		if (reconnect <= 0)
+			return -EINVAL;
+		prdcr->conn_intrvl_us = reconnect;
+	}
 	rc = __ldmsd_prdcr_start(prdcr, ctxt);
 	ldmsd_prdcr_put(prdcr);
 	return rc;
@@ -1176,6 +1183,20 @@ int ldmsd_prdcr_start_regex(const char *prdcr_regex, const char *interval_str,
 	regex_t regex;
 	ldmsd_prdcr_t prdcr;
 	int rc;
+	long reconnect;
+
+	if (interval_str) {
+		rc = ovis_time_str2us(interval_str, &reconnect);
+		if (rc) {
+			snprintf(rep_buf, rep_len, "The reconnect interval value "
+					           "(%s) is invalid.", interval_str);
+			return EINVAL;
+		}
+		if (reconnect <= 0) {
+			snprintf(rep_buf, rep_len, "The reconnect interval must be a positive interval.");
+			return EINVAL;
+		}
+	}
 
 	rc = ldmsd_compile_regex(&regex, prdcr_regex, rep_buf, rep_len);
 	if (rc)
@@ -1187,12 +1208,12 @@ int ldmsd_prdcr_start_regex(const char *prdcr_regex, const char *interval_str,
 		if (rc)
 			continue;
 		if (interval_str)
-			prdcr->conn_intrvl_us = strtol(interval_str, NULL, 0);
+			prdcr->conn_intrvl_us = reconnect;
 		__ldmsd_prdcr_start(prdcr, ctxt);
 	}
 	ldmsd_cfg_unlock(LDMSD_CFGOBJ_PRDCR);
 	regfree(&regex);
-	return 0;
+	return rc;
 }
 
 int ldmsd_prdcr_stop_regex(const char *prdcr_regex, char *rep_buf,

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -1488,7 +1488,7 @@ static int prdcr_add_handler(ldmsd_req_ctxt_t reqc)
 	char *auth;
 	enum ldmsd_prdcr_type type = -1;
 	unsigned short port_no = 0;
-	int interval_us = -1;
+	long interval_us = -1;
 	size_t cnt;
 	uid_t uid;
 	gid_t gid;
@@ -1561,12 +1561,16 @@ static int prdcr_add_handler(ldmsd_req_ctxt_t reqc)
 	if (!interval_s) {
 		goto einval;
 	} else {
-		char *ptr;
-		interval_us = strtol(interval_s, &ptr, 0);
-		if ((*interval_s == '\0') || (*ptr != '\0') || (interval_us <= 0)) {
+		reqc->errcode = ovis_time_str2us(interval_s, &interval_us);
+		if (reqc->errcode) {
+			cnt = snprintf(reqc->line_buf, reqc->line_len,
+					"The given 'reconnect' is invalid.");
+			goto send_reply;
+		}
+		if (interval_us <= 0) {
 			reqc->errcode = EINVAL;
 			cnt = snprintf(reqc->line_buf, reqc->line_len,
-					"The 'reconnect' value must be a positive number.");
+					"The reconnect interval must be a positive number.");
 			goto send_reply;
 		}
 	}
@@ -1618,7 +1622,7 @@ static int prdcr_add_handler(ldmsd_req_ctxt_t reqc)
 			goto enomem;
 	}
 	__dlog(DLOG_CFGOK, "prdcr_add name=%s xprt=%s host=%s port=%u type=%s "
-		"interval=%d auth=%s uid=%d gid=%d perm=%o\n",
+		"interval=%ld auth=%s uid=%d gid=%d perm=%o\n",
 		name, xprt, host, port_no, type_s,
 		interval_us, auth ? auth : "none", (int)uid, (int)gid,
 		(unsigned)perm);
@@ -1747,6 +1751,14 @@ static int prdcr_start_handler(ldmsd_req_ctxt_t reqc)
 	case EACCES:
 		Snprintf(&reqc->line_buf, &reqc->line_len,
 				"Permission denied.");
+		break;
+	case EINVAL:
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+				"The 'reconnect' value (%s) is invalid.", interval_str);
+		break;
+	case -EINVAL:
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+				"The 'reconnect' interval must be a positive interval.");
 		break;
 	default:
 		Snprintf(&reqc->line_buf, &reqc->line_len,
@@ -3223,7 +3235,6 @@ static int updtr_add_handler(ldmsd_req_ctxt_t reqc)
 	gid_t gid;
 	int perm;
 	char *perm_s = NULL;
-	char *endptr;
 	int push_flags, is_auto_task;
 	long interval, offset;
 
@@ -3264,11 +3275,10 @@ static int updtr_add_handler(ldmsd_req_ctxt_t reqc)
 					"an empty string.");
 			goto send_reply;
 		}
-		interval = strtol(interval_str, &endptr, 0);
-		if ('\0' != endptr[0]) {
-			reqc->errcode = EINVAL;
+		reqc->errcode = ovis_time_str2us(interval_str, &interval);
+		if (reqc->errcode) {
 			cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
-				"The given update interval value (%s) is not a number.",
+				"The given update interval value (%s) is invalid.",
 				interval_str);
 			goto send_reply;
 		} else {
@@ -3293,12 +3303,11 @@ static int updtr_add_handler(ldmsd_req_ctxt_t reqc)
 					"The given update offset value is an empty string.");
 			goto send_reply;
 		}
-		offset = strtol(offset_str, &endptr, 0);
-		if ('\0' != endptr[0]) {
-			reqc->errcode = EINVAL;
+		reqc->errcode = ovis_time_str2us(offset_str, &offset);
+		if (reqc->errcode) {
 			cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
 					"The given update offset value (%s) "
-					"is not a number.", offset_str);
+					"is invalid.", offset_str);
 			goto send_reply;
 		}
 		if (interval_str && (interval < labs(offset) * 2)) {
@@ -3856,7 +3865,6 @@ static int updtr_start_handler(ldmsd_req_ctxt_t reqc)
 	char *updtr_name, *interval_str, *offset_str, *auto_interval;
 	updtr_name = interval_str = offset_str = auto_interval = NULL;
 	size_t cnt = 0;
-	char *endptr;
 	long interval, offset = 0;
 	struct ldmsd_sec_ctxt sctxt;
 
@@ -3880,12 +3888,11 @@ static int updtr_start_handler(ldmsd_req_ctxt_t reqc)
 					"The given update offset value is an empty string.");
 			goto send_reply;
 		}
-		offset = strtol(offset_str, &endptr, 0);
-		if ('\0' != endptr[0]) {
-			reqc->errcode = EINVAL;
+		reqc->errcode = ovis_time_str2us(offset_str, &offset);
+		if (reqc->errcode) {
 			cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
 					"The given update offset value (%s) "
-					"is not a number.", offset_str);
+					"is invalid.", offset_str);
 			goto send_reply;
 		}
 	}
@@ -3898,19 +3905,18 @@ static int updtr_start_handler(ldmsd_req_ctxt_t reqc)
 					"an empty string.");
 			goto send_reply;
 		}
-		interval = strtol(interval_str, &endptr, 0);
-		if ('\0' != endptr[0]) {
-			reqc->errcode = EINVAL;
+		reqc->errcode = ovis_time_str2us(interval_str, &interval);
+		if (reqc->errcode) {
 			cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
-				"The given update interval value (%s) is not a number.",
+				"The given update interval value (%s) is invalid.",
 				interval_str);
 			goto send_reply;
 		} else {
 			if (0 >= interval) {
 				reqc->errcode = EINVAL;
 				cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
-						"The update interval value must "
-						"be larger than 0. (%ld)", interval);
+						"The update interval must "
+						"be a positive interval. (%ld)", interval);
 				goto send_reply;
 			}
 			if (offset_str && interval < labs(offset) * 2) {
@@ -4918,6 +4924,10 @@ static int plugn_start_handler(ldmsd_req_ctxt_t reqc)
 		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
 				"Sampler '%s' is already running.", plugin_name);
 	} else if (reqc->errcode == EDOM) {
+		reqc->errcode = EINVAL;
+		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
+				"The given 'offset' (%s) is invalid.", offset);
+	} else if (reqc->errcode == -EDOM) {
 		reqc->errcode = EINVAL;
 		cnt = Snprintf(&reqc->line_buf, &reqc->line_len,
 				"Sampler parameters interval and offset are "

--- a/ldms/src/ldmsd/ldmsd_updtr.c
+++ b/ldms/src/ldmsd/ldmsd_updtr.c
@@ -927,8 +927,8 @@ ldmsd_updtr_new_with_auth(const char *name, char *interval_str, char *offset_str
 					int push_flags, int is_auto_task,
 					uid_t uid, gid_t gid, int perm)
 {
+	int rc;
 	struct ldmsd_updtr *updtr;
-	char *endptr;
 	long interval_us = UPDTR_TREE_MGMT_TASK_INTRVL, offset_us = LDMSD_UPDT_HINT_OFFSET_NONE;
 	updtr = (struct ldmsd_updtr *)
 		ldmsd_cfgobj_new_with_auth(name, LDMSD_CFGOBJ_UPDTR,
@@ -941,16 +941,12 @@ ldmsd_updtr_new_with_auth(const char *name, char *interval_str, char *offset_str
 	updtr->default_task.is_default = 1;
 	updtr->is_auto_task = is_auto_task;
 	if (interval_str) {
-		interval_us = strtol(interval_str, &endptr, 0);
-		if (('\0' == interval_str[0]) || ('\0' != endptr[0]))
-			goto einval;
-		if (0 >= interval_us)
+		rc = ovis_time_str2us(interval_str, &interval_us);
+		if (rc || (0 >= interval_us))
 			goto einval;
 		if (offset_str) {
-			offset_us = strtol(offset_str, &endptr, 0);
-			if (('\0' == offset_str[0]) || ('\0' != endptr[0]))
-				goto einval;
-			if (interval_us < labs(offset_us) * 2)
+			rc = ovis_time_str2us(offset_str, &offset_us);
+			if (rc || (interval_us < labs(offset_us) * 2))
 				goto einval;
 			/* Make it a hint offset */
 			offset_us -= updtr_sched_offset_skew_get();
@@ -1097,8 +1093,12 @@ int ldmsd_updtr_start(const char *updtr_name, const char *interval_str,
 	interval_us = updtr->default_task.sched.intrvl_us;
 	offset_us = updtr->default_task.hint.offset_us;
 	if (interval_str) {
-		/* A new interval is given. */
-		interval_us = strtol(interval_str, NULL, 0);
+		/* A new interval is given, and its value has been checked by the handler. */
+		rc = ovis_time_str2us(interval_str, &interval_us);
+		if (rc || (interval_us <= 0)) {
+			rc = EINVAL;
+			goto err;
+		}
 		if (!offset_str) {
 			/* An offset isn't given. We assume that
 			 * users want the updater to schedule asynchronously.
@@ -1106,17 +1106,21 @@ int ldmsd_updtr_start(const char *updtr_name, const char *interval_str,
 			offset_us = LDMSD_UPDT_HINT_OFFSET_NONE;
 		}
 	}
-	if (offset_str)
-		offset_us = strtol(offset_str, NULL, 0)
-					- updtr_sched_offset_skew_get();
-
-	if (interval_us < labs(offset_us) * 2) {
-		ovis_log(updtr_log, OVIS_LERROR, "%s: The absolute value of the offset"
-			" value must not be larger than the half of "
-			"the update interval. (i=%ld, o=%ld)\n", "ldmsd_updtr_start",
-			interval_us, offset_us);
-		rc = EINVAL;
-		goto err;
+	if (offset_str) {
+		rc = ovis_time_str2us(offset_str, &offset_us);
+		if (rc) {
+			rc = EINVAL;
+			goto err;
+		}
+		if (interval_us < labs(offset_us) * 2) {
+			ovis_log(updtr_log, OVIS_LERROR, "%s: The absolute value of the offset"
+				" value must not be larger than the half of "
+				"the update interval. (i=%ld, o=%ld)\n", "ldmsd_updtr_start",
+				interval_us, offset_us);
+			rc = EINVAL;
+			goto err;
+		}
+		offset_us = offset_us - updtr_sched_offset_skew_get();
 	}
 	/* Initialize the default task */
 	updtr_task_init(&updtr->default_task, updtr, 1, interval_us, offset_us);

--- a/lib/src/ovis_util/util.c
+++ b/lib/src/ovis_util/util.c
@@ -597,6 +597,50 @@ size_t ovis_get_mem_size(const char *s)
     }
 }
 
+/*
+ * microseconds:	us
+ * milliseconnds:	ms
+ * seconds:		s
+ * minutes:		m
+ * hours:		h
+ * days:		d
+ */
+int ovis_time_str2us(const char *s, long *v)
+{
+	char *unit;
+	double x;
+
+	x = strtod(s, &unit);
+	if (unit == s)
+		return EINVAL;
+
+	while (unit[0] == ' ')
+		unit++;
+
+	if ((unit[0] == '\0') || (0 == strcmp(unit, "us")) || (0 == strncmp(unit, "micro", 5))) {
+		/* microseconds */
+		*v = (long long)x;
+	} else if ((0 == strcmp(unit, "ms")) || (0 == strncmp(unit, "milli", 5))) {
+		/* milliseconds */
+		*v = x * 1000;
+	} else if (unit[0] == 's') {
+		/* seconds */
+		*v = x * 1000000;
+	} else if (unit[0] == 'm') {
+		/* minutes */
+		*v = x * 1000000 * 60;
+	} else if (unit[0] == 'h') {
+		/* hours */
+		*v = x * 1000000 * 60 * 60;
+	} else if (unit[0] == 'd') {
+		/* days */
+		*v = x * 1000000 * 60 * 60 * 24;
+	} else {
+		return EINVAL;
+	}
+	return 0;
+}
+
 pid_t ovis_execute(const char *command)
 {
 	char *argv[] = {"/bin/sh", "-c", (char*)command, NULL};

--- a/lib/src/ovis_util/util.h
+++ b/lib/src/ovis_util/util.h
@@ -194,6 +194,28 @@ int av_check_expansion(printf_t log, const char *name, const char *value);
 size_t ovis_get_mem_size(const char *s);
 
 /**
+ * \brief Convert a time-interval string to microseconds
+ *
+ * A time-interval string is an integer followed by a unit string.
+ * A unit string is one of the following:
+ *
+ *   'us'       - microseconds
+ *   'ms'       - milliseconds
+ *   's'        - seconds
+ *   'm'        - minutes
+ *   'h'        - hours
+ *   'd'        - days
+ *
+ * If no unit string is given, the default unit is microseconds.
+ *
+ * \param s  a string to be converted. The valid format is <time><unit>.
+ * \oaram v  a resulting integer in microseconds.
+ *
+ * \return 0 on success. Otherwise, an errno is returned.
+ */
+int ovis_time_str2us(const char *s, long *v);
+
+/**
  * \brief Fork and exec the given command with /bin/sh.
  *
  * This function call will fork and execute the given command with bash. It is


### PR DESCRIPTION
The patch makes LDMSD support time-interval strings. A time-interval string is an integer followed by a unit string. A unit string is one of the followings:
  us -- microseconds
  ms -- milliseconds
  s  -- seconds
  min -- minutes
  hr  -- hours
  day -- days

For example, with this patch, to specify a sampling interval of 1 second, '1s' can be used.