### PR TITLE
Fix ldmsd_stream_subscribe intermingled events output

### DIFF
--- a/ldms/src/ldmsd/test/ldmsd_stream_subscribe.c
+++ b/ldms/src/ldmsd/test/ldmsd_stream_subscribe.c
@@ -165,16 +165,13 @@ static int stream_unsubscribe_status_ev(ldms_stream_event_t ev, void *arg)
 
 static int stream_recv_ev(ldms_stream_event_t ev, void *arg)
 {
-	if (!events_raw) {
-		if (ev->recv.type == LDMS_STREAM_STRING)
-			msglog("EVENT:{\"type\":\"string\",\"size\":%d,\"event\":", ev->recv.data_len);
-		else
-			msglog("EVENT:{\"type\":\"json\",\"size\":%d,\"event\":", ev->recv.data_len);
+	if (events_raw) {
+		msglog("%s\n", ev->recv.data);
+		return 0;
 	}
-	msglog(ev->recv.data);
-	if (!events_raw)
-		msglog("}");
-	msglog("\n");
+	msglog("EVENT:{\"type\":\"%s\",\"size\":%d,\"event\":%s}\n",
+			LDMS_STREAM_STRING ? "string" : "json",
+			ev->recv.data_len, ev->recv.data);
 	return 0;
 }
 


### PR DESCRIPTION
Multiple threads in `ldmsd_stream_subscribe` can race to handle stream recv events. The recv handler called `msglog()` multiple times to print out the EVENT. This lead to intermingled events in the output. This patch modifies the handler to print the events in single msglog call to avoid the intermingled output.