### PR TITLE
Fix segmentation fault in stream stats

### DIFF
--- a/ldms/src/core/ldms_stream.c
+++ b/ldms/src/core/ldms_stream.c
@@ -1841,6 +1841,8 @@ struct ldms_stream_client_stats_tq_s *ldms_stream_client_stats_tq_get()
 		pthread_rwlock_rdlock(&s->rwlock);
 		TAILQ_FOREACH(sce, &s->client_tq, stream_client_entry) {
 			cli = sce->client;
+			if (!cli)
+				continue;
 			if (cli->is_regex)
 				continue; /* already handled above */
 			cs = ldms_stream_client_get_stats(cli);


### PR DESCRIPTION
The `ldms_stream_close()` race fix (3fe7765a) changed the condition of the stream-client entry (sce) such that it can contain NULL client or stream. The stream stats code path that also go through the list must also been modified to support it.