### PR TITLE
Make ldms_xprt_by_remote_sin() support IPv6

### DIFF
--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -495,10 +495,12 @@ int ldms_version_check(const struct ldms_version *v);
 /**
  * \brief Find a transport that matches the specified address.
  *
- * \param sin	Specifies the address that should match the remote peer's ip address.
+ * The function will only compare the address if the port is 65535.
+ *
+ * \param sa	Specifies the address that should match the remote peer's ip address.
  * \returns	The matching transport endpoint or NULL if no match was found.
  */
-ldms_t ldms_xprt_by_remote_sin(struct sockaddr_in *sin);
+ldms_t ldms_xprt_by_remote_sin(struct sockaddr *sa);
 
 /**
  * \brief Get the local and remote names of a transport

--- a/ldms/src/ldmsd/ldmsd_prdcr.c
+++ b/ldms/src/ldmsd/ldmsd_prdcr.c
@@ -76,9 +76,12 @@ int prdcr_resolve(const char *hostname, unsigned short port_no,
 {
 	char port_str[16];
 
-	snprintf(port_str, sizeof(port_str), "%d", port_no);
-
-	return ldms_getsockaddr(hostname, port_str, (struct sockaddr*)ss, ss_len);
+	if (port_no) {
+		snprintf(port_str, sizeof(port_str), "%d", port_no);
+		return ldms_getsockaddr(hostname, port_str, (struct sockaddr*)ss, ss_len);
+	} else {
+		return ldms_getsockaddr(hostname, NULL, (struct sockaddr*)ss, ss_len);
+	}
 }
 
 void ldmsd_prdcr___del(ldmsd_cfgobj_t obj)
@@ -777,7 +780,7 @@ static void prdcr_connect(ldmsd_prdcr_t prdcr)
 		}
 		break;
 	case LDMSD_PRDCR_TYPE_PASSIVE:
-		prdcr->xprt = ldms_xprt_by_remote_sin((struct sockaddr_in *)&prdcr->ss);
+		prdcr->xprt = ldms_xprt_by_remote_sin((struct sockaddr *)&prdcr->ss);
 		/* Call connect callback to advance state and update timers*/
 		if (prdcr->xprt) {
 			ldms_xprt_event_cb_set(prdcr->xprt, prdcr_connect_cb, prdcr);


### PR DESCRIPTION
Without this patch, passive producers may not function correctly on systems that support IPv6. This patch ensures that passive producers work properly on IPv6.