### PR TITLE
Improve dump_cfg

### DIFF
--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -742,10 +742,15 @@ int process_config_file(const char *path, int *lineno, int trust);
 #define LDMSD_MAX_PLUGIN_NAME_LEN 64
 #define LDMSD_CFG_FILE_XPRT_MAX_REC 8192
 struct attr_value_list;
+struct avl_q_item {
+	struct attr_value_list *av_list;
+	TAILQ_ENTRY(avl_q_item) entry;
+};
+TAILQ_HEAD(avl_q, avl_q_item);
 struct ldmsd_plugin {
 	char name[LDMSD_MAX_PLUGIN_NAME_LEN];
-	struct attr_value_list *av_list;
-	struct attr_value_list *kw_list;
+	struct avl_q avl_q;
+	struct avl_q kwl_q;
 	enum ldmsd_plugin_type {
 		LDMSD_PLUGIN_OTHER = 0,
 		LDMSD_PLUGIN_SAMPLER,

--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -181,6 +181,8 @@ struct ldmsd_plugin_cfg *new_plugin(char *plugin_name,
 	if (!pi->libpath)
 		goto enomem;
 	pi->plugin = lpi;
+	TAILQ_INIT(&lpi->avl_q);
+	TAILQ_INIT(&lpi->kwl_q);
 	lpi->pi = pi;
 	pi->sample_interval_us = 1000000;
 	pi->sample_offset_us = 0;
@@ -204,10 +206,24 @@ err:
 
 void destroy_plugin(struct ldmsd_plugin_cfg *p)
 {
+	struct avl_q_item *avl;
+	struct avl_q_item *kwl;
 	free(p->libpath);
 	free(p->name);
-	av_free(p->plugin->av_list);
-	av_free(p->plugin->kw_list);
+
+	/*
+	 * Assume that the length of av_list_q and
+	 * the length of kw_list_q are equal.
+	 */
+	while ((avl = TAILQ_FIRST(&p->plugin->avl_q)) &&
+			(kwl = TAILQ_FIRST(&p->plugin->kwl_q))) {
+		TAILQ_REMOVE(&p->plugin->avl_q, avl, entry);
+		TAILQ_REMOVE(&p->plugin->kwl_q, kwl, entry);
+		free(avl->av_list);
+		free(avl);
+		free(kwl->av_list);
+		free(kwl);
+	}
 	LIST_REMOVE(p, entry);
 	dlclose(p->handle);
 	free(p);
@@ -309,6 +325,17 @@ int ldmsd_config_plugin(char *plugin_name,
 {
 	int rc = 0;
 	struct ldmsd_plugin_cfg *pi;
+	struct avl_q_item *avl;
+	struct avl_q_item *kwl;
+
+	avl = calloc(1, sizeof(*avl));
+	kwl = calloc(1, sizeof(*kwl));
+	if (!avl || !kwl)
+		return ENOMEM;
+	avl->av_list = av_copy(_av_list);
+	kwl->av_list = av_copy(_kw_list);
+	if (!avl->av_list || !kwl->av_list)
+		return ENOMEM;
 
 	pi = ldmsd_get_plugin(plugin_name);
 	if (!pi)
@@ -316,8 +343,8 @@ int ldmsd_config_plugin(char *plugin_name,
 
 	pthread_mutex_lock(&pi->lock);
 	rc = pi->plugin->config(pi->plugin, _kw_list, _av_list);
-	pi->plugin->av_list = av_copy(_av_list);
-	pi->plugin->kw_list = av_copy(_kw_list);
+	TAILQ_INSERT_TAIL(&pi->plugin->kwl_q, kwl, entry);
+	TAILQ_INSERT_TAIL(&pi->plugin->avl_q, avl, entry);
 	pthread_mutex_unlock(&pi->lock);
 	return rc;
 }


### PR DESCRIPTION
- dump_cfg exports the command-line options, e.g., the log path and verbosity
- Make dump_cfg support plugins that allow multiple config command lines
- Make dump_cfg export the regex instead of schema at strgp_add if regex was originally given.