### PR TITLE
Add logic in configure.ac to check for flex and fail if not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,11 @@ dnl if LEX is not available, the configure still won't fail
 AC_PROG_LEX
 AC_PROG_LN_S
 
+AC_PATH_PROG(FLEX, flex)
+if test -z "$FLEX"; then
+   AC_MSG_ERROR([You need the 'flex' lexer generator to compile LDMS])
+fi
+
 AC_ARG_VAR([BISON], [bison command])
 AC_CHECK_PROG([BISON], [bison -y], [bison -y], [no])
 AS_IF([test "x$BISON" = "xno"], [AC_MSG_ERROR([bison not found])])

--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,6 @@ AC_PATH_PROG(FLEX, flex)
 if test -z "$FLEX"; then
    AC_MSG_ERROR([You need the 'flex' lexer generator to compile LDMS])
 fi
-
 AC_ARG_VAR([BISON], [bison command])
 AC_CHECK_PROG([BISON], [bison -y], [bison -y], [no])
 AS_IF([test "x$BISON" = "xno"], [AC_MSG_ERROR([bison not found])])


### PR DESCRIPTION
I encountered an issue when trying to build LDMS on AlmaLinux8 where flex wasn't installed on the system.  It doesn't fail at configure, and the error during compilation is esoteric. 

@nichamon @bschwal @baallan

The issue:

there’s a problem when you run configure without flex support, it configures fine, but fails with some esoteric error:

```
make[6]: Entering directory '/home/jkgreen/Source/ovis/build/lib/src/ovis_json'
  CC       ovis_json_test-ovis_json_test.o
  CC       ovis_json.lo
: -o ovis_json_lexer.c ../../../../lib/src/ovis_json/ovis_json_lexer.l
  CC       ovis_json_lexer.lo
gcc: error: ovis_json_lexer.c: No such file or directory
gcc: fatal error: no input files
```
The error output suggests a bug or incompatibility in bison or yacc, when really, it just needs a flex package to work.  Apparently, this has bit more than one of us, so I thought I'd supply a quick patch.

Here's a reproducer:

```bash
#!/bin/bash
[[ -d OVIS ]] && rm -Rf OVIS

## Reproducer for issue with flex not being on the system

git clone -b OVIS-4 https://github.com/ovis-hpc/ovis.git OVIS
cd ovis/
cd ../OVIS/
./autogen.sh || echo "Autogen failed"
mkdir build
cd build
../configure --prefix=/home/jkgreen/OVIS/build/4

if [[ $? -ne 0 ]] ; then
  echo "configure failed"
  exit -1 
fi

make || echo "configure failed"  ### this fails due to not having a lexer generator
cd ../../
rm -Rf OVIS

### TRY THE PATCH

git clone -b OVIS-4 https://github.com/ovis-hpc/ovis.git OVIS
cd OVIS

## Apply the patch to test it
cat <<EOF >flex-configure.ac-fix.patch
diff --git a/configure.ac b/configure.ac
index 5c1846d7..4562eb8b 100644
--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,11 @@ dnl if LEX is not available, the configure still won't fail
 AC_PROG_LEX
 AC_PROG_LN_S
 
+AC_PATH_PROG(FLEX, flex)
+if test -z "\$FLEX"; then
+   AC_MSG_ERROR([You need the 'flex' lexer generator to compile LDMS])
+fi
+
 AC_ARG_VAR([BISON], [bison command])
 AC_CHECK_PROG([BISON], [bison -y], [bison -y], [no])
 AS_IF([test "x\$BISON" = "xno"], [AC_MSG_ERROR([bison not found])])

EOF

[[ -f flex-configure.ac-fix.patch ]] && git apply -v flex-configure.ac-fix.patch
if [[ $? -ne 0 ]] ; then
  echo "git apply patch fails... "
fi

./autogen.sh || echo "Autogen failed"
mkdir build
cd build

../configure --prefix=/home/jkgreen/OVIS/build/4
if [[ $? -ne 0 ]] ; then
  echo "configure failed"
  exit -1 
fi

make ||  echo "make failed"
```
