### PR TITLE
ldms_stream_close race fix

### DIFF
--- a/ldms/python/ldms.pxd
+++ b/ldms/python/ldms.pxd
@@ -229,6 +229,30 @@ cdef extern from "ovis_util/util.h" nogil:
     int av_add(attr_value_list *avl, const char *name, const char *value)
     void av_free(attr_value_list *avl)
 
+cdef extern from "ovis_log/ovis_log.h" nogil:
+    cpdef enum:
+        OVIS_LDEFAULT
+        OVIS_LQUIET
+        OVIS_LDEBUG
+        OVIS_LINFO
+        OVIS_LWARN
+        OVIS_LWARNING
+        OVIS_LERROR
+        OVIS_LCRITICAL
+        OVIS_LCRIT
+
+        LDEFAULT  "OVIS_LDEFAULT"
+        LQUIET    "OVIS_LQUIET"
+        LDEBUG    "OVIS_LDEBUG"
+        LINFO     "OVIS_LINFO"
+        LWARN     "OVIS_LWARN"
+        LWARNING  "OVIS_LWARNING"
+        LERROR    "OVIS_LERROR"
+        LCRITICAL "OVIS_LCRITICAL"
+        LCRIT     "OVIS_LCRIT"
+
+    int ovis_log_set_level_by_name(const char *subsys_name, int level)
+
 cdef extern from "ldms_rail.h" nogil:
     cpdef enum :
         __RAIL_UNLIMITED

--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -4141,3 +4141,31 @@ cdef class ZapThrStat(object):
 
     def __repr__(self):
         return str(self)
+
+LOG_LEVEL_MAP = {
+        "LDEFAULT":  LDEFAULT,
+        "LQUIET":    LQUIET,
+        "LDEBUG":    LDEBUG,
+        "LINFO":     LINFO,
+        "LWARN":     LWARN,
+        "LWARNING":  LWARNING,
+        "LERROR":    LERROR,
+        "LCRITICAL": LCRITICAL,
+        "LCRIT":     LCRIT,
+
+        "DEFAULT":  LDEFAULT,
+        "QUIET":    LQUIET,
+        "DEBUG":    LDEBUG,
+        "INFO":     LINFO,
+        "WARN":     LWARN,
+        "WARNING":  LWARNING,
+        "ERROR":    LERROR,
+        "CRITICAL": LCRITICAL,
+        "CRIT":     LCRIT,
+        }
+
+def ovis_log_set_level_by_name(str subsys_name, level):
+    """ovis_log_set_level_by_name(str subsys_name, level)"""
+    if type(level) is str:
+        level = LOG_LEVEL_MAP[level.upper()]
+    ldms.ovis_log_set_level_by_name(BYTES(subsys_name), level)


### PR DESCRIPTION
This pull request includes
- `ldms_stream_close()` race fix
- Python `ldms.Xprt.stream_unscribe()` GIL deadlock fix
- Exporting `ovis_log_set_level_by_name()` to Python ldms for debugging / verification purpose.

The following is the description of the `ldms_stream_close()` race: 

Stream-Client-Entry (sce) is a tailq entry that lives in
`stream->client_tq` (list of clients subscribing the stream) and
`client->stream_tq` (list of streams the client subscribed to) to
manage client-stream relation. When a stream client closes, it is
unbound from the stream, and the `sce` is removed from the list. This
leads to a use-after-free when another thread iterate through the
`stream->client_tq` and unlock to call the application callback
function. This patch modifies the unbind procedure to NOT remove the
`sce`, and just unbind the client - stream from the `sce`. The unbound
`sce` is later removed from the `client->stream_tq` list when the client
is closed, and is removed from `stream->client_tq` when the callback
processing thread detects an unbound `sce`.
