### PR TITLE
remove extra string substitution that crashes in linux_proc_sampler

### DIFF
--- a/ldms/src/sampler/app_sampler/linux_proc_sampler.c
+++ b/ldms/src/sampler/app_sampler/linux_proc_sampler.c
@@ -2789,7 +2789,7 @@ static int publish_argv_pid(linux_proc_sampler_inst_t inst, struct linux_proc_sa
 #endif
 	if (inst->log_send) {
 		INST_LOG(inst, LDMSD_LDEBUG,
-			"Sending pid %d argv %s%s%s\n",
+			"Sending pid %d argv %s%s\n",
 			app_set->key.os_pid, pname ? " on" : "",
 			pname ? pname : "");
 	}


### PR DESCRIPTION
Extraneous %s in format strings cause wild pointer reads and crashes.