### PR TITLE
Update kokkos_appmon.c to not pad extra characters to node / name

### DIFF
--- a/ldms/src/store/kokkos_appmon/kokkos_appmon.c
+++ b/ldms/src/store/kokkos_appmon/kokkos_appmon.c
@@ -396,9 +396,9 @@ static int stream_recv_cb(ldmsd_stream_client_t c, void *ctxt,
 		}
 		sos_obj_attr_by_id_set(obj, TIMESTAMP_ID, timestamp);
 		sos_obj_attr_by_id_set(obj, JOB_ID, job_id);
-		sos_obj_attr_by_id_set(obj, NODE_NAME_ID, strlen(node_name)+1, node_name);
+		sos_obj_attr_by_id_set(obj, NODE_NAME_ID, strlen(node_name), node_name);
 		sos_obj_attr_by_id_set(obj, RANK_ID, rank);
-		sos_obj_attr_by_id_set(obj, NAME_ID, strlen(name)+1, name);
+		sos_obj_attr_by_id_set(obj, NAME_ID, strlen(name), name);
 		sos_obj_attr_by_id_set(obj, TYPE_ID, type);
 		sos_obj_attr_by_id_set(obj, CURRENT_KERNEL_COUNT_ID, current_kernel_count);
 		sos_obj_attr_by_id_set(obj, TOTAL_KERNEL_COUNT_ID, total_kernel_count);


### PR DESCRIPTION
Top of tree has the correct file but b4.4 and 4.4.3 do not. Strings should not get padded by 1, this is from some legacy stuff.