### PR TITLE
Enable github workflow tests on 'OVIS-4.x.x'

### DIFF
--- a/.github/workflows/4.3.3-compat-test.yaml
+++ b/.github/workflows/4.3.3-compat-test.yaml
@@ -23,7 +23,7 @@ on:
   push:
     branches: [ OVIS-4 ]
   pull_request:
-    branches: [ OVIS-4 ]
+    branches: [ 'OVIS-4**' ]
 
 defaults:
   run:

--- a/.github/workflows/build-ddebug-centos7.yaml
+++ b/.github/workflows/build-ddebug-centos7.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ OVIS-4 ]
   pull_request:
-    branches: [ OVIS-4 ]
+    branches: [ 'OVIS-4**' ]
 
 jobs:
   build:

--- a/.github/workflows/build-test-centos7.yaml
+++ b/.github/workflows/build-test-centos7.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ OVIS-4 ]
   pull_request:
-    branches: [ OVIS-4 ]
+    branches: [ 'OVIS-4**' ]
 
 jobs:
   build:

--- a/.github/workflows/build-test-ubuntu-22.04.yaml
+++ b/.github/workflows/build-test-ubuntu-22.04.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ OVIS-4 ]
   pull_request:
-    branches: [ OVIS-4 ]
+    branches: [ 'OVIS-4**' ]
 
 jobs:
   build:

--- a/.github/workflows/build-test-ubuntu.yaml
+++ b/.github/workflows/build-test-ubuntu.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ OVIS-4 ]
   pull_request:
-    branches: [ OVIS-4 ]
+    branches: [ 'OVIS-4**' ]
 
 jobs:
   build:

--- a/.github/workflows/ldms-test-build.yaml
+++ b/.github/workflows/ldms-test-build.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ OVIS-4 ]
   pull_request:
-    branches: [ OVIS-4 ]
+    branches: [ 'OVIS-4**' ]
 
 jobs:
   build:

--- a/.github/workflows/space-check.yaml
+++ b/.github/workflows/space-check.yaml
@@ -2,7 +2,7 @@ name: Space Check
 
 on:
   pull_request:
-    branches: [ OVIS-4 ]
+    branches: [ 'OVIS-4**' ]
 
 jobs:
   space_check:

--- a/.github/workflows/test-make-dist.yaml
+++ b/.github/workflows/test-make-dist.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ OVIS-4 ]
   pull_request:
-    branches: [ OVIS-4 ]
+    branches: [ 'OVIS-4**' ]
 
 jobs:
   build:


### PR DESCRIPTION
The github workflow tests we have only target pull requests for 'OVIS-4' branch. This patch make them target pull requests for any branch matching 'OVIS-4**' (any branch starting with 'OVIS-4').