### PR TITLE
Fix `zap_sock` rejected endpoint leak (on 4.4.1)

### DIFF
--- a/lib/src/zap/sock/zap_sock.c
+++ b/lib/src/zap/sock/zap_sock.c
@@ -1999,6 +1999,7 @@ static zap_err_t z_sock_reject(zap_ep_t ep, char *data, size_t data_len)
 	if (zerr)
 		goto err;
 	pthread_mutex_unlock(&sep->ep.lock);
+	zap_free(ep); /* corresponding to zap_new() in __z_sock_conn_request */
 	return ZAP_ERR_OK;
 err:
 	sep->ep.state = ZAP_EP_ERROR;


### PR DESCRIPTION
`zap_sock` forgot to put the reference corresponding to `zap_new()` when the application `zap_reject()` the endpoint of the incoming connection request. This resulted in endpoint resource leakage (e.g. file descriptor). This patch put back the reference (calling `zap_free()`) in reject call.