### PR TITLE
Add stream meta data to JSON stream metric set

### DIFF
--- a/ldms/src/sampler/json/Plugin_json_stream_sampler.man
+++ b/ldms/src/sampler/json/Plugin_json_stream_sampler.man
@@ -71,6 +71,14 @@ The encoding of all JSON types except strings, dictionaries and lists is
 straightfoward. The coding of Strings, Lists and Dictionaries have additional
 limitations as described below.
 
+.SS "Stream Meta-data"
+.PP
+Stream events include the user-id, and group-id of the application
+publishing the stream data. This data is encoded in the metric set
+with the special names \fBS_uid\fR, and \fBS_gid\fR respectively. The
+intention is that this data can stored in rows as configured by the
+user with a decomposition configuration.
+
 .SS "Encoding Strings"
 Strings are encoded as LDMS_V_BYTE_ARRAY. By default, the length of
 the array is 255 unless an attribute with the name \fINAME\fR_max_len
@@ -117,6 +125,8 @@ results in a metric set as follows:
 .nf
 $ ldms_ls -h localhost -p 10411 -a munge -E example -l
 ovs-5416_example: consistent, last update: Sat Aug 05 11:38:26 2023 -0500 [281178us]
+D s32        S_uid                                      1002
+D s32        S_gid                                      1002
 D s64        component_id                               10001
 D s64        job_id                                     2048
 D list<>     seq                                        [1,2,3]
@@ -145,6 +155,8 @@ results in the following LDMS metric set.
 .RS 4
 .nf
 ovs-5416_dict: consistent, last update: Sat Aug 05 21:14:38 2023 -0500 [839029us]
+D s32         S_uid                                      1002
+D s32         S_gid                                      1002
 M record_type  a_dict_record                             LDMS_V_RECORD_TYPE
 D record[]     a_dict
   attr_2 attr_1
@@ -179,6 +191,8 @@ results in the following LDMS metric set.
 .RS 4
 .nf
 ovs-5416_dict_list: consistent, last update: Sat Aug 05 21:23:11 2023 -0500 [52659us]
+D s32         S_uid                                      1002
+D s32         S_gid                                      1002
 M record_type a_dict_list_record                         LDMS_V_RECORD_TYPE
 D list<>      a_dict_list
   attr_2 attr_1
@@ -187,6 +201,7 @@ D list<>      a_dict_list
 D char[]     schema                                     "dict_list"
 .fi
 .RE
+.PP
 .SH "CONFIG OPTIONS"
 
 .TP


### PR DESCRIPTION
This change adds the uid and gid from the stream
event to the JSON stream metric set.