### PR TITLE
fix missing ldmsd_plugins_usage check for 'all' that crashes

### DIFF
--- a/ldms/src/ldmsd/ldmsd_config.c
+++ b/ldms/src/ldmsd/ldmsd_config.c
@@ -1159,7 +1159,7 @@ int ldmsd_plugins_usage(const char *plugname)
 	char *libpath;
 	char *saveptr = NULL;
 
-	if (0 == strcmp(plugname, "all"))
+	if (plugname && 0 == strcmp(plugname, "all"))
 		plugname = NULL;
 
 	char *path = getenv("LDMSD_PLUGIN_LIBPATH");


### PR DESCRIPTION
ldmsd_plugins_usage checking for input 'all' must be done only if the input is not already null.