### PR TITLE
Memory leak

### DIFF
--- a/ldms/src/store/avro_kafka/store_avro_kafka.c
+++ b/ldms/src/store/avro_kafka/store_avro_kafka.c
@@ -134,14 +134,17 @@ serdes_schema_find(aks_handle_t sh, char *schema_name,
 
 	/* Create a new schema from the row specification and LDMS schema */
 	rc = ldmsd_row_to_json_avro_schema(row, &json_buf, &json_len);
-	if (rc)
+	if (rc) {
+		free(entry);
 		goto out;
+	}
 	sschema =
 	    serdes_schema_add(sh->serdes,
 			      schema_name, -1,
 			      json_buf, json_len,
 			      errstr, sizeof(errstr));
 	if (!sschema) {
+		free(entry);
 		LOG_ERROR("%s\n", json_buf);
 		LOG_ERROR("Error '%s' creating schema '%s'\n", errstr, schema_name);
 		goto out;


### PR DESCRIPTION
We are seeing huge memory leakage when store_avro_kafka is used, but kafka is down. During that time we see these errors:

```
ERROR: store_avro_kafka: {"name":"meminfo","type":"record","fields":[{"name":"timestamp","type":{"type":"long","logicalType":"time>
ERROR: store_avro_kafka: Error 'REST request failed (code -1): HTTP request failed: Couldn't connect to server' creating schema 'm>
ERROR: store_avro_kafka: A serdes schema for 'meminfo' could not be constructed.
```

The attached memory leak fixes compile, but haven't actually been tested. They need close review.