### PR TITLE
fix free of wild pointer if user omits an arg

### DIFF
--- a/ldms/src/ldmsd/ldmsd_request.c
+++ b/ldms/src/ldmsd/ldmsd_request.c
@@ -2425,7 +2425,7 @@ int strgp_decomp_init(ldmsd_strgp_t strgp, ldmsd_req_ctxt_t req);
 static int strgp_add_handler(ldmsd_req_ctxt_t reqc)
 {
 	char *attr_name, *name, *plugin, *container, *schema, *interval, *regex;
-	char *decomp;
+	char *decomp = NULL;
 	name = plugin = container = schema = NULL;
 	size_t cnt = 0;
 	uid_t uid;


### PR DESCRIPTION
strgp_decomp_init 'goto einval' jumps free an
uninitialized pointer (decomp) if the user supplies the wrong arguments.