### PR TITLE
Fix configure script GIT SHA issue

### DIFF
--- a/.github/workflows/ldms-test-build.yaml
+++ b/.github/workflows/ldms-test-build.yaml
@@ -30,6 +30,7 @@ jobs:
     - name: build-ovis
       shell: bash
       run: |
+        git config --global --add safe.directory ${PWD}
         mkdir -p build
         PREFIX=/opt/ovis
         OPTIONS=(

--- a/m4/options.m4
+++ b/m4/options.m4
@@ -623,16 +623,33 @@ dnl dnl queries git for version hash and branch info.
 AC_DEFUN([OPTION_GITINFO], [
 
 	export srcdir
+
+	dnl git test
+	if test -d "${srcdir}/.git"; then
+		AC_MSG_NOTICE(['.git' directory presented. Checking git ...])
+		dnl For configure output
+		git rev-parse --git-dir >&AS_MESSAGE_FD 2>&1
+		dnl For configure log
+		git rev-parse --git-dir >&AS_MESSAGE_LOG_FD 2>&1
+		if test 0 -ne $?; then
+			dnl git error
+			AC_MSG_ERROR([git command error])
+		else
+			AC_MSG_RESULT([OK])
+		fi
+	fi
 	TOP_LEVEL="$(cd "$srcdir" && git rev-parse --show-toplevel 2>/dev/null)"
+
 	GITLONG="$(cd "$srcdir" && git rev-parse HEAD 2>/dev/null)"
 	GITDIRTY="$(cd "$srcdir" && git status -uno -s 2>/dev/null)"
 	if test -n "$GITLONG" -a -n "$GITDIRTY"; then
 		GITLONG="${GITLONG}-dirty"
 	fi
 
+	AC_MSG_NOTICE([Determining GIT SHA ...])
 	if test -s "$TOP_LEVEL/m4/Ovis-top.m4" -a -n "$GITLONG"; then
 		dnl Git OK from ovis repo.
-		AC_MSG_RESULT([Using git SHA])
+		AC_MSG_RESULT([Using SHA from the git repository])
 	elif test -s $srcdir/SHA.txt ; then
 		dnl Git not OK, try $srcdir/SHA.txt
 		AC_MSG_NOTICE([Using SHA.txt from $srcdir for version info. ])
@@ -645,8 +662,9 @@ AC_DEFUN([OPTION_GITINFO], [
 		AC_MSG_RESULT([Using tree-top SHA.txt])
 	else
 		GITLONG="NO_GIT_SHA"
-		AC_MSG_RESULT([NO GIT SHA])
+		AC_MSG_WARN([Git SHA cannot be determined. This is not a working git repository and SHA.txt is not present.])
 	fi
+	AC_MSG_NOTICE([GIT SHA: ${GITLONG}])
 
 AC_DEFINE_UNQUOTED([OVIS_GIT_LONG],["$GITLONG"],[Hash of last git commit])
 AC_SUBST([OVIS_GIT_LONG], ["$GITLONG"])


### PR DESCRIPTION
Since git v2.30.3, git added a top-level directory ownership check
(please see https://github.com/git/git/commit/8959555ce). If the owner
of the top-level directory does not match the current user, all git
commands failed with message "fatal: detected dubious ownership in
repository at _PATH_". However, our configure script does not properly
report the error nor give a recommended action. The configure script
silently moving on with 'NO_GIT_SHA' value.

This patch modify the configure script to check the git command if we
are in a git repository. If the git command resulted in an error, the
configure script report the error messages from the git command and
exited with a failure status. Please note that if the source tree is not
in a git repository (no .git directory), the configure scirpt will skip
git command checking.

Example error output with recommended action from the git command:
```sh
configure: '.git' directory presented. Checking git ...
fatal: detected dubious ownership in repository at '/home/narate/projects/ovis'
To add an exception for this directory, call:

        git config --global --add safe.directory /home/narate/projects/ovis
configure: error: git command error
make: *** [Makefile:636: config.status] Error 1
```

Example of a good output:
```sh
configure: '.git' directory presented. Checking git ...
__GIT_DIR_PATH__
OK
```