### PR TITLE
Adjust libcxi test to be correct on toss4 and some libcxi versions  supplies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -881,6 +881,7 @@ AM_CONDITIONAL([SYSCONFDIR_NOT_ETC], [test "${sysconfdir}" != "/etc"])
 AC_LIB_HAVE_LINKFLAGS([cxi], [], [
 #include <stddef.h> /* libcxi.h fails to include this */
 #include <libcxi/libcxi.h>
+const char *c = c1_cntr_descs[0].name;
 ])
 AM_CONDITIONAL([HAVE_LIBCXI], [test "x$HAVE_LIBCXI" = xyes])
 


### PR DESCRIPTION
Toss4 libcxi is incompatible with slingshot sampler source which assumes libcxi.h defines c1_cntr_descs.
cray-libcxi-2.1.0-4.t4.x86_64 doesn't have a header defining c1_cntr_descs.

cherry picked from 4.4.2 patch https://github.com/ovis-hpc/ovis/pull/1345/commits/fac259c837f1b2f49f3195234eaedcb2dbd801ed