### PR TITLE
Make ldmsd_controller exit on connection error

### DIFF
--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -931,7 +931,15 @@ class Communicator(object):
                 self.ldms = ldms.Xprt(name=self.xprt, auth=self.auth, auth_opts=self.auth_opt)
             rc = self.ldms.connect(self.host, self.port, timeout=timeout)
         except Exception as e:
-            print(f'Error {e}: connecting to {self.host} on port {self.port}')
+            if self.auth is not None:
+                if self.auth_opt is not None:
+                    s = ' '.join([f"{n}={v}" for n, v in self.auth_opt.items()])
+                    auth_s = f" with auth {self.auth} {s}"
+                else:
+                    auth_s = f" with auth {self.auth}"
+            else:
+                auth_s = ""
+            print(f'{e}: connecting to {self.host} on port {self.port} using {self.xprt}{auth_s}')
             self.state = self.CLOSED
             return errno.ENOTCONN
         if rc:

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -66,7 +66,6 @@ from ldmsd import ldmsd_util
 from ldmsd.ldmsd_communicator import LDMSD_Request, LDMSD_Req_Attr
 from ldmsd.ldmsd_communicator import Communicator, fmt_status
 import errno
-from _ast import Or
 
 LDMSD_REQ_SOM_F=1
 LDMSD_REQ_EOM_F=2
@@ -102,7 +101,9 @@ class LdmsdCmdParser(cmd.Cmd):
                                          port,
                                          auth,
                                          auth_opt)
-            self.comm.connect()
+            rc = self.comm.connect()
+            if rc:
+                raise ConnectionError("Please verify the transport, hostname, port, and authentication method.")
             self.prompt = "{0}:{1}:{2}> ".format(xprt, host, port)
         else:
             self.comm = None
@@ -2275,3 +2276,4 @@ if __name__ == "__main__":
             raise
         else:
             print(e)
+            sys.exit(0)


### PR DESCRIPTION
The patch also updates the connection error message to include the transport and the authentication method.