### PR TITLE
add the key piece of the json parser error output: the bad input

### DIFF
--- a/lib/src/ovis_json/ovis_json_parser.y
+++ b/lib/src/ovis_json/ovis_json_parser.y
@@ -16,7 +16,8 @@ void yyerror(YYLTYPE *yylloc, json_parser_t parser, char *input, size_t input_le
 	fprintf(stderr, "last line    : %d\n", yylloc->last_line);
 	fprintf(stderr, "first column : %d\n", yylloc->first_column);
 	fprintf(stderr, "last column  : %d\n", yylloc->last_column);
-	fprintf(stderr, "str           : %s\n", str);
+	fprintf(stderr, "str          : %s\n", str);
+	fprintf(stderr, "input        : %s\n", input);
 	if (*pentity) {
 		json_entity_free(*pentity);
 		*pentity = NULL;


### PR DESCRIPTION
When users send malformed json, we get urps such as
```
first_line   : 0
last line    : 0
first column : 0
last column  : 5
str: a cryptic message about colons, commas or curlies.
```
This patch includes 'input' in the message, which tends to be truncated from the complete input very near the error.
With this, the admin has a modest chance of figuring out what message went wrong.