### PR TITLE
Fix 'ldms_stream_client_stats_str() error: 2' in ldmsd_controller

### DIFF
--- a/ldms/src/core/ldms_stream.c
+++ b/ldms/src/core/ldms_stream.c
@@ -1821,8 +1821,13 @@ char *ldms_stream_client_stats_str()
 	struct ldms_stream_client_stats_tq_s *tq;
 	char *ret = NULL;
 	tq = ldms_stream_client_stats_tq_get();
-	if (!tq)
+	if (!tq) {
+		if (errno == ENOENT) {
+			ret = strdup("[]");
+			return ret;
+		}
 		return NULL;
+	}
 	ret = ldms_stream_client_stats_tq_to_str(tq);
 	ldms_stream_client_stats_tq_free(tq);
 	return ret;


### PR DESCRIPTION
The error arose from 'ldms_stream_client_stat_str()' on the ldmsd side.

When the stream client list was empty, 'ldms_stream_client_stat_str()' returned `NULL` with errno=ENOENT. This consequently got forwarded to `ldmsd_controller` and displayed as an error.

This patch modified ldms_stream_client_stat_str() to return "[]" on empty client list.