### PR TITLE
Add dcgm option to use sampler base and add help string.

### DIFF
--- a/ldms/scripts/examples/dcgm1
+++ b/ldms/scripts/examples/dcgm1
@@ -1,0 +1,15 @@
+export plugname=dcgm
+portbase=61073
+VGARGS="--leak-check=full --track-origins=yes --trace-children=yes"
+JOBDATA $TESTDIR/job.data 1 2
+vgoff
+LDMSD -p prolog.jobid 1 2
+vgoff
+MESSAGE ldms_ls on host 1:
+LDMS_LS 1 -lv
+SLEEP 1
+MESSAGE ldms_ls on host 2:
+LDMS_LS 2 -l
+SLEEP 5
+KILL_LDMSD 1 2
+file_created $STOREDIR/node/$testname

--- a/ldms/scripts/examples/dcgm1.1
+++ b/ldms/scripts/examples/dcgm1.1
@@ -1,0 +1,3 @@
+load name=dcgm_sampler
+config name=dcgm_sampler producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} interval=1000000 perm=757 uid=3556 gid=3556 job_set=instance=localhost${i}/job_info use_base=1
+start name=dcgm_sampler interval=1000000 offset=0

--- a/ldms/scripts/examples/dcgm1.2
+++ b/ldms/scripts/examples/dcgm1.2
@@ -1,0 +1,15 @@
+# cannot load sampler instance on same node.
+
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=2000000
+prdcr_start name=localhost1
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+strgp_add name=store_${testname} plugin=store_csv schema=${testname} container=node
+strgp_prdcr_add name=store_${testname} regex=.*
+strgp_start name=store_${testname}

--- a/ldms/src/sampler/dcgm_sampler/Makefile.am
+++ b/ldms/src/sampler/dcgm_sampler/Makefile.am
@@ -1,8 +1,10 @@
 libdcgm_sampler_la_SOURCES = \
         dcgm_sampler.c
 libdcgm_sampler_la_LIBADD = \
+	$(top_builddir)/ldms/src/sampler/libsampler_base.la \
 	$(top_builddir)/ldms/src/core/libldms.la \
 	$(top_builddir)/lib/src/coll/libcoll.la \
+	$(top_builddir)/lib/src/ovis_util/libovis_util.la \
         $(top_builddir)/ldms/src/sampler/libjobid_helper.la \
 	-ldcgm
 libdcgm_sampler_la_LDFLAGS = \

--- a/ldms/src/sampler/dcgm_sampler/Plugin_dcgm_sampler.man
+++ b/ldms/src/sampler/dcgm_sampler/Plugin_dcgm_sampler.man
@@ -6,7 +6,7 @@ Plugin_dcgm_sampler - man page for the LDMS dcgm_sampler plugin
 .SH SYNOPSIS
 Within ldmsd_controller or a configuration file:
 .br
-config name=dcgm_sampler [ <attr>=<value> ]
+config name=dcgm_sampler [ <attr>=<value> ] [use_base=<*>]
 
 .SH DESCRIPTION
 With LDMS (Lightweight Distributed Metric Service), plugins for the ldmsd (ldms daemon) are configured via ldmsd_controller
@@ -17,7 +17,7 @@ The schema is named "dcgm" by default.
 
 .TP
 .BR config
-name=<plugin_name> interval=<interval(us)> [fields=<fields>] [schema=<schema_name>] [job_set=<metric set name>]
+name=<plugin_name> interval=<interval(us)> [fields=<fields>] [schema=<schema_name>] [job_set=<metric set name>] [use_base=<*> [uid=<int>] [gid=<int>] [perm=<octal>] [instance=<name>] [producer=<name>] [job_id=<metric name in job_set set>]]
 .br
 configuration line
 .RS
@@ -26,16 +26,24 @@ name=<plugin_name>
 .br
 This MUST be dcgm_sampler.
 .TP
+use_base=<*>
+.br
+Any value given enables the sampler_base configuration option processing (see ldms_sampler_base(7)). If not given, the options not
+listed below are ignored.
+.TP
 interval=<interval(us)>
 .br
-The sampling interval.  This MUST be set to the same value that is
-set on the "start" line, otherwise behavior is undetermined.
+The DCGM library sampling interval (dcgmWatchFields() updateFreq). This MUST be set to the same value that is
+set on the dcgm_sampler start line, otherwise behavior is undetermined.
 .TP
 fields=<fields>
 .br
 <fields> is a comma-separated list of integers representing DCGM field
-numebers that the plugin should watch.  By default the plugin will
-watch fields 150,155.
+identifiers that the plugin should watch.  By default the plugin will
+watch fields 150,155. The field identifier meanings are defined in dcgm_fields.h
+and the DCGM Library API Reference Manual and may vary with DCGM release version.
+The plugin usage message provides a table of fields, subject to hardware
+support; see the output of 'ldms-plugins.sh dcgm_sampler'.
 .TP
 schema=<schema_name>
 .br


### PR DESCRIPTION
An integration test demonstrating use and optionally valgrind-cleanliness is also supplied.
'ldms-static-test.sh dcgm_sampler'

Unlike the previous attempt, this version does not:
- add the pthread code to prevent term/sample/config collisions.
- use an extra use_base variable where the base pointer itself will do. 
- add an extra program to dump the available metric and their numbers.