### PR TITLE
Fix CYTHON_CHECK m4 macro

### DIFF
--- a/m4/cython_check.m4
+++ b/m4/cython_check.m4
@@ -6,7 +6,7 @@
 #
 #   Look for variations on the cython binary name, including ones
 #   that contain the PYTHON_VESRION parameter. For instance,
-#   if PYTHON_VERSION is 3.6, look for cython-3.6, cython3.6, and cython
+#   if PYTHON_VERSION is 3.6, look for cython-3.6, cython3.6, cython3, and cython
 #   in that order. Each found binary is feature checked to determine
 #   if its Cython version is greater than or equal to the supplied
 #   CYTHON_MIN_VESRION parameter. The serach stops on the first binary
@@ -20,16 +20,26 @@
 AC_DEFUN([CYTHON_CHECK],[
  cython_min_version=$1
  python_version=$2
- found=false
+ found=untested
+ python_major_version=$( echo ${python_version} | sed 's/\..*//' )
  AC_CACHE_CHECK([for a version of Cython >= ${cython_min_version}],
                [ac_cv_path_CYTHON],
                [AC_PATH_PROGS_FEATURE_CHECK([CYTHON],
-                       [cython-${python_version} cython${python_version} cython],
+                       [cython-${python_version} cython${python_version} cython${python_major_version} cython],
                        [cython_version=$(${ac_path_CYTHON} --version 2>&1 | sed -e 's/.*\s//')
                         AX_COMPARE_VERSION([${cython_version}],[ge],[$cython_min_version],
                        [ac_cv_path_CYTHON=$ac_path_CYTHON ac_path_CYTHON_found=:
 		        found=true])],
                        [found=false])])
+ # When CYTHON is specified (e.g. './configure CYTHON=/opt/cython/bin/cython3'),
+ # 'ac_cv_path_CYTHON' variable is set to that value and the
+ # AC_PATH_PROGS_FEATURE_CHECK skips the 'feature-test' part, which contains
+ # version-checking logic. Hence, we handle that case here.
+ AS_IF([ test "$found" = "untested" && test -n "$ac_cv_path_CYTHON" ], [
+	 cython_version=$(${ac_cv_path_CYTHON} --version 2>&1 | sed -e 's/.*\s//')
+	 AX_COMPARE_VERSION([${cython_version}],[ge],[$cython_min_version],
+		 [found=true])
+ ])
  AS_IF([test "$found" = "true"],
 	[AC_SUBST([CYTHON], [$ac_cv_path_CYTHON])
 	 m4_ifnblank([$3],[$3],[[:]])],


### PR DESCRIPTION
This patch addresses 2 things:

1) Add `cython{$python_major_version}` (e.g. 'cython3') into the
   cython program check list. Let's suppose the Python version is 3.6,
   the current check list only contains 'cython-3.6', 'cython3.6', and
   'cython'. This caused an issue on Ubuntu 22.04 since the cython
   package installed the program as 'cython3'.

2) Fix the version checking logic when CYTHON configure variable is
   specified (e.g.  './configure CYTHON=/opt/cython/bin/cython3').
   The existing CYTHON_CHECK macro uses 'AC_PATH_PROGS_FEATURE_CHECK'
   macro on CYTHON variable, which will skip the 'feature-test' part of
   the macro if the variable (CYTHON) is defined. Since the version
   checking logic is in the 'feature-test' part, the cython version has
   never been checked and 'cython not found' error is reported. This
   patch adds a logic to cover this case.