### PR TITLE
Use `callable()` to check callable in ldms.Xprt (ldms.pyx)

### DIFF
--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -3209,7 +3209,7 @@ cdef class Xprt(object):
         import types
         cdef int rc
         cdef timespec ts
-        if not isinstance(cb, types.FunctionType) and cb is not None:
+        if cb is not None and not callable(cb):
             raise TypeError("Callback argument must be callable")
         self._conn_cb = cb
         self._conn_cb_arg = cb_arg


### PR DESCRIPTION
The `isinstance(cb, types.FunctionType)` check does not cover all callables. If the application supplies a method as `cb`, the `isinstance` check failed. This patch modifies the condition to use `callable()` check instead to cover all callable types.