### PR TITLE
Fix buffer size declaration in syspapi

### DIFF
--- a/ldms/src/sampler/syspapi/syspapi_sampler.c
+++ b/ldms/src/sampler/syspapi/syspapi_sampler.c
@@ -89,7 +89,7 @@ typedef struct syspapi_metric_s {
 	int init_rc; /* if 0, attr is good for perf_event_open() */
 	struct perf_event_attr attr; /* perf attribute */
 	char papi_name[256]; /* metric name in PAPI */
-	char pfm_name[256]; /* metric name in perfmon (PAPI native) */
+	char pfm_name[PAPI_HUGE_STR_LEN]; /* metric name in perfmon (PAPI native) */
 	int pfd[]; /* one perf fd per CPU */
 } *syspapi_metric_t;
 


### PR DESCRIPTION
pfm_name copy may be up to size of .info field being copied.
this uses the papi header macro to match.