### PR TITLE
Resolve segfault when using deprecated producer type "passive"

### DIFF
--- a/ldms/src/ldmsd/ldmsd_prdcr.c
+++ b/ldms/src/ldmsd/ldmsd_prdcr.c
@@ -867,6 +867,8 @@ static void prdcr_connect(ldmsd_prdcr_t prdcr)
 	case LDMSD_PRDCR_TYPE_PASSIVE:
 		assert(prdcr->xprt == NULL);
 		prdcr->xprt = ldms_xprt_by_remote_sin((struct sockaddr *)&prdcr->ss);
+                if (!prdcr->xprt)
+			break;
 		ldms_xprt_event_cb_set(prdcr->xprt, prdcr_connect_cb, prdcr);
 		/* let through */
 	case LDMSD_PRDCR_TYPE_ADVERTISED:


### PR DESCRIPTION
Check that transport exists before attempting to assign event callback
when using deprecated producer type passive