### PR TITLE
Stream-Rail distribution with addr + port

### DIFF
--- a/ldms/src/core/ldms.h
+++ b/ldms/src/core/ldms.h
@@ -1171,6 +1171,7 @@ struct ldms_stream_recv_data_s {
 	json_entity_t json; /* json entity */
 	struct ldms_cred cred; /* credential */
 	uint32_t perm; /* permission */
+	uint32_t name_hash; /* stream name hash */
 };
 
 /* To report subscrube / unsubscribe return status */

--- a/ldms/src/core/ldms_stream.c
+++ b/ldms/src/core/ldms_stream.c
@@ -271,6 +271,7 @@ __remote_client_cb(ldms_stream_event_t ev, void *cb_arg)
 	ldms_rail_t r;
 	int ep_idx;
 	int rc;
+	uint64_t addr_port;
 	if (ev->type == LDMS_STREAM_EVENT_CLOSE)
 		return 0;
 	assert( ev->type == LDMS_STREAM_EVENT_RECV );
@@ -282,10 +283,14 @@ __remote_client_cb(ldms_stream_event_t ev, void *cb_arg)
 		ep_idx = 0;
 		break;
 	case AF_INET:
-		ep_idx = ( be32toh(*(int*)&ev->recv.src.addr[0]) % primer ) % r->n_eps;
+		addr_port = be32toh(*(int*)&ev->recv.src.addr[0]);
+		addr_port = (addr_port<<16) | be16toh(ev->recv.src.sin_port);
+		ep_idx = ( addr_port % primer ) % r->n_eps;
 		break;
 	case AF_INET6:
-		ep_idx = ( be32toh(*(int*)&ev->recv.src.addr[12]) % primer ) % r->n_eps;
+		addr_port = be32toh(*(int*)&ev->recv.src.addr[12]);
+		addr_port = (addr_port<<16) | be16toh(ev->recv.src.sin_port);
+		ep_idx = ( addr_port % primer ) % r->n_eps;
 		break;
 	default:
 		assert(0 == "Unexpected network family");

--- a/ldms/src/core/ldms_stream.h
+++ b/ldms/src/core/ldms_stream.h
@@ -134,7 +134,7 @@ struct ldms_stream_full_msg_s {
 	uint32_t stream_type;
 	struct ldms_cred cred; /* credential of the originator */
 	uint32_t perm; /* 0777 style permission */
-	uint32_t preserved;
+	uint32_t name_hash;
 	char     msg[OVIS_FLEX];
 	/* `msg` format:
 	 * .----------------------.


### PR DESCRIPTION
When the stream forward the stream data, it used the peer address to determine the endpoint in the rail to forward the data. This patch adds `port` into the calculation as well to increase the stream data distribution among the endpoints in the rail.