### PR TITLE
Make json_stream_sampler handle UID, GID, and perm

### DIFF
--- a/ldms/python/ldms.pxd
+++ b/ldms/python/ldms.pxd
@@ -298,6 +298,8 @@ cdef extern from "ldms.h" nogil:
 		           sockaddr *remote_sa,
 		           socklen_t *sa_len)
 
+    const char *ldms_metric_type_to_str(ldms_value_type t)
+
     # --- dir operation related --- #
     struct ldms_key_value_s:
         char *key

--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -3009,6 +3009,7 @@ cdef class Set(object):
 
     def json_obj(self):
         """Return dict/list values appropriate for json.dumps()"""
+        cdef const char *tmp
         ret = dict()
         meta_lst = [ 'name', 'schema_name', 'transaction_timestamp',
                      'transaction_duration', 'card', 'data_gn', 'data_sz',
@@ -3017,9 +3018,13 @@ cdef class Set(object):
         for k in meta_lst:
             ret[k] = getattr(self, k)
         data = dict()
+        meta = dict()
         for k, v in self.items():
             data[k] = JSON_OBJ(v)
+            tmp = ldms_metric_type_to_str(self.get_metric_type(k))
+            meta[k] = {'type' : STR(tmp)}
         ret['data'] = data
+        ret['meta'] = meta
         return ret
 
     def json(self, indent=None):

--- a/ldms/src/sampler/json/Plugin_json_stream_sampler.man
+++ b/ldms/src/sampler/json/Plugin_json_stream_sampler.man
@@ -202,6 +202,21 @@ D char[]     schema                                     "dict_list"
 .fi
 .RE
 .PP
+
+.SS "Set Security"
+.PP
+The metric sets' UID, GID, and permission can be configured using the
+configuration attributes uid, gid, and perm consecutively. If one is not given,
+the value of the received stream data will be used at set creation. Once a
+metric set has been created, the UID, GID, and permission will not be changed
+automatically when the stream data's security data gets changed. However, it
+could be modified via an LDMSD configuration command, set_sec_mod. See
+ldmsd_controller's Man Page.
+
+Note that the UID, GID, and permissions values given at the configuration line
+do not affect the S_uid and S_gid metric values. The S_uid and S_gid metric
+values are always the security embeded with the stream data.
+
 .SH "CONFIG OPTIONS"
 
 .TP

--- a/ldms/src/sampler/json/json_stream_sampler.c
+++ b/ldms/src/sampler/json/json_stream_sampler.c
@@ -859,6 +859,13 @@ static int json_recv_cb(ldms_stream_event_t ev, void *arg)
 	msg = ev->recv.data;
 	entity = ev->recv.json;
 
+	if ((int32_t)inst->uid < 0)
+		inst->uid = ev->recv.cred.uid;
+	if ((int32_t)inst->gid < 0)
+		inst->gid = ev->recv.cred.gid;
+	if ((int32_t)inst->perm < 0)
+		inst->perm = ev->recv.perm;
+
 	/* Find/create the schema for this JSON object */
 	schema_name = json_value_find(entity, "schema");
 	if (!schema_name || (JSON_STRING_VALUE != json_entity_type(schema_name))) {
@@ -878,7 +885,8 @@ static int json_recv_cb(ldms_stream_event_t ev, void *arg)
 		      json_value_str(schema_name)->str);
 	ldms_set_t set = ldms_set_by_name(set_name);
 	if (!set) {
-		set = ldms_set_new_with_heap(set_name, schema, inst->heap_sz);
+		set = ldms_set_create(set_name, schema, inst->uid, inst->gid,
+						  inst->perm, inst->heap_sz);
 		if (set) {
 			LINFO("Created the set '%s' with schema '%s'\n",
 			      set_name, ldms_schema_name_get(schema));

--- a/ldms/src/sampler/json/json_stream_sampler.c
+++ b/ldms/src/sampler/json/json_stream_sampler.c
@@ -274,8 +274,8 @@ static int make_list(ldms_schema_t schema, json_entity_t parent, json_entity_t l
 		item_size = ldms_record_heap_size_get(record);
 		break;
 	default:
-		LERROR("Invalid item type encountered in list");
-		return EINVAL;
+		LERROR("Invalid item type encountered in list\n");
+		return -EINVAL;
 	}
 	/* Check if there is a max specified for the list to override
 	 * the current length */
@@ -867,17 +867,24 @@ static int json_recv_cb(ldms_stream_event_t ev, void *arg)
 		inst->perm = ev->recv.perm;
 
 	/* Find/create the schema for this JSON object */
+	if (JSON_DICT_VALUE != json_entity_type(entity)) {
+		rc = EINVAL;
+		LERROR("%s: Ignoring message that is not a JSON dictionary.\n",
+				ev->recv.name);
+		goto err_0;
+	}
+
 	schema_name = json_value_find(entity, "schema");
 	if (!schema_name || (JSON_STRING_VALUE != json_entity_type(schema_name))) {
 		rc = EINVAL;
-		LERROR("Ignoring message with 'schema' attribute that is "
-		       "missing or not a string.\n");
+		LERROR("%s: Ignoring message with 'schema' attribute that is "
+		       "missing or not a string.\n", ev->recv.name);
 		goto err_0;
 	}
 	rc = get_schema_for_json(json_value_str(schema_name)->str, entity, &schema);
 	if (rc) {
-		LERROR("Error %d creating an LDMS schema for the JSON object '%s'\n",
-		       rc, msg);
+		LERROR("%s: Error %d creating an LDMS schema for the JSON object '%s'\n",
+		       ev->recv.name, rc, msg);
 		goto err_0;
 	}
 	char *set_name;
@@ -912,7 +919,7 @@ static int json_recv_cb(ldms_stream_event_t ev, void *arg)
  err_1:
 	free(set_name);
  err_0:
-	pthread_mutex_lock(&inst->lock);
+	pthread_mutex_unlock(&inst->lock);
 	return rc;
 }
 


### PR DESCRIPTION
Without the patch, the json_stream_sampler receives the UID, GID, and perm values at the config line, but it does not apply the values to the metric sets.

The patch makes the plugin use the specified UID, GID, and permission; otherwise, it will use the security data from the received stream data. The security data is applied at the set creation time. The configuration command set_sec_mod must be used to modify the sets' security. The plugin does not automatically revise the set security according to the stream data's security changes.