### PR TITLE
protect ovis_log_flush from invalid arguments.

### DIFF
--- a/lib/src/ovis_log/ovis_log.c
+++ b/lib/src/ovis_log/ovis_log.c
@@ -890,7 +890,9 @@ int ovis_log_open(const char *path)
 
 int ovis_log_flush()
 {
-	return fflush(log_fp);
+	if (log_fp && log_fp != OVIS_LOG_SYSLOG)
+		return fflush(log_fp);
+	return 0;
 }
 
 int ovis_log_close()


### PR DESCRIPTION
ovis_log_flush can be called in any order wrt initialization, so it must be guarded against null and syslog values. This prevents segfault in fflush.