### PR TITLE
Convert rx_rate parameter argument to string in prdcr_subscribe

### DIFF
--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -2201,7 +2201,7 @@ class Communicator(object):
             self.close()
             return errno.ENOTCONN, str(e)
 
-    def prdcr_subscribe(self, regex, stream, rx_rate=-1):
+    def prdcr_subscribe(self, regex, stream, rx_rate='-1'):
         """
         Subscribe to stream data from matching producers
 
@@ -2219,7 +2219,7 @@ class Communicator(object):
                 attrs = [
                     LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.REGEX, value=regex),
                     LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.STREAM, value=stream),
-                    LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.RX_RATE, value=rx_rate)
+                    LDMSD_Req_Attr(attr_id=LDMSD_Req_Attr.RX_RATE, value=str(int(rx_rate)))
                 ])
         try:
             req.send(self)

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -360,7 +360,7 @@ class LdmsdCmdParser(cmd.Cmd):
         interval= The connection retry interval (us) (Deprecated, please use 'reconnect'.)
         auth=     The authentication method
         [perm=]   The permission to modify the producer in the future.
-        [rail=]   The number of rail endpooints for the prdcr (default: 1).
+        [rail=]   The number of rail endpoints for the prdcr (default: 1).
         [credits=] The send credits our ldmsd (the one we are controlling)
                    advertises to the prdcr (default: value from ldmsd --credits
                    option). This limits how much outstanding data our ldmsd


### PR DESCRIPTION
Ensure rx_rate argument is a string before instantiating LDMSD_Req_Attr object