### PR TITLE
Including the ldms_xprt.h library

### DIFF
--- a/ldms/src/core/ldms_stream.h
+++ b/ldms/src/core/ldms_stream.h
@@ -58,6 +58,7 @@
 #include <sys/queue.h>
 #include <pthread.h>
 
+#include "ldms_xprt.h"
 #include "ovis_ref/ref.h"
 #include "coll/rbt.h"
 #include "ldms.h"


### PR DESCRIPTION
The ``ldms_xprt.h`` library was removed in ``ldms_stream.h`` in a previous commit and caused compile failures with the darshanConnector code. 

I would prefer to add this back in but if there are issues with this, I can always explicitly include it in the darshanConnector code.