### PR TITLE
fix task end message env variables copy code in netlink notifier

### DIFF
--- a/ldms/src/sampler/netlink/netlink-notifier.c
+++ b/ldms/src/sampler/netlink/netlink-notifier.c
@@ -3309,7 +3309,7 @@ static jbuf_t make_process_end_data_slurm(forkstat_t *ft, const struct proc_info
 	int i, iend;
 	iend = sizeof(slurm_env_end_default)/sizeof(slurm_env_end_default[0]);
 	for (i = 0 ; i < iend; i++)
-		if (add_env_attr(&slurm_env_start_default[i], &jb, info, ft))
+		if (add_env_attr(&slurm_env_end_default[i], &jb, info, ft))
 			goto out_1;
 	jb = jbuf_append_str(jb,
 			"\"task_id\":" NULL_STEP_ID ","


### PR DESCRIPTION
cloned code from init message env variable copy code needed conversion to the _end variable.
