### PR TITLE
fix mis-sizing of string in jbuf implementation

### DIFF
--- a/lib/src/ovis_json/ovis_json.c
+++ b/lib/src/ovis_json/ovis_json.c
@@ -62,10 +62,10 @@ jbuf_t jbuf_append_va(jbuf_t jb, const char *fmt, va_list _ap)
 	cnt = vsnprintf(&jb->buf[jb->cursor], space, fmt, ap);
 	va_end(ap);
 	if (cnt >= space) {
-		space = jb->buf_len + cnt + JSON_BUF_START_LEN;
+		space = jb->buf_len + cnt + JSON_BUF_START_LEN + sizeof(*jb);
 		jb = realloc(jb, space);
 		if (jb) {
-			jb->buf_len = space;
+			jb->buf_len = space - sizeof(*jb);
 			goto retry;
 		} else {
 			return NULL;


### PR DESCRIPTION
Any time the jbuf string grows, the head of the jbuf must be accounted for. This patch fixes that oversight. The oversight leads to writing past the end of the string after it is expanded.  Any code publishing large messages assembled with jbuf_t is subject to memory corruption if it writes in the last 16 bytes of the space believed to be available when they in fact aren't.

