### PR TITLE
Netlink stream format harmonization for 4.4

### DIFF
--- a/ldms/scripts/examples/linux_proc_sampler.job
+++ b/ldms/scripts/examples/linux_proc_sampler.job
@@ -5,13 +5,14 @@ export LDMSD_LOG_LEVEL=ERROR
 export LDMSD_LOG_TIME_SEC=1
 export LDMSD_EXTRA="-m 128m"
 
+tuser=nobody
 function SUSLEEP () {
 	if test "$bypass" = "1"; then
 		echo skipping sleep
 		return 0
 	fi
 	echo -n sleep $1 ...
-	runuser -u $USER sleep $1
+	runuser -p -u $tuser sleep $1
 	echo done
 }
 
@@ -86,9 +87,12 @@ JOBDATA $TESTDIR/job.data 1
 
 drd="valgrind -v --tool=drd --log-file=$LOGDIR/vg.netlink.drd.txt --trace-cond=yes --trace-fork-join=yes"
 memcheck="valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.memcheck.txt --keep-debuginfo=yes --malloc-fill=3b"
+memcheck="valgrind -v --leak-check=full --track-origins=yes --trace-children=yes  --log-file=$LOGDIR/vg.netlink.memcheck.txt --malloc-fill=3b"
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked --purge-track-dir &
 
-${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 3 --ProducerName=$(hostname) --purge-track-dir --format 2 --jobid-file=$TESTDIR/job.data.1 &
+echo \
+"${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 1 --ProducerName=$(hostname) --purge-track-dir --format 3 --jobid-file=$TESTDIR/job.data.1 " > ${LDMSD_RUN}/start.netlink
+${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json.log --exclude-dir-path= --exclude-short-path= --exclude-programs --track-dir=${LDMSD_RUN}/ldms-netlink-tracked -x -e exec,clone,exit  -L $LOGDIR/nl.log --heartbeat 1 -v 1 --ProducerName=$(hostname) --purge-track-dir --format 3 --jobid-file=$TESTDIR/job.data.1 &
 
 # uncomment next one to test duplicate handling
 #${BUILDDIR}/sbin/ldms-netlink-notifier --port=61061 --auth=none --reconnect=1 -D 30 -r -j $LOGDIR/json2.log --exclude-dir-path= --exclude-short-path= --exclude-programs &
@@ -109,14 +113,20 @@ JOBDATA $TESTDIR/job.data 1
 SUSLEEP 1
 LDMS_LS 2 -v
 JOBDATA $TESTDIR/job.data 1
+export LSB_JOBID=12345
 SUSLEEP 5
+unset LSB_JOBID
+export LSB_JOBID
 #MESSAGE stream_client_dump on sampler daemon 1
 #for lc in $(seq 1); do
 #ldmsd_controller --auth none --port 61061 --cmd stream_client_dump
 #	SUSLEEP 1
 #done
 JOBDATA $TESTDIR/job.data 1
+export SLURM_JOB_ID=54321
 SUSLEEP 5
+unset SLURM_JOB_ID
+export SLURM_JOB_ID
 for lc in $(seq 1); do
 #LDMS_LS 1 -v
 	JOBDATA $TESTDIR/job.data 1

--- a/ldms/src/sampler/netlink/netlink-notifier.c
+++ b/ldms/src/sampler/netlink/netlink-notifier.c
@@ -3317,20 +3317,38 @@ err:
 /* /////////// end of functions to get env var from a pid ///////////////// */
 #include "ovis_json/ovis_json.h"
 
+/* If jobid unset, copy host_jobid into info.
+ */
+void check_info_jobid( struct proc_info *info, forkstat_t *ft) {
+	if (info->jobid)
+		return;
+	if (info->uid >= UID_MIN && ft->host_jobid)
+		info->jobid = strdup(ft->host_jobid);
+}
+
 /* get jobid string from pid environ if present, or if uid > UID_MIN,
- * get host_jobid */
-#define info_jobid_str(info, ft) info->jobid ? info->jobid : ( (info->uid >= UID_MIN && ft->host_jobid) ? ft->host_jobid : "0")
+ * get host_jobid.
+ */
+char *info_jobid_str( const struct proc_info *info, forkstat_t *ft) {
+	if (info->jobid)
+		return info->jobid;
+	if (info->uid >= UID_MIN && ft->host_jobid) {
+		return ft->host_jobid;
+	}
+	return "0";
+}
 
 
-static int add_env_attr(struct env_attr *a, jbuf_t *jb, const struct proc_info *info, forkstat_t *ft)
+/* append attr string to jb; if !last, field is also followed by a comma */
+static int add_env_attr(struct env_attr *a, jbuf_t *jb, const struct proc_info *info, forkstat_t *ft, bool last)
 {
 	const char *s = info_get_var(a->env, info, ft);
 	if (!s)
 		s = a->v_default;
 	if (a->quoted == ATTR_QUOTED) {
-		*jb = jbuf_append_attr(*jb, a->attr, "\"%s\",", s );
+		*jb = jbuf_append_attr(*jb, a->attr, "\"%s\"%s", s , (last ? "" : ","));
 	} else {
-		*jb = jbuf_append_attr(*jb, a->attr, "%s,", s);
+		*jb = jbuf_append_attr(*jb, a->attr, "%s%s", s, (last ? "" : ","));
 	}
 	if (!*jb)
 		return errno;
@@ -3349,50 +3367,99 @@ static jbuf_t make_process_start_data_linux(forkstat_t *ft, const struct proc_in
 	if (!jb)
 		return NULL;
 	pthread_mutex_lock(&host_jobid_lock);
-	jb = jbuf_append_str(jb,
-		"{"
-		"\"msgno\":%" PRIu64 ","
-		"\"schema\":\"linux_task_data\","
-		"\"event\":\"task_init_priv\","
-		"\"timestamp\":%d,"
-#if DEBUG_EMITTER
-		"\"emitter\":\"%s\","
-#endif
-		"\"context\":\"*\","
-		"\"data\":"
+	if (ft->format < 3) {
+		jb = jbuf_append_str(jb,
 			"{"
-			"%s%s"
-			"\"start\":\"%lu.%06lu\","
-			/* format start_tick as string because u64 is out
-			 * of ovis_json signed int range */
-			"\"start_tick\":\"%" PRIu64 "\","
-			"\"job_id\":\"%s\","
-			"\"serial\":%" PRId64 ","
-			"\"os_pid\":%" PRId64 ","
-			"\"uid\":%" PRId64 ","
-			"\"gid\":%" PRId64 ","
-			"\"task_pid\":%d,"
-			"\"task_global_id\":" NULL_STEP_ID ","
-			"\"is_thread\":%d,"
-			"\"exe\":\"%s\""
-			"}"
-		"}",
-		forkstat_get_serial(ft),
-		time(NULL),
+			"\"msgno\":%" PRIu64 ","
+			"\"schema\":\"linux_task_data\","
+			"\"event\":\"task_init_priv\","
+			"\"timestamp\":%d,"
 #if DEBUG_EMITTER
-		type,
+			"\"emitter\":\"%s\","
 #endif
-			ft->prod_field, ft->compid_field,
-			info->start.tv_sec, info->start.tv_usec,
-			info->start_tick,
-			info_jobid_str(info, ft),
-			info->serno,
-			(int64_t)info->pid,
-			(int64_t)info->uid,
-			(int64_t)info->gid,
-			(int)info->pid,
-			(int)info->is_thread,
-			info->exe);
+			"\"context\":\"*\","
+			"\"data\":"
+				"{"
+				"%s%s"
+				"\"start\":\"%lu.%06lu\","
+				/* format start_tick as string because u64 is out
+				 * of ovis_json signed int range */
+				"\"start_tick\":\"%" PRIu64 "\","
+				"\"job_id\":\"%s\","
+				"\"serial\":%" PRId64 ","
+				"\"os_pid\":%" PRId64 ","
+				"\"uid\":%" PRId64 ","
+				"\"gid\":%" PRId64 ","
+				"\"task_pid\":%d,"
+				"\"task_global_id\":" NULL_STEP_ID ","
+				"\"is_thread\":%d,"
+				"\"exe\":\"%s\""
+				"}"
+			"}",
+			forkstat_get_serial(ft),
+			time(NULL),
+#if DEBUG_EMITTER
+			type,
+#endif
+				ft->prod_field, ft->compid_field,
+				info->start.tv_sec, info->start.tv_usec,
+				info->start_tick,
+				info_jobid_str(info, ft),
+				info->serno,
+				(int64_t)info->pid,
+				(int64_t)info->uid,
+				(int64_t)info->gid,
+				(int)info->pid,
+				(int)info->is_thread,
+				info->exe);
+	}
+	if (ft->format == 3) {
+		jb = jbuf_append_str(jb,
+			"{"
+			"\"msgno\":%" PRIu64 ","
+			"\"schema\":\"linux_task_data\","
+			"\"event\":\"task_init_priv\","
+			"\"timestamp\":%d,"
+#if DEBUG_EMITTER
+			"\"emitter\":\"%s\","
+#endif
+			"\"context\":\"*\","
+			"\"data\":"
+				"{"
+				"%s%s"
+				"\"start\":\"%lu.%06lu\","
+				"\"job_id\":\"%s\","
+				"\"serial\":%" PRId64 ","
+				"\"os_pid\":%" PRId64 ","
+				"\"uid\":%" PRId64 ","
+				"\"gid\":%" PRId64 ","
+				"\"is_thread\":%d,"
+				"\"exe\":\"%s\","
+				/* format start_tick as string because u64 is out
+				 * of ovis_json signed int range */
+				"\"start_tick\":\"%" PRIu64 "\","
+				"\"task_pid\":%d,"
+				"\"task_global_id\":" NULL_STEP_ID
+				"}"
+			"}",
+			forkstat_get_serial(ft),
+			time(NULL),
+#if DEBUG_EMITTER
+			type,
+#endif
+				ft->prod_field, ft->compid_field,
+				info->start.tv_sec, info->start.tv_usec,
+				info_jobid_str(info, ft),
+				info->serno,
+				(int64_t)info->pid,
+				(int64_t)info->uid,
+				(int64_t)info->gid,
+				(int)info->is_thread,
+				info->exe,
+				info->start_tick,
+				(int)info->pid
+				);
+	}
 	pthread_mutex_unlock(&host_jobid_lock);
 	return jb;
 
@@ -3504,6 +3571,49 @@ static jbuf_t make_process_end_data_linux(forkstat_t *ft, const struct proc_info
 				info->duration,
 				info->exe ? info->exe : no_exe_data
 				);
+	else if (ft->format == 3) {
+		jb = jbuf_append_str(jb,
+			"{"
+			"\"msgno\":%" PRIu64 ","
+			"\"schema\":\"linux_task_data\","
+			"\"event\":\"task_exit\","
+			"\"timestamp\":%d,"
+			"\"context\":\"*\","
+			"\"data\":"
+				"{"
+				"%s%s"
+				"\"start\":\"%lu.%06lu\","
+				"\"job_id\":\"%s\","
+				"\"serial\":%" PRId64 ","
+				"\"os_pid\":%" PRId64 ","
+				"\"uid\":%" PRId64 ","
+				"\"gid\":%" PRId64 ","
+				"\"is_thread\":%d,"
+				"\"exe\":\"%s\","
+				"\"duration\":%.17g",
+				/* format start_tick as string because u64 is out
+				 * of ovis_json signed int range */
+				"\"start_tick\":\"%" PRIu64 "\","
+				"\"task_pid\":%d,"
+				"\"task_global_id\":" NULL_STEP_ID
+				"}"
+			"}",
+			forkstat_get_serial(ft),
+			time(NULL),
+				ft->prod_field, ft->compid_field,
+				info->start.tv_sec, info->start.tv_usec,
+				info_jobid_str(info, ft),
+				info->serno,
+				(int64_t)info->pid,
+				(int64_t)info->uid,
+				(int64_t)info->gid,
+				(int)info->is_thread,
+				info->exe ? info->exe : no_exe_data,
+				info->duration,
+				info->start_tick,
+				(int)info->pid
+				);
+	}
 	else
 		jb = NULL;
 
@@ -3518,45 +3628,92 @@ static jbuf_t make_process_start_data_lsf(forkstat_t *ft, const struct proc_info
 	if (!jb)
 		return NULL;
 	pthread_mutex_lock(&host_jobid_lock);
-	jb = jbuf_append_str(jb,
-		"{"
-		"\"msgno\":%" PRIu64 ","
-		"\"schema\":\"lsf_task_data\","
-		"\"event\":\"task_init_priv\","
-		"\"timestamp\":%d,"
-		"\"context\":\"*\","
-		"\"data\":"
+	if (ft->format < 3) {
+		jb = jbuf_append_str(jb,
 			"{"
-			"%s%s"
-			"\"start\":\"%lu.%06lu\","
-			"\"job_id\":\"%s\","
-			"\"serial\":%" PRId64 ","
-			"\"os_pid\":%" PRId64 ",",
-		forkstat_get_serial(ft),
-		time(NULL),
-			ft->prod_field, ft->compid_field,
-			info->start.tv_sec, info->start.tv_usec,
-			info_jobid_str(info, ft),
-			info->serno,
-			(int64_t)info->pid);
-	if (!jb)
-		goto out_1;
-	size_t i, iend;
-	iend = ARRAY_SIZE(lsf_env_start_default);
-	for (i = 0 ; i < iend; i++)
-		if (add_env_attr(&lsf_env_start_default[i], &jb, info, ft))
+			"\"msgno\":%" PRIu64 ","
+			"\"schema\":\"lsf_task_data\","
+			"\"event\":\"task_init_priv\","
+			"\"timestamp\":%d,"
+			"\"context\":\"*\","
+			"\"data\":"
+				"{"
+				"%s%s"
+				"\"start\":\"%lu.%06lu\","
+				"\"job_id\":\"%s\","
+				"\"serial\":%" PRId64 ","
+				"\"os_pid\":%" PRId64 ",",
+			forkstat_get_serial(ft),
+			time(NULL),
+				ft->prod_field, ft->compid_field,
+				info->start.tv_sec, info->start.tv_usec,
+				info_jobid_str(info, ft),
+				info->serno,
+				(int64_t)info->pid);
+		if (!jb)
 			goto out_1;
-	jb = jbuf_append_str(jb,
-			"\"uid\":%" PRId64 ","
-			"\"gid\":%" PRId64 ","
-			"\"is_thread\":%d,"
-			"\"exe\":\"%s\""
-			"}"
-		"}",
-			(int64_t)info->uid,
-			(int64_t)info->gid,
-			(int)info->is_thread,
-			info->exe);
+		size_t i, iend;
+		iend = ARRAY_SIZE(lsf_env_start_default);
+		for (i = 0 ; i < iend; i++)
+			if (add_env_attr(&lsf_env_start_default[i], &jb, info, ft, 0))
+				goto out_1;
+		jb = jbuf_append_str(jb,
+				"\"uid\":%" PRId64 ","
+				"\"gid\":%" PRId64 ","
+				"\"is_thread\":%d,"
+				"\"exe\":\"%s\""
+				"}"
+			"}",
+				(int64_t)info->uid,
+				(int64_t)info->gid,
+				(int)info->is_thread,
+				info->exe);
+	} else if (ft->format == 3) {
+		jb = jbuf_append_str(jb,
+			"{"
+			"\"msgno\":%" PRIu64 ","
+			"\"schema\":\"lsf_task_data\","
+			"\"event\":\"task_init_priv\","
+			"\"timestamp\":%d,"
+			"\"context\":\"*\","
+			"\"data\":"
+				"{"
+				"%s%s"
+				"\"start\":\"%lu.%06lu\","
+				"\"job_id\":\"%s\","
+				"\"serial\":%" PRId64 ","
+				"\"os_pid\":%" PRId64 ","
+				"\"uid\":%" PRId64 ","
+				"\"gid\":%" PRId64 ","
+				"\"is_thread\":%d,"
+				"\"exe\":\"%s\","
+				/* format start_tick as string because u64 is out
+				 * of ovis_json signed int range */
+				"\"start_tick\":\"%" PRIu64 "\",",
+			forkstat_get_serial(ft),
+			time(NULL),
+				ft->prod_field, ft->compid_field,
+				info->start.tv_sec, info->start.tv_usec,
+				info_jobid_str(info, ft),
+				info->serno,
+				(int64_t)info->pid,
+				(int64_t)info->uid,
+				(int64_t)info->gid,
+				(int)info->is_thread,
+				info->exe,
+				info->start_tick
+				);
+		if (!jb)
+			goto out_1;
+		size_t i, iend;
+		iend = ARRAY_SIZE(lsf_env_start_default);
+		for (i = 0 ; i < iend; i++)
+			if (add_env_attr(&lsf_env_start_default[i], &jb, info, ft, (i == (iend-1))))
+				goto out_1;
+		jb = jbuf_append_str(jb,
+				"}"
+			"}");
+	}
 
  out_1:
 	pthread_mutex_unlock(&host_jobid_lock);
@@ -3570,7 +3727,7 @@ static jbuf_t make_process_end_data_lsf(forkstat_t *ft, const struct proc_info *
 	if (!jb)
 		return NULL;
 	pthread_mutex_lock(&host_jobid_lock);
-	if (ft->format == 0)
+	if (ft->format == 0) {
 		jb = jbuf_append_str(jb,
 			"{"
 			"\"msgno\":%" PRIu64 ","
@@ -3592,7 +3749,7 @@ static jbuf_t make_process_end_data_lsf(forkstat_t *ft, const struct proc_info *
 				info_jobid_str(info, ft),
 				info->serno,
 				(int64_t)info->pid);
-	else if (ft->format == 1)
+	} else if (ft->format == 1) {
 		jb = jbuf_append_str(jb,
 			"{"
 			"\"msgno\":%" PRIu64 ","
@@ -3617,7 +3774,7 @@ static jbuf_t make_process_end_data_lsf(forkstat_t *ft, const struct proc_info *
 				(int64_t)info->pid,
 				info->duration
 				);
-	else if (ft->format == 2)
+	} else if (ft->format == 2) {
 		jb = jbuf_append_str(jb,
 			"{"
 			"\"msgno\":%" PRIu64 ","
@@ -3644,20 +3801,71 @@ static jbuf_t make_process_end_data_lsf(forkstat_t *ft, const struct proc_info *
 				info->duration,
 				info->exe ? info->exe : no_exe_data
 				);
+	} else if (ft->format == 3) {
+		jb = jbuf_append_str(jb,
+			"{"
+			"\"msgno\":%" PRIu64 ","
+			"\"schema\":\"linux_task_data\","
+			"\"event\":\"task_init_priv\","
+			"\"timestamp\":%d,"
+			"\"context\":\"*\","
+			"\"data\":"
+				"{"
+				"%s%s"
+				"\"start\":\"%lu.%06lu\","
+				"\"job_id\":\"%s\","
+				"\"serial\":%" PRId64 ","
+				"\"os_pid\":%" PRId64 ","
+				"\"uid\":%" PRId64 ","
+				"\"gid\":%" PRId64 ","
+				"\"is_thread\":%d,"
+				"\"exe\":\"%s\","
+				"\"duration\":%.17g",
+				/* format start_tick as string because u64 is out
+				 * of ovis_json signed int range */
+				"\"start_tick\":\"%" PRIu64 "\",",
+			forkstat_get_serial(ft),
+			time(NULL),
+				ft->prod_field, ft->compid_field,
+				info->start.tv_sec, info->start.tv_usec,
+				info_jobid_str(info, ft),
+				info->serno,
+				(int64_t)info->pid,
+				(int64_t)info->uid,
+				(int64_t)info->gid,
+				(int)info->is_thread,
+				info->exe ? info->exe : no_exe_data,
+				info->duration,
+				info->start_tick
+				);
+		if (!jb)
+			goto out_1;
+		size_t i, iend;
+		iend = ARRAY_SIZE(lsf_env_start_default);
+		for (i = 0 ; i < iend; i++)
+			if (add_env_attr(&lsf_env_start_default[i], &jb, info, ft, (i == (iend-1))))
+				goto out_1;
+		jb = jbuf_append_str(jb,
+				"}"
+			"}");
+	}
 	else
 		jb = NULL;
 	if (!jb)
 		goto out_1;
-	size_t i, iend;
-	iend = ARRAY_SIZE(lsf_env_start_default);
-	for (i = 0 ; i < iend; i++)
-		if (add_env_attr(&lsf_env_start_default[i], &jb, info, ft))
-			goto out_1;
-	jb = jbuf_append_str(jb,
-			"\"uid\":%" PRId64
-			"}"
-		"}",
-			(int64_t)info->uid);
+	/* common append env for cases 0-2 */
+	if (ft->format < 3) {
+		size_t i, iend;
+		iend = ARRAY_SIZE(lsf_env_start_default);
+		for (i = 0 ; i < iend; i++)
+			if (add_env_attr(&lsf_env_start_default[i], &jb, info, ft, 0))
+				goto out_1;
+		jb = jbuf_append_str(jb,
+				"\"uid\":%" PRId64
+				"}"
+			"}",
+				(int64_t)info->uid);
+	}
 
  out_1:
 	pthread_mutex_unlock(&host_jobid_lock);
@@ -3675,48 +3883,107 @@ static jbuf_t make_process_start_data_slurm(forkstat_t *ft, const struct proc_in
 	if (!jb)
 		return NULL;
 	pthread_mutex_lock(&host_jobid_lock);
-	jb = jbuf_append_str(jb,
-		"{"
-		"\"msgno\":%" PRIu64 ","
-		"\"schema\":\"slurm_task_data\","
-		"\"event\":\"task_init_priv\","
-		"\"timestamp\":%d,"
-#if DEBUG_EMITTER
-		"\"emitter\":\"%s\","
-#endif
-		"\"context\":\"*\","
-		"\"data\":"
+	if (ft->format < 3) {
+		jb = jbuf_append_str(jb,
 			"{"
-			"%s%s"
-			"\"job_id\":\"%s\","
-			"\"serial\":%" PRId64 ","
-			"\"os_pid\":%" PRId64 ",",
-		forkstat_get_serial(ft),
-		time(NULL),
+			"\"msgno\":%" PRIu64 ","
+			"\"schema\":\"slurm_task_data\","
+			"\"event\":\"task_init_priv\","
+			"\"timestamp\":%d,"
 #if DEBUG_EMITTER
-		type,
+			"\"emitter\":\"%s\","
 #endif
-			ft->prod_field, ft->compid_field,
-			info_jobid_str(info, ft),
-			info->serno,
-			(int64_t)info->pid);
-	size_t i, iend;
-	iend = ARRAY_SIZE(slurm_env_start_default);
-	for (i = 0 ; i < iend; i++) {
-		if (add_env_attr(&slurm_env_start_default[i], &jb, info, ft))
+			"\"context\":\"*\","
+			"\"data\":"
+				"{"
+				"%s%s"
+				"\"job_id\":\"%s\","
+				"\"serial\":%" PRId64 ","
+				"\"os_pid\":%" PRId64 ",",
+			forkstat_get_serial(ft),
+			time(NULL),
+#if DEBUG_EMITTER
+			type,
+#endif
+				ft->prod_field, ft->compid_field,
+				info_jobid_str(info, ft),
+				info->serno,
+				(int64_t)info->pid);
+		size_t i, iend;
+		iend = ARRAY_SIZE(slurm_env_start_default);
+		for (i = 0 ; i < iend; i++) {
+			if (add_env_attr(&slurm_env_start_default[i], &jb, info, ft, 0))
+				goto out_1;
+		}
+		jb = jbuf_append_str(jb,
+				"\"task_id\":" NULL_STEP_ID ","
+				"\"task_global_id\":" NULL_STEP_ID ","
+				"\"is_thread\":%d,"
+				"\"exe\":\"%s\","
+				"\"ncpus\":" NULL_STEP_ID ","
+				"\"local_tasks\":" NULL_STEP_ID
+				"}"
+			"}",
+				(int)info->is_thread,
+				info->exe);
+	} else if (ft->format == 3) {
+		jb = jbuf_append_str(jb,
+			"{"
+			"\"msgno\":%" PRIu64 ","
+			"\"schema\":\"slurm_task_data\","
+			"\"event\":\"task_init_priv\","
+			"\"timestamp\":%d,"
+#if DEBUG_EMITTER
+			"\"emitter\":\"%s\","
+#endif
+			"\"context\":\"*\","
+			"\"data\":"
+				"{"
+				"%s%s"
+				"\"start\":\"%lu.%06lu\","
+				"\"job_id\":\"%s\","
+				"\"serial\":%" PRId64 ","
+				"\"os_pid\":%" PRId64 ","
+				"\"uid\":%" PRId64 ","
+				"\"gid\":%" PRId64 ","
+				"\"is_thread\":%d,"
+				"\"exe\":\"%s\","
+				/* format start_tick as string because u64 is out
+				 * of ovis_json signed int range */
+				"\"start_tick\":\"%" PRIu64 "\","
+				"\"task_pid\":%d,"
+				"\"task_global_id\":" NULL_STEP_ID ","
+				"\"ncpus\":" NULL_STEP_ID ","
+				"\"local_tasks\":" NULL_STEP_ID ",",
+			forkstat_get_serial(ft),
+			time(NULL),
+#if DEBUG_EMITTER
+			type,
+#endif
+				ft->prod_field, ft->compid_field,
+				info->start.tv_sec, info->start.tv_usec,
+				info_jobid_str(info, ft),
+				info->serno,
+				(int64_t)info->pid,
+				(int64_t)info->uid,
+				(int64_t)info->gid,
+				(int)info->is_thread,
+				info->exe,
+				info->start_tick,
+				(int)info->pid
+				);
+		if (!jb)
 			goto out_1;
+		size_t i, iend;
+		iend = ARRAY_SIZE(slurm_env_start_default);
+		for (i = 0 ; i < iend; i++) {
+			if (add_env_attr(&slurm_env_start_default[i], &jb, info, ft, (i == (iend-1))))
+				goto out_1;
+		}
+		jb = jbuf_append_str(jb,
+				"}"
+			"}");
 	}
-	jb = jbuf_append_str(jb,
-			"\"task_id\":" NULL_STEP_ID ","
-			"\"task_global_id\":" NULL_STEP_ID ","
-			"\"is_thread\":%d,"
-			"\"exe\":\"%s\","
-			"\"ncpus\":" NULL_STEP_ID ","
-			"\"local_tasks\":" NULL_STEP_ID
-			"}"
-		"}",
-			(int)info->is_thread,
-			info->exe);
  out_1:
 	pthread_mutex_unlock(&host_jobid_lock);
 	return jb;
@@ -3802,21 +4069,79 @@ static jbuf_t make_process_end_data_slurm(forkstat_t *ft, const struct proc_info
 				info->duration,
 				info->exe ? info->exe : no_exe_data
 				);
+	else if  (ft->format == 3) {
+		jb = jbuf_append_str(jb,
+			"{"
+			"\"msgno\":%" PRIu64 ","
+			"\"schema\":\"slurm_task_data\","
+			"\"event\":\"task_init_priv\","
+			"\"timestamp\":%d,"
+			"\"context\":\"*\","
+			"\"data\":"
+				"{"
+				"%s%s"
+				"\"start\":\"%lu.%06lu\","
+				"\"job_id\":\"%s\","
+				"\"serial\":%" PRId64 ","
+				"\"os_pid\":%" PRId64 ","
+				"\"uid\":%" PRId64 ","
+				"\"gid\":%" PRId64 ","
+				"\"is_thread\":%d,"
+				"\"exe\":\"%s\","
+				"\"duration\":%.17g",
+				/* format start_tick as string because u64 is out
+				 * of ovis_json signed int range */
+				"\"start_tick\":\"%" PRIu64 "\","
+				"\"task_pid\":%d,"
+				"\"task_global_id\":" NULL_STEP_ID ","
+				"\"ncpus\":" NULL_STEP_ID ","
+				"\"local_tasks\":" NULL_STEP_ID ",",
+			forkstat_get_serial(ft),
+			time(NULL),
+				ft->prod_field, ft->compid_field,
+				info->start.tv_sec, info->start.tv_usec,
+				info_jobid_str(info, ft),
+				info->serno,
+				(int64_t)info->pid,
+				(int64_t)info->uid,
+				(int64_t)info->gid,
+				(int)info->is_thread,
+				info->exe ? info->exe : no_exe_data,
+				info->duration,
+				info->start_tick,
+				(int)info->pid
+				);
+		if (!jb)
+			goto out_1;
+		size_t i, iend;
+		iend = ARRAY_SIZE(slurm_env_start_default);
+		for (i = 0 ; i < iend; i++) { /* deliberately reusing start array here. */
+			if (add_env_attr(&slurm_env_start_default[i], &jb, info, ft, (i == (iend-1))))
+				goto out_1;
+		}
+		jb = jbuf_append_str(jb,
+				"}"
+			"}");
+
+	}
 	else
 		jb = NULL;
 	if (!jb)
 		goto out_1;
-	int i, iend;
-	iend = ARRAY_SIZE(slurm_env_end_default);
-	for (i = 0 ; i < iend; i++)
-		if (add_env_attr(&slurm_env_start_default[i], &jb, info, ft))
-			goto out_1;
-	jb = jbuf_append_str(jb,
-			"\"task_id\":" NULL_STEP_ID ","
-			"\"task_global_id\":" NULL_STEP_ID ","
-			"\"task_exit_status\":\"*\""
-			"}"
-		"}");
+	if (ft->format < 3) {
+		/* common end for formats < 3 */
+		int i, iend;
+		iend = ARRAY_SIZE(slurm_env_end_default);
+		for (i = 0 ; i < iend; i++)
+			if (add_env_attr(&slurm_env_end_default[i], &jb, info, ft, 0))
+				goto out_1;
+		jb = jbuf_append_str(jb,
+				"\"task_id\":" NULL_STEP_ID ","
+				"\"task_global_id\":" NULL_STEP_ID ","
+				"\"task_exit_status\":\"*\""
+				"}"
+			"}");
+	}
 
  out_1:
 	pthread_mutex_unlock(&host_jobid_lock);
@@ -3887,6 +4212,7 @@ static jbuf_t make_ldms_message(forkstat_t *ft, struct proc_info *info, const ch
 			free_env(pidenv);
 		}
 	}
+	check_info_jobid(info, ft);
 
 	if (emit_event & EMIT_EXIT) {
 		switch (info->rm_type) {


### PR DESCRIPTION
Adds format 3 option to the netlink publisher. This makes linux/slurm/lsf json messages and init/exit messages similar in field ordering to the maximum extent possible so that creating policies and tools transforming stream data across resource managers is simpler. 