### PR TITLE
Workaround for GitHub workflow dropping CentOS7 support

### DIFF
--- a/.github/workflows/4.3.3-compat-test.yaml
+++ b/.github/workflows/4.3.3-compat-test.yaml
@@ -41,7 +41,7 @@ jobs:
     container:
         image: ovishpc/ovis-compat-centos7
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v1
     - run: sh autogen.sh
     - name: build and install
       run: |
@@ -332,7 +332,3 @@ jobs:
         for V in 4.3.{3..6}; do
           diff -u /test/${V}.enum /test/HEAD-${V}.enum > /test/enum-${V}.diff
         done
-    - uses: actions/upload-artifact@v3
-      if: ${{ always() }}
-      with:
-        path: /test/

--- a/.github/workflows/build-ddebug-centos7.yaml
+++ b/.github/workflows/build-ddebug-centos7.yaml
@@ -21,7 +21,7 @@ jobs:
     container:
         image: ovishpc/ovis-centos-build:latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v1
     - run: sh autogen.sh
     - run: |
         _CFLAGS_=(

--- a/.github/workflows/build-test-centos7.yaml
+++ b/.github/workflows/build-test-centos7.yaml
@@ -18,7 +18,7 @@ jobs:
     container:
         image: ovishpc/ovis-centos-build
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v1
     - run: sh autogen.sh
     - run: ./configure CFLAGS="-Wall -Werror"
     - run: make
@@ -28,7 +28,7 @@ jobs:
     container:
         image: ovishpc/ovis-centos-build
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v1
     - run: sh autogen.sh
     - run: ./configure
     - run: make distcheck
@@ -38,7 +38,7 @@ jobs:
     container:
         image: ovishpc/ovis-centos-build
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v1
     - run: sh autogen.sh
     - run: ./configure --enable-rdma CFLAGS="-Wall -Werror"
     - run: make


### PR DESCRIPTION
CentOS7 is old, and GitHub Runner recently uses 'node20' which requires newer GLIBC that does not exist in CentOS7. As a result, the three workflows in our repository that use 'ovis-centos-build' image fails to even checkout the code since `actions/checkout@v3` was implemented in TypeScript that run using 'node.js'.

According to this:
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ CentOS7 is also removed from the supported OS list due to node20 not supported on CentOS7.

This patch does the following on the CentOS7-based workflows:

- Use `actions/checkout@v1` (instead of v3) because it is implemented as a plugin that comes with the GitHub Runner (C++). We do not use any advanced features that does not exist in v1.

- Remove the use of `actions/upload-artifact`. v3 is implemented in TypeScript, and v1 (C++ Runner Plugin) does not work. The artifact's purpose was for debugging.