### PR TITLE
443 netlink improvements

### DIFF
--- a/ldms/scripts/examples/linux_proc_sampler
+++ b/ldms/scripts/examples/linux_proc_sampler
@@ -67,11 +67,16 @@ cat << EOF > $LDMSD_RUN/metrics.input
 }
 EOF
 rm -f $LOGDIR/json*.log
+for pi in $(seq 80 100); do
+	touch ${LDMSD_RUN}/ldms-netlink-tracked/$pi
+done
+/bin/rm $LOGDIR/nl.log
+
 drd="valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.drd.txt --trace-cond=yes --trace-fork-join=yes"
 memcheck="valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.memcheck.txt --keep-debuginfo=yes --malloc-fill=3b"
-#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked &
+#${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked --purge-track-dir &
 
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 0 &
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 3 --ProducerName=$(hostname) --purge-track-dir --format 2 &
 
 # uncomment next one to test duplicate handling
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &

--- a/ldms/src/sampler/netlink/netlink-notifier.man
+++ b/ldms/src/sampler/netlink/netlink-notifier.man
@@ -95,7 +95,7 @@ The 'short' options do not override the exclude entirely options.
 .fi
 
 .SH ENVIRONMENT
-The following variables override defaults if a command line option is not present, as describe in the options section.
+The following variables override defaults if a command line option is not present, as described in the options section.
 .nf
 NOTIFIER_EXCLUDE_PROGRAMS="(nullexe):<unknown>"
 NOTIFIER_EXCLUDE_DIRS=/sbin
@@ -109,11 +109,11 @@ NOTIFIER_LDMS_XPRT=sock
 NOTIFIER_LDMS_HOST=localhost
 NOTIFIER_LDMS_PORT=411
 NOTIFIER_LDMS_AUTH=munge
-NOTIFIER_FORMAT=1
+NOTIFIER_FORMAT=2
 NOTIFIER_HEARTBEAT=(none)
 .fi
 Omitting (nullexe):<unknown> from NOTIFIER_EXCLUDE_PROGRAMS may cause incomplete output
-related to processes no longer present. In exotic circumstances, this may be desirable anyway.
+related to processes no longer present. In exotic circumstances, this may be desirable.
 
 .SH FILES
 
@@ -139,6 +139,8 @@ ProducerName and component_id. The version of the tuned formats is specified by 
 Format 0 omits the start time from slurm process end messages (since it is only sometimes known) and omits process duration, which depend on the start time.
 .PP
 Format 1 includes the start time for slurm process or the dummy value 0 when unknown) and includes process duration for all end messages. When the start time is unavailable, duration of -1.0 is published. Merging data from other sources may allow durations flagged as -1 to be computed in some later data cleanup step.
+.PP
+Format 2 extends process end messages with the executable name in field 'exe'. When this is not available, exe of '/no-exe-data' is published. Merging data from other sources may allow exe flagged as /no-exe-data to be computed in some later data cleanup step.
 
 
 .SH NOTES
@@ -152,22 +154,23 @@ to add a node identifier to the messages. Normally a process-following sampler t
 will add the node identifier automatically.
 .PP
 When the daemon is started after a process is started, the process start time and therefore process
-duration may not be available. In message formats which report start time, 0 indicates
+duration may not be available. Similarly exe may not be available. In message formats which report
+start time, 0 indicates
 data was unavailable. For processes without completely known time bounds, the duration is reported
-as -1.0.
+as -1.0. For processes without known program paths, exe is reported as /no-exe-data.
 .PP
 Options are still in development. Several options affect only the trace output.
 
 .SH EXAMPLES
 .PP
-Run for 30 seconds with screen and json.log test output connecting to the ldmsd from 'ldms-static-test.sh blobwriter' test:
+To run for 30 seconds with screen and json.log test output connecting to the ldmsd from 'ldms-static-test.sh blobwriter' test:
 .nf
 netlink-notifier -t -D 30 -g -u 1 -x  -e exec,clone,exit  \\
 	-j json.log --exclude-dir-path=/bin:/sbin:/usr \\
 	--port=61061 --auth=none --reconnect=1"
 .fi
 .PP
-Run in a typical deployment (sock, munge, port 411, localhost, forever, 10 minute reconnect):
+To run in a typical deployment (sock, munge, port 411, localhost, forever, 10 minute reconnect):
 .nf
 netlink-notifier
 .fi

--- a/ldms/src/sampler/netlink/netlink-notifier.man
+++ b/ldms/src/sampler/netlink/netlink-notifier.man
@@ -86,6 +86,9 @@ The 'short' options do not override the exclude entirely options.
 	 and it should not contain any files except those created by
 	 this daemon. When enabled, track-dir will be populated even if
 	 -S is used to suppress the stream output.
+--purge-track-dir	if track-dir is set, purge any files there
+	 which do not correspond to current processes.
+	 Equivalently, NOTIFIER_PURGE_TRACK_DIR may be set.
 --component_id=<U64>     set the value of component_id.
 	 If not set, the component_id field is not included in the stream formats produced.
 --ProducerName=<name>    set the value of ProducerName
@@ -111,9 +114,11 @@ NOTIFIER_LDMS_PORT=411
 NOTIFIER_LDMS_AUTH=munge
 NOTIFIER_FORMAT=2
 NOTIFIER_HEARTBEAT=(none)
+NOTIFIER_PURGE_TRACK_DIR
 .fi
 Omitting (nullexe):<unknown> from NOTIFIER_EXCLUDE_PROGRAMS may cause incomplete output
 related to processes no longer present. In exotic circumstances, this may be desirable.
+The value of NOTIFIER_PURGE_TRACK_DIR is not used to enable purge, just its presence.
 
 .SH FILES
 
@@ -126,10 +131,12 @@ For each pid started event which would be emitted to an LDMS stream, a temporary
 file with the name of the pid is created in NOTIFIER_TRACK_DIR. The file
 will contain the json event attempted. The temporary file will
 be removed when the corresponding pid stopped event is sent.
-These files are not removed when the notifier daemon exits.
+These files are not removed when the notifier daemon exits, so that
+they will be found after a restart.
 Client applications may validate a file by checking the contents
 against the /proc/$pid/stat content, if it exists.
-Invalid files should be removed by clients or system scripts.
+Invalid files should be removed by clients or system scripts; the purge option
+is provided to optionally do this on start.
 
 .SH MESSAGE FORMATS
 Message formats tuned to SLURM, LSF, and Linux without a batch scheduler


### PR DESCRIPTION
This adds a format extension to include program names in exit messages, the purge-track-dir option to clean up expired tracking files, and fixes certain ignored environment variables. The test of the notifier is updated with it.