### PR TITLE
Add LDMS_STREAM_EVENT_CLOSE

### DIFF
--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -3875,7 +3875,12 @@ cdef class StreamData(object):
 
 cdef int __stream_client_cb(ldms_stream_event_t ev, void *arg) with gil:
     cdef StreamClient c = <StreamClient>arg
-    cdef StreamData sdata = StreamData.from_ldms_stream_event(PTR(ev))
+    cdef StreamData sdata
+
+    if ev.type != LDMS_STREAM_EVENT_RECV:
+        return 0
+
+    sdata = StreamData.from_ldms_stream_event(PTR(ev))
     if c.cb:
         c.cb(c, sdata, c.cb_arg)
     else:

--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -1153,6 +1153,9 @@ enum ldms_stream_event_type {
 	LDMS_STREAM_EVENT_RECV, /* stream data received */
 	LDMS_STREAM_EVENT_SUBSCRIBE_STATUS, /* reporting subscription status */
 	LDMS_STREAM_EVENT_UNSUBSCRIBE_STATUS, /* reporting unsubscription status */
+	LDMS_STREAM_EVENT_CLOSE, /* reporting stream client close event.
+				  * This is the last event to deliver from a
+				  * client. */
 };
 
 /* For stream data delivery to the application */
@@ -1177,12 +1180,18 @@ struct ldms_stream_return_status_s {
 	int status;
 };
 
+/* For stream close event */
+struct ldms_stream_close_event_s {
+	ldms_stream_client_t client;
+};
+
 typedef struct ldms_stream_event_s {
 	ldms_t r; /* rail */
 	enum ldms_stream_event_type type;
 	union {
 		struct ldms_stream_recv_data_s recv;
 		struct ldms_stream_return_status_s status;
+		struct ldms_stream_close_event_s close;
 	};
 } *ldms_stream_event_t;
 


### PR DESCRIPTION
Due to the asynchronous nature of `ldms_stream`, a stream event may already in the process of being delivered to the application callback function at the same time that the application closes the stream client and releases application's resources associated with it. This results in a use-after-free.

This patch adds `LDMS_STREAM_EVENT_CLOSE` callback event that is delivered to the application callback function when the stream client is closed. The `LDMS_STREAM_EVENT_CLOSE` is the last event to be delivered to the client call back function, so that the application can then safely release resources asscoiated with the stream client after receiving it.