### PR TITLE
add use_base to dcgm sampler to ovis-4

### DIFF
--- a/ldms/scripts/examples/.canned
+++ b/ldms/scripts/examples/.canned
@@ -42,6 +42,7 @@ lustre_mdc
 dstat.job
 many
 conf_csv
+dcgm1
 
 # not yet tested
 rabbitv3

--- a/ldms/scripts/examples/dcgm1
+++ b/ldms/scripts/examples/dcgm1
@@ -1,0 +1,15 @@
+export plugname=dcgm
+portbase=61073
+VGARGS="--leak-check=full --track-origins=yes --trace-children=yes"
+JOBDATA $TESTDIR/job.data 1 2
+vgoff
+LDMSD -p prolog.jobid 1 2
+vgoff
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1 -lv
+SLEEP 1
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2 -l
+SLEEP 5
+KILL_LDMSD 1 2
+file_created $STOREDIR/node/$testname

--- a/ldms/scripts/examples/dcgm1.1
+++ b/ldms/scripts/examples/dcgm1.1
@@ -1,0 +1,3 @@
+load name=dcgm_sampler
+config name=dcgm_sampler producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} interval=1000000 perm=757 uid=3556 gid=3556 job_set=instance=localhost${i}/job_info use_base=1
+start name=dcgm_sampler interval=1000000 offset=0

--- a/ldms/scripts/examples/dcgm1.2
+++ b/ldms/scripts/examples/dcgm1.2
@@ -1,0 +1,15 @@
+# cannot load sampler instance on same node.
+
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_start name=localhost1
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+strgp_add name=store_${testname} plugin=store_csv schema=${testname} container=node
+strgp_prdcr_add name=store_${testname} regex=.*
+strgp_start name=store_${testname}

--- a/ldms/src/sampler/dcgm_sampler/Makefile.am
+++ b/ldms/src/sampler/dcgm_sampler/Makefile.am
@@ -1,17 +1,34 @@
+bin_PROGRAMS = ldms-dcgm-list-fields
+
 libdcgm_sampler_la_SOURCES = \
-        dcgm_sampler.c
+	dcgm_sampler.c
+
 libdcgm_sampler_la_LIBADD = \
+	$(top_builddir)/ldms/src/sampler/libsampler_base.la \
 	$(top_builddir)/ldms/src/core/libldms.la \
 	$(top_builddir)/lib/src/coll/libcoll.la \
-        $(top_builddir)/ldms/src/sampler/libjobid_helper.la \
+	$(top_builddir)/ldms/src/sampler/libjobid_helper.la \
 	-ldcgm
+
 libdcgm_sampler_la_LDFLAGS = \
 	-no-undefined \
-        -export-symbols-regex 'get_plugin' \
-        -version-info 1:0:0
+	-export-symbols-regex 'get_plugin' \
+	-version-info 1:0:0
 libdcgm_sampler_la_CPPFLAGS = \
 	@OVIS_INCLUDE_ABS@
 
 pkglib_LTLIBRARIES = libdcgm_sampler.la
 
 dist_man7_MANS = Plugin_dcgm_sampler.man
+
+dist_noinst_SCRIPTS = gen-ldms-dcgm-list-fields
+
+ldms-dcgm-list-fields.c: $(srcdir)/gen-ldms-dcgm-list-fields
+	$(srcdir)/gen-ldms-dcgm-list-fields > ldms-dcgm-list-fields.c
+
+ldms_dcgm_list_fields_SOURCES = ldms-dcgm-list-fields.c
+ldms_dcgm_list_fields_CPPFLAGS = @OVIS_INCLUDE_ABS@
+ldms_dcgm_list_fields_LDADD = -ldcgm
+
+clean-local::
+	$(RM) $(builddir)/ldms_dcgm_list_fields.c

--- a/ldms/src/sampler/dcgm_sampler/Plugin_dcgm_sampler.man
+++ b/ldms/src/sampler/dcgm_sampler/Plugin_dcgm_sampler.man
@@ -6,7 +6,7 @@ Plugin_dcgm_sampler - man page for the LDMS dcgm_sampler plugin
 .SH SYNOPSIS
 Within ldmsd_controller or a configuration file:
 .br
-config name=dcgm_sampler [ <attr>=<value> ]
+config name=dcgm_sampler [ <attr>=<value> ] [use_base=1]
 
 .SH DESCRIPTION
 With LDMS (Lightweight Distributed Metric Service), plugins for the ldmsd (ldms daemon) are configured via ldmsd_controller
@@ -17,7 +17,7 @@ The schema is named "dcgm" by default.
 
 .TP
 .BR config
-name=<plugin_name> interval=<interval(us)> [fields=<fields>] [schema=<schema_name>] [job_set=<metric set name>]
+name=<plugin_name> interval=<interval(us)> [fields=<fields>] [schema=<schema_name>] [job_set=<metric set name>] [use_base=1 [[uid=<int>] [gid=<int>] [perm=<octal>] [instance=<name>] [producer=<name>] [job_id=<metric name in job_set set>]]
 .br
 configuration line
 .RS
@@ -26,16 +26,24 @@ name=<plugin_name>
 .br
 This MUST be dcgm_sampler.
 .TP
+use_base=1
+.br
+This enables the sampler_base configuration option processing (see ldms_sampler_base(7)). If not given, the options not
+listed below are ignored.
+.TP
 interval=<interval(us)>
 .br
-The sampling interval.  This MUST be set to the same value that is
-set on the "start" line, otherwise behavior is undetermined.
+The DCGM library sampling interval (dcgmWatchFields() updateFreq). This MUST be set to the same value that is
+set on the dcgm_sampler start line, otherwise behavior is undetermined.
 .TP
 fields=<fields>
 .br
 <fields> is a comma-separated list of integers representing DCGM field
-numebers that the plugin should watch.  By default the plugin will
-watch fields 150,155.
+identifiers that the plugin should watch.  By default the plugin will
+watch fields 150,155. The field identifier meanings are defined in dcgm_fields.h
+and the DCGM Library API Reference Manual and may vary with DCGM release version.
+The ldms-dcgm-list-fields command provides a table of fields, subject to hardware
+support.
 .TP
 schema=<schema_name>
 .br
@@ -58,6 +66,9 @@ load name=dcgm_sampler
 config name=dcgm_sampler interval=1000000 fields=150,155,1001,1002,1003 schema=dcgmfav5
 start name=dcgm_sampler interval=1000000
 .fi
+
+.SH NOTES
+Multiple instances of the sampler cannot run on the same server.
 
 .SH SEE ALSO
 ldmsd(8), ldms_quickstart(7), ldmsd_controller(8), ldms_sampler_base(7)

--- a/ldms/src/sampler/dcgm_sampler/gen-ldms-dcgm-list-fields
+++ b/ldms/src/sampler/dcgm_sampler/gen-ldms-dcgm-list-fields
@@ -1,0 +1,90 @@
+#! /bin/bash
+cat << EOF
+/* generated with gen_ldms_dcgm_list_fields */
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <dcgm_agent.h>
+struct fielddef { const char *macro; int field_id; char *tag;};
+#define FIELDDEF(m) { #m, m, NULL },
+struct fielddef all_fields[] = {
+EOF
+grep DCGM_FI_ /usr/include/dcgm_fields.h |grep '^#define' |grep ' [0-9]'|grep -v + | sed -e 's/#define //' -e 's/ .*//g' -e 's/^/FIELDDEF(/' -e 's/$/)/'
+cat << EOF
+	{ NULL, 0, NULL }
+};
+
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(*a))
+#define _GNU_SOURCE
+
+
+static int dcgm_init()
+{
+        dcgmReturn_t rc;
+
+        rc = dcgmInit();
+        if (rc != DCGM_ST_OK) {
+                return -1;
+        }
+
+        return 0;
+}
+
+static void dcgm_fini()
+{
+        dcgmShutdown();
+}
+
+const char *typeString(int ft)
+{
+	switch (ft) {
+	case DCGM_FT_DOUBLE:
+		return "double";
+	case DCGM_FT_INT64:
+		return "int64_t";
+	case DCGM_FT_STRING:
+		return "string";
+	case DCGM_FT_TIMESTAMP:
+		return "timestamp";
+	default:
+		return "unmapped_type";
+	}
+}
+
+static void dump_dcgm_tags()
+{
+        int i;
+	printf("field_id\ttag\tmacro\ttype\tunits\n");
+        for (i = 0; i < ARRAY_SIZE(all_fields) &&
+		all_fields[i].macro != NULL; i++) {
+
+                dcgm_field_meta_p field_meta;
+                field_meta = DcgmFieldGetById(all_fields[i].field_id);
+		if (field_meta) {
+			switch (field_meta->fieldType) {
+			case DCGM_FT_DOUBLE:
+			case DCGM_FT_INT64:
+			case DCGM_FT_STRING:
+			case DCGM_FT_TIMESTAMP:
+				all_fields[i].tag = strdup(field_meta->tag);
+				printf("%d\t%s\t%s\t%s\t\"%s\"\n",
+					all_fields[i].field_id, field_meta->tag,
+					all_fields[i].macro,
+					typeString(field_meta->fieldType),
+					field_meta->valueFormat->unit);
+				break;
+			default:
+				break;
+			}
+		}
+        }
+}
+
+int main()
+{
+	dcgm_init();
+	dump_dcgm_tags();
+	dcgm_fini();
+}
+EOF


### PR DESCRIPTION
* enables compid, perms, uid/gid, etc, with default the original behavior
* provide demo/test of dcgm
* provide configuration support utility listing fields available and numbers
* fix omissions in ldms_sampler_base man page