### PR TITLE
this installcheck version checks the return code and wraps test_slps

### DIFF
--- a/ldms/src/sampler/netlink/Makefile.am
+++ b/ldms/src/sampler/netlink/Makefile.am
@@ -44,3 +44,6 @@ EXTRA_DIST = $(srcdir)/input/test_slps.sh
 
 distclean-local:
 	$(RM) test_slps.* $(EXTRA_PROGRAMS)
+
+installcheck-local: test_slps $(srcdir)/input/test_slps.sh
+	LD_LIBRARY_PATH=$(DESTDIR)$(libdir) BIN=$(DESTDIR)$(sbindir) TESTBIN=. bash $(srcdir)/input/test_slps.sh

--- a/ldms/src/sampler/netlink/simple_lps.c
+++ b/ldms/src/sampler/netlink/simple_lps.c
@@ -1005,7 +1005,6 @@ struct slps_send_result slps_send_string(struct slps *l, size_t buf_len,
 			target->last_publish_rc = ldmsd_stream_publish(
 				target->ldms, l->stream, LDMSD_STREAM_STRING,
 				buf, buf_len);
-			target->last_publish_rc = 0;
 			if (target->last_publish_rc) {
 				if (l->send_log_f)
 					fprintf(l->send_log_f, "%s: Fail %d "


### PR DESCRIPTION
this installcheck version checks the return code and wraps test_slps in 'timeout' so it cannot hang forever, should a transport hang occur.

also
fixes #1095

This is the rc branch version of  #1145, which is still being worked on.