### PR TITLE
slingshot_metrics: new header include needed by shs-2.1.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -911,6 +911,7 @@ AM_CONDITIONAL([SYSCONFDIR_NOT_ETC], [test "${sysconfdir}" != "/etc"])
 AC_LIB_HAVE_LINKFLAGS([cxi], [], [
 #include <stddef.h> /* libcxi.h fails to include this */
 #include <libcxi/libcxi.h>
+#include <cassini_cntr_desc.h> /* needed at least starting with shs-2.1.0 */
 ])
 AM_CONDITIONAL([HAVE_LIBCXI], [test "x$HAVE_LIBCXI" = xyes])
 
@@ -918,7 +919,7 @@ AC_ARG_ENABLE([slingshot],
     [AS_HELP_STRING([--enable-slingshot], [require the slinghost related plugins @<:@default=check@:>@])],
     [],
     [enable_slingshot="check"])
-AM_CONDITIONAL([ENABLE_SLINGSHOT], [test "x$enable_slingshot" != xno])
+AM_CONDITIONAL([ENABLE_SLINGSHOT], [test "x$enable_slingshot" != xno -a "x$HAVE_LIBCXI" = xyes])
 AS_IF([test "x$enable_slingshot" = xyes],[
     AS_IF([test "x$HAVE_LIBCXI" = xno],
         [AC_MSG_ERROR([libcxi or its headers not found])])

--- a/configure.ac
+++ b/configure.ac
@@ -451,7 +451,7 @@ AC_ARG_ENABLE([infiniband],
 	[AS_HELP_STRING([--enable-infiniband], [require components that depend upon libibmad and libibumad @<:@default=check@:>@])],
 	[],
 	[enable_infiniband="check"])
-AM_CONDITIONAL([ENABLE_INFINIBAND], [test "xenable_infiniband" != xno])
+AM_CONDITIONAL([ENABLE_INFINIBAND], [test "x$enable_infiniband" != xno])
 AS_IF([test "x$enable_infiniband" = xyes],[
 	AS_IF([test "x$HAVE_LIBIBMAD" = xno],
 		[AC_MSG_ERROR([infiniband required libibmad or <infiniband/mad.h> not found])])
@@ -465,8 +465,9 @@ AC_ARG_ENABLE([ibnet],
 	[AS_HELP_STRING([--enable-ibnet], [require the ibnet plugin @<:@default=check@:>@])],
 	[],
 	[enable_ibnet="check"])
-AM_CONDITIONAL([ENABLE_IBNET], [test "xenable_ibnet" != xno])
+AM_CONDITIONAL([ENABLE_IBNET], [test "x$enable_ibnet" != xno])
 AS_IF([test "$enable_ibnet" = xyes],[
+	AC_MSG_NOTICE([Disable ibnet module NOT requested])
 	AS_IF([test "x$HAVE_LIBIBMAD" = xno],
 		[AC_MSG_ERROR([ibnet required libibmad or <infiniband/mad.h> not found])])
 	AS_IF([test "x$HAVE_LIBIBUMAD" = xno],
@@ -481,7 +482,7 @@ AC_ARG_ENABLE([opa2],
 	[AS_HELP_STRING([--enable-opa2], [require the opa2 plugin @<:@default=check@:>@])],
 	[],
 	[enable_opa2="check"])
-AM_CONDITIONAL([ENABLE_OPA2], [test "xenable_opa2" != xno])
+AM_CONDITIONAL([ENABLE_OPA2], [test "x$enable_opa2" != xno])
 AS_IF([test "x$enable_opa2" = xyes],[
 	AS_IF([test "x$HAVE_LIBIBMAD" = xno],
 		[AC_MSG_ERROR([opa2 required libibmad or <infiniband/mad.h> not found])])
@@ -917,7 +918,7 @@ AC_ARG_ENABLE([slingshot],
     [AS_HELP_STRING([--enable-slingshot], [require the slinghost related plugins @<:@default=check@:>@])],
     [],
     [enable_slingshot="check"])
-AM_CONDITIONAL([ENABLE_SLINGSHOT], [test "xenable_slingshot" != xno])
+AM_CONDITIONAL([ENABLE_SLINGSHOT], [test "x$enable_slingshot" != xno])
 AS_IF([test "x$enable_slingshot" = xyes],[
     AS_IF([test "x$HAVE_LIBCXI" = xno],
         [AC_MSG_ERROR([libcxi or its headers not found])])

--- a/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
+++ b/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
@@ -16,6 +16,7 @@
 
 #include <stddef.h> /* libcxi.h neglects to include this */
 #include <libcxi/libcxi.h>
+#include <cassini_cntr_desc.h> /* needed at least starting with shs-2.1.0 */
 #define _GNU_SOURCE
 
 #define SAMP "slingshot_metrics"


### PR DESCRIPTION
libcxi.h fails to include cassini_cntr_desc.h, which is almost certainly a bug in their header include tree. We include it explicitly until they fix things.