### PR TITLE
fix segfault caused by attempting to flush syslog

### DIFF
--- a/ldms/src/ldmsd/ldmsd.c
+++ b/ldms/src/ldmsd/ldmsd.c
@@ -327,7 +327,7 @@ int log_actor(ev_worker_t src, ev_worker_t dst, ev_status_t status, ev_t ev)
 		rc = __logrotate();
 	} else {
 		rc = __log(level, msg, tv, tm);
-		if (0 == ev_pending(logger_w))
+		if (0 == ev_pending(logger_w) && log_fp != LDMSD_LOG_SYSLOG)
 			fflush(log_fp);
 		free(msg);
 	}


### PR DESCRIPTION
when logging is via syslog, flush must not be called. Calling syslog is achieved by assigning log_fp a sentinel value which can never be a file pointer and checking for it before calls that expect a file pointer. This patch fixes a missing check before an fflush that was introduced with the new logging infrastructure.