### PR TITLE
Change prefix used by git-version-gen to "v" from "OVIS-".

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.64)
 AC_INIT([ovis-ldms],
-        m4_esyscmd([config/git-version-gen --prefix 'OVIS-' .tarball-version]),
+        m4_esyscmd([config/git-version-gen --prefix 'v' .tarball-version]),
         [ovis-help@sandia.gov])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([m4/Ovis-top.m4])


### PR DESCRIPTION
The last tag in the OVIS-4 branch's history is OVIS-4.3.11. We might want to make a "v4.3.11" tag pointing to the same commit as OVIS-4.3.11 to give git-verson-gen something to find when this commit lands.
