### PR TITLE
V4.4.2 fixes

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -855,8 +855,7 @@ static void __destroy_set_no_lock(void *v)
 	__ldms_set_info_delete(&set->local_info);
 	__ldms_set_info_delete(&set->remote_info);
 	zap_unmap(set->lmap);
-	if (set->rmap)
-		zap_unmap(set->rmap);
+	zap_unmap(set->rmap);
 	free(set);
 }
 

--- a/ldms/src/decomp/as_is/decomp_as_is.c
+++ b/ldms/src/decomp/as_is/decomp_as_is.c
@@ -442,7 +442,7 @@ __get_row_cfg(__decomp_as_is_cfg_t dcfg, ldms_set_t set)
 	col_count = 1;
 
 	/* create other columns */
-	for (i = 0; i < set_card; i++) {
+	for (i = 1; i < set_card; i++) {
 		mtype = ldms_metric_type_get(set, i);
 		switch (mtype) {
 		case LDMS_V_CHAR:
@@ -578,6 +578,8 @@ __get_row_cfg(__decomp_as_is_cfg_t dcfg, ldms_set_t set)
 	return drow;
 
  err:
+	if (name)
+		free(name);
 	if (drow->cols) {
 		for (i = 0; i < drow->col_count; i++) {
 			free(drow->cols[i].name);
@@ -633,36 +635,15 @@ static int __decomp_as_is_decompose(ldmsd_strgp_t strgp, ldms_set_t set,
 	TAILQ_HEAD(, _list_entry) list_cols;
 	int row_more_le;
 	struct ldms_timestamp ts;
-	const char *set_schema;
-	int row_schema_name_len;
 	ldms_mval_t phony;
-	char *row_schema_name = NULL;
 
 	if (!TAILQ_EMPTY(row_list))
 		return EINVAL;
 
 	ts = ldms_transaction_timestamp_get(set);
 
-	set_schema = ldms_set_schema_name_get(set);
-
 	TAILQ_INIT(&list_cols);
 	ldms_digest = ldms_set_digest_get(set);
-
-	/*
-	 * NOTE Create rows from the set as-is, with list entry expansion.
-	 *
-	 * The schema format is "<schema_name>_<short_sha>", where the
-	 * "<short_sha>" is the first 7 characters of the hex string
-	 * representation of the SHA (similar to git short commit ID).
-	 *
-	 */
-	row_schema_name_len = asprintf(&row_schema_name, "%s_%02hhx%02hhx%02hhx%hhx", set_schema,
-			ldms_digest->digest[0],
-			ldms_digest->digest[1],
-			ldms_digest->digest[2],
-			(unsigned char)(ldms_digest->digest[3] >> 4));
-	if (row_schema_name_len < 0)
-		return errno;
 
 	drow = __get_row_cfg(dcfg, set);
 	if (!drow)

--- a/ldms/src/decomp/as_is/decomp_as_is.c
+++ b/ldms/src/decomp/as_is/decomp_as_is.c
@@ -442,7 +442,7 @@ __get_row_cfg(__decomp_as_is_cfg_t dcfg, ldms_set_t set)
 	col_count = 1;
 
 	/* create other columns */
-	for (i = 1; i < set_card; i++) {
+	for (i = 0; i < set_card; i++) {
 		mtype = ldms_metric_type_get(set, i);
 		switch (mtype) {
 		case LDMS_V_CHAR:

--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -2606,6 +2606,7 @@ send_reply:
 	free(container);
 	free(schema);
 	free(perm_s);
+	free(decomp);
 	return 0;
 }
 

--- a/lib/src/zap/zap.c
+++ b/lib/src/zap/zap.c
@@ -635,6 +635,8 @@ zap_err_t zap_unmap(zap_map_t map)
 	int i;
 
 	zerr = ZAP_ERR_OK;
+	if (!map)
+		goto out;
 	assert(map->ref_count);
 	if (__sync_sub_and_fetch(&map->ref_count, 1))
 		return ZAP_ERR_OK;
@@ -646,6 +648,7 @@ zap_err_t zap_unmap(zap_map_t map)
 		zerr = tmp?tmp:zerr; /* remember last error */
 	}
 	free(map);
+ out:
 	return zerr;
 }
 


### PR DESCRIPTION
These changes fix issue found during v4.4.2 testing. The first commit fixes an issue with outstanding update requests occurring with concurrent incoming LDMS_SET_DELETE notifications. The second commit removes memory leaks from the as_is decomposition plugin. 

@nichamon, @narategithub, @nick-enoent please take a look. I'm most concerned with the transport changes.
