### PR TITLE
Fixes to configure tests and add disable options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -414,6 +414,7 @@ AS_IF([test "x$enable_papi" != xno],[
 ])
 AM_CONDITIONAL([HAVE_LIBPAPI], [test "x$HAVE_LIBPAPI" = xyes])
 AM_CONDITIONAL([HAVE_LIBPFM], [test "x$HAVE_LIBPFM" = xyes])
+AM_CONDITIONAL([ENABLE_PAPI], [test "x$enable_papi" != no -a "x$HAVE_LIBPAPI" = xyes -a "x$HAVE_LIBPFM" = xyes])
 
 AC_LIB_HAVE_LINKFLAGS([ibmad], [], [#include <infiniband/mad.h>])
 AM_CONDITIONAL([HAVE_LIBIBMAD], [test "x$HAVE_LIBIBMAD" = xyes])
@@ -451,8 +452,7 @@ AC_ARG_ENABLE([ibnet],
 	[],
 	[enable_ibnet="check"])
 AM_CONDITIONAL([ENABLE_IBNET], [test "x$enable_ibnet" != xno])
-AS_IF([test "$enable_ibnet" = xyes],[
-	AC_MSG_NOTICE([Disable ibnet module NOT requested])
+AS_IF([test "x$enable_ibnet" = xyes],[
 	AS_IF([test "x$HAVE_LIBIBMAD" = xno],
 		[AC_MSG_ERROR([ibnet required libibmad or <infiniband/mad.h> not found])])
 	AS_IF([test "x$HAVE_LIBIBUMAD" = xno],
@@ -635,7 +635,7 @@ AC_ARG_WITH([slurm],
 	[with_slurm=check])
 have_slurm=no
 AC_SUBST([SLURM_CFLAGS])
-AS_IF([test "x$with_slurm" != no],[
+AS_IF([test "x$with_slurm" != xno],[
 	save_CFLAGS=$CFLAGS
 	CFLAGS="$CFLAGS $SLURM_CFLAGS"
 	AC_CHECK_HEADER([slurm/spank.h], [have_slurm=yes], [have_slurm=no])
@@ -647,6 +647,8 @@ AS_IF([test "x$with_slurm" != no],[
 			[AC_MSG_WARN([Disabling SLURM support.])])])
 ])
 AM_CONDITIONAL([HAVE_SLURM], [test "x$have_slurm" = xyes])
+
+OPTION_DEFAULT_ENABLE([spank_subscriber], [ENABLE_SPANK_SUBSCRIBER], [Builds sampler that subscribes to spank plugin])
 
 AC_CHECK_HEADER([linux/netlink.h], [have_netlink=yes], [have_netlink=no])
 AM_CONDITIONAL([HAVE_NETLINK], [test "x$have_netlink" = xyes])

--- a/ldms/src/Makefile.am
+++ b/ldms/src/Makefile.am
@@ -4,13 +4,12 @@ SUBDIRS += third-plugins
 SUBDIRS += core
 SUBDIRS += ldmsd
 
-SUBDIRS += decomp
-
 if ENABLE_OVIS_AUTH
 SUBDIRS += auth
 endif
 
 if ENABLE_STORE
+SUBDIRS += decomp
 SUBDIRS += store
 endif
 

--- a/ldms/src/sampler/Makefile.am
+++ b/ldms/src/sampler/Makefile.am
@@ -30,10 +30,14 @@ ldmssamplerincludedir = $(includedir)/ldms/sampler
 ldmssamplerinclude_HEADERS = sampler_base.h
 
 SUBDIRS += netlink
+
+if ENABLE_LUSTRE
 SUBDIRS += lustre_client
 SUBDIRS += lustre_mdt
 SUBDIRS += lustre_ost
 SUBDIRS += lustre_mdc
+endif
+
 SUBDIRS += json
 
 if HAVE_DCGM
@@ -112,8 +116,10 @@ SUBDIRS += job_info_slurm
 SUBDIRS += spank
 endif
 
+if ENABLE_SPANK_SUBSCRIBER
 # This slurm sampler does not have a slurm build dependency
 SUBDIRS += slurm
+endif
 
 if ENABLE_LUSTRE
 SUBDIRS += lustre
@@ -181,6 +187,7 @@ if ENABLE_MPI_SAMPLER
 SUBDIRS += shm
 endif
 
+if ENABLE_PAPI
 if HAVE_LIBPAPI
 SUBDIRS += papi
 
@@ -190,6 +197,7 @@ SUBDIRS += rapl
 SUBDIRS += hweventpapi
 endif
 
+endif
 endif
 
 if ENABLE_PROCDISKSTATS


### PR DESCRIPTION
Cherry-pick forward of just the fixes in #1325 (but not the new slingshot server sampler) for 4.4.2.