### PR TITLE
Python2 removal multiple scripts

### DIFF
--- a/ldms/scripts/ldms-csv-anonymize
+++ b/ldms/scripts/ldms-csv-anonymize
@@ -567,14 +567,14 @@ mapmagic = "#anonymize-csv-map"
 def write_map(maps, kind, fn):
     if len(maps[kind]) > 0:
         with open(fn, "w") as o:
-            print(f"{mapmagic} {kind}")
+            print(mapmagic, kind)
             m = maps[kind]
             for key in sorted(m):
                 if key == "netdomains":
                     if len(m[key]) > 0:
                         print(key, ",".join(m[key]))
                 else:
-                    print(f"{key} {m[key]}")
+                    print(key, m[key])
 
 def reload_map(m, fn, kind):
     """prime m with data from prior run. input can be empty, otherwise must match kind."""
@@ -587,7 +587,7 @@ def reload_map(m, fn, kind):
             (k,v) = ln.split()
             if header:
                 if k != mapmagic:
-                    print("Error loading map- not a mapping file:")
+                    print(f"Error loading map- not a mapping file: {fn}")
                     sys.exit(1)
                 if v != kind:
                     print(f"Error loading map file- wrong type. {kind} vs {v} in")
@@ -723,7 +723,7 @@ if __name__ == "__main__":
         sys.exit(1)
     for f in files:
         if not os.path.isfile(f):
-            print("File not found {}")
+            print("File not found {f}")
             sys.exit(1)
     for f in files:
         if args.debug:

--- a/ldms/scripts/ldms-csv-anonymize
+++ b/ldms/scripts/ldms-csv-anonymize
@@ -567,14 +567,14 @@ mapmagic = "#anonymize-csv-map"
 def write_map(maps, kind, fn):
     if len(maps[kind]) > 0:
         with open(fn, "w") as o:
-            print(mapmagic, kind)
+            print(mapmagic, kind, file=o)
             m = maps[kind]
             for key in sorted(m):
                 if key == "netdomains":
                     if len(m[key]) > 0:
-                        print(key, ",".join(m[key]))
+                        print(key, ",".join(m[key]), file=o)
                 else:
-                    print(key, m[key])
+                    print(key, m[key], file=o)
 
 def reload_map(m, fn, kind):
     """prime m with data from prior run. input can be empty, otherwise must match kind."""
@@ -696,7 +696,7 @@ if __name__ == "__main__":
         print(files)
         print(cols)
     maps = dict()
-    for key in rewrite.keys():
+    for key in list(rewrite.keys()):
         maps[key] =  dict()
     if args.imap:
         reload_map(maps["int"], args.imap, "int")
@@ -707,7 +707,7 @@ if __name__ == "__main__":
     maps["host"]["netdomains"] = []
     if args.hmap:
         reload_map(maps["host"], args.hmap, "host")
-        if maps["host"].has_key("netdomains"):
+        if "netdomains" in maps["host"]:
             maps["host"]["netdomains"] = maps["host"]["netdomains"].split(",")
 
     prefix = args.save_maps
@@ -715,7 +715,7 @@ if __name__ == "__main__":
         prefix = 'anonmap_'
     seed = args.seed
     if not seed:
-        seed = random.randint(1,sys.maxint)
+        seed = random.randint(1,sys.maxsize)
     random.seed(seed)
     od = args.out_dir
     if not od or not os.path.isdir(od):
@@ -735,7 +735,7 @@ if __name__ == "__main__":
                 for ln in i:
                     ln = ln.rstrip()
                     if len(ln) < 3:
-                        print(ln)
+                        print(ln, file=o)
                         continue
                     if ln[0] == '#':
                         x = ln.split(sep)
@@ -744,7 +744,7 @@ if __name__ == "__main__":
                             k = convert_col(k)
                             x[k] = map_header(x[k], method)
                         y = sep.join(x)
-                        print(y)
+                        print(y, file=o)
                         continue
                     x = ln.split(sep)
                     for c in cols:
@@ -755,7 +755,7 @@ if __name__ == "__main__":
                         k = convert_col(k)
                         x[k] = rewrite[method](x[k], maps[method])
                     y = sep.join(x)
-                    print(y)
+                    print(y, file=o)
 
     
     # print seed file if we ever use random

--- a/ldms/scripts/ldms-csv-anonymize
+++ b/ldms/scripts/ldms-csv-anonymize
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 ########### section II below by NTESS ################################
 license_ntess="""
@@ -548,10 +548,10 @@ def host_substitute(h, vmap):
                 canon.append(head)
                 continue
             else:
-                print "Fix hmap. Can't map", nonum, "in", i, "of", h
+                print(f"Fix hmap. Can't map {nonum} in {i} of {h}")
                 sys.exit(1)
         else:
-            print "Fix hmap file. Can't map", i, "in", h
+            print(f"Fix hmap file. Can't map {i} in {h}")
             sys.exit(1)
     
     fin = "-".join(canon)
@@ -567,14 +567,14 @@ mapmagic = "#anonymize-csv-map"
 def write_map(maps, kind, fn):
     if len(maps[kind]) > 0:
         with open(fn, "w") as o:
-            print >>o, mapmagic, kind
+            print(f"{mapmagic} {kind}")
             m = maps[kind]
             for key in sorted(m):
                 if key == "netdomains":
                     if len(m[key]) > 0:
-                        print >>o, key, ",".join(m[key])
+                        print(key, ",".join(m[key]))
                 else:
-                    print >>o, key, m[key]
+                    print(f"{key} {m[key]}")
 
 def reload_map(m, fn, kind):
     """prime m with data from prior run. input can be empty, otherwise must match kind."""
@@ -587,10 +587,10 @@ def reload_map(m, fn, kind):
             (k,v) = ln.split()
             if header:
                 if k != mapmagic:
-                    print "error loading map- not a mapping file:", fn,
+                    print("Error loading map- not a mapping file:")
                     sys.exit(1)
                 if v != kind:
-                    print "error loading map file- wrong type.", kind, "vs", v, "in", fn
+                    print(f"Error loading map file- wrong type. {kind} vs {v} in")
                     sys.exit(1)
                 header = False
                 continue
@@ -600,7 +600,7 @@ def convert_col(kstr):
     """convert extended cut index string to python notation."""
     k = int(kstr) 
     if k == 0:
-        print "column numbers are 1-N (as cut(1)) or negative, not 0."
+        print("column numbers are 1-N (as cut(1)) or negative, not 0.")
         sys.exit(1)
     if k > 0:
         k -= 1
@@ -668,12 +668,12 @@ if __name__ == "__main__":
     parser.add_argument("--gen-args", default=None, help="input metric names and file")
     parser.add_argument("--debug", default=False, action='store_true', help="enable debug")
     if len(sys.argv) < 2:
-        print "need some arguments. try -h"
+        print("Need some arguments. Try -h")
         sys.exit(1)
     args = parser.parse_args()
 
     if args.debug:
-        print args
+        print(args)
     sep = args.col_sep
     if not sep:
         sep = ','
@@ -685,7 +685,7 @@ if __name__ == "__main__":
         files.extend(i.split())
     cols = []
     if len(args.mappings) == 0:
-        print "nothing to do"
+        print("Nothing to do")
         sys.exit(1)
     for i in args.mappings:
         if ":" in i:
@@ -693,8 +693,8 @@ if __name__ == "__main__":
         else:
             files.append(i)
     if args.debug:
-        print files
-        print cols
+        print(files)
+        print(cols)
     maps = dict()
     for key in rewrite.keys():
         maps[key] =  dict()
@@ -719,15 +719,15 @@ if __name__ == "__main__":
     random.seed(seed)
     od = args.out_dir
     if not od or not os.path.isdir(od):
-        print "output directory not given or not found"
+        print("output directory not given or not found")
         sys.exit(1)
     for f in files:
         if not os.path.isfile(f):
-            print "file not found", f
+            print("File not found {}")
             sys.exit(1)
     for f in files:
         if args.debug:
-            print f
+            print(f)
         bname = os.path.basename(f)
         with open(f, "r") as i:
             out = os.path.join(od, bname)
@@ -735,7 +735,7 @@ if __name__ == "__main__":
                 for ln in i:
                     ln = ln.rstrip()
                     if len(ln) < 3:
-                        print >>o, ln
+                        print(ln)
                         continue
                     if ln[0] == '#':
                         x = ln.split(sep)
@@ -744,18 +744,18 @@ if __name__ == "__main__":
                             k = convert_col(k)
                             x[k] = map_header(x[k], method)
                         y = sep.join(x)
-                        print >>o, y
+                        print(y)
                         continue
                     x = ln.split(sep)
                     for c in cols:
                         (method, k) = c.split(":")
                         if method == "host" and args.hmap == None:
-                            print "--hmap required for host mapping"
+                            print("--hmap required for host mapping")
                             sys.exit(1)
                         k = convert_col(k)
                         x[k] = rewrite[method](x[k], maps[method])
                     y = sep.join(x)
-                    print >>o, y
+                    print(y)
 
     
     # print seed file if we ever use random

--- a/ldms/scripts/ldms-csv-export-sos
+++ b/ldms/scripts/ldms-csv-export-sos
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 # currently dump sos import map and optionally schema
 import argparse
 import sys
@@ -39,31 +39,31 @@ ldms_types = [ "char",
                 "f32[]",
                 "d64[]",
                 "timestamp",
-            ]
+             ]
 
 ldms_type_sos_map = { "char" : "uint16",
-        "u8" : "uint16",
-        "s8" : "int16",
-        "u16" : "uint16",
-        "s16" : "int16",
-        "u32" : "uint32",
-        "s32": "int32",
-        "u64" : "uint64",
-        "s64" : "int64" ,
-        "f32" : "float",
-        "d64" : "double",
-        "char[]" : "char_array",
-        "u8[]" : "byte_array",
-        "s8[]" : "byte_array",
-        "u16[]" : "uint16_array",
-        "s16[]" : "int16_array",
-        "u32[]" : "uint32_array",
-        "s32[]" : "int32_array",
-        "u64[]" : "uint64_array",
-        "s64[]" : "int64_array",
-        "f32[]" : "float_array",
-        "d64[]" : "double_array",
-        "timestamp" : "timestamp"
+                      "u8" : "uint16",
+                      "s8" : "int16",
+                      "u16" : "uint16",
+                      "s16" : "int16",
+                      "u32" : "uint32",
+                      "s32": "int32",
+                      "u64" : "uint64",
+                      "s64" : "int64" ,
+                      "f32" : "float",
+                      "d64" : "double",
+                      "char[]" : "char_array",
+                      "u8[]" : "byte_array",
+                      "s8[]" : "byte_array",
+                      "u16[]" : "uint16_array",
+                      "s16[]" : "int16_array",
+                      "u32[]" : "uint32_array",
+                      "s32[]" : "int32_array",
+                      "u64[]" : "uint64_array",
+                      "s64[]" : "int64_array",
+                      "f32[]" : "float_array",
+                      "d64[]" : "double_array",
+                      "timestamp" : "timestamp"
     }
 
 match_elements = lambda p, s: [i for (q, i) in zip(s, range(len(s))) if p == q]
@@ -108,10 +108,10 @@ def parse_aliases(fn):
                 continue
             y = i.strip().split()
             if len(y) != 2:
-                print "misformatted alias in", fn, ":", y
+                print(f"Misformatted alias in {fn}: {y}")
                 sys.exit(1)
             if y[0] in aliases:
-                print "redefined alias in", fn, ":", y[0]
+                print(f"Redefined alias in {fn}: {y[0]}")
                 sys.exit(1)
             aliases[y[0]] = y[1]
     return aliases
@@ -145,13 +145,13 @@ def parse_kind(fn, arr, udata, col_heads):
             a = i.rstrip("0123456789")
             if i in ldms_types or a in ldms_types:
                 continue
-            print "invalid kind", "X"+i+"X", "in", fn
-            print i, a, ldms_types
+            print(f"Invalid kind X{i}X in {fn}")
+            print(f"{i} {a} {ldms_types}")
             sys.exit(1)
     # validate kind list vs arr, udata, col_heads
     if not arr:
         if len(col_heads) != len(z):
-            print "column count of header does not match column count of kinds file", fn
+            print(f"Column count of header does not match column count of kinds file {fn}")
             sys.exit(1)
     nc = 0
     for i in z:
@@ -164,7 +164,7 @@ def parse_kind(fn, arr, udata, col_heads):
             if udata:
                 nc += x-1; # one udata appears explicitly
     if nc != len(col_heads):
-        print "column count of header", len(col_heads), "does not match column count of kinds file", fn, ":", nc
+        print(f"Column count of header {len(col_heads)} does not match column count of kinds file {fn}:{nc}")
         sys.exit(1)
     return z
 
@@ -241,8 +241,8 @@ def value_type(v):
     return "char[]"
             
 def uncastable(old, new, val):
-    print "incompatible data in guessing column type"
-    print "oldtype=", old, "newtype=", new, "value=", val
+    print("Incompatible data in guessing column type")
+    print(f"Oldtype={old} newtype={new} value={val}")
     sys.exit(1)
     pass
 
@@ -381,7 +381,7 @@ def guess_kind(col_heads, fn, maxlines):
 def validate_assume(a):
     """ return validated type or exit"""
     if not a in ldms_types:
-        print "invalid option to --assume: ", a, "Try one of:", ldms_types
+        print(f"Invalid option to --assume: {a} Try one of: {ldms_types}")
         sys.exit(1)
     return a
 
@@ -417,7 +417,7 @@ def internal_header(fn):
         return False
 
 def strip_gz(s):
-    print "strip_gz", s
+    print(f"strip_gz {s}")
     sp = os.path.splitext(s)
     if sp[1].lower() == ".gz":
         return sp[0]
@@ -429,7 +429,7 @@ def get_filenames(fn, args):
     Does not verify existence or formats.
     """
     if fn is None:
-        print "define input with --data=<file>"
+        print("define input with --data=<file>")
         sys.exit(1)
 
     if ".HEADER" in fn:
@@ -485,19 +485,19 @@ def get_filenames(fn, args):
     if args.kind_file:
         if os.path.isfile(kind) and args.kind_file != kind:
             if args.verbose:
-                print "WARNING: creating", args.kind_file, "but", kind, " is also present."
+                print(f"WARNING: creating {args.kind_file} but {kind} is also present.")
         kind = args.kind_file
     if args.map_file:
         if os.path.isfile(mapfile) and args.map_file != mapfile:
             if args.verbose:
-                print "WARNING: creating", args.map_file, "but", mapfile, " is also present."
+                print(f"WARNING: creating {args.map_file} but {mapfile} is also present.")
         mapfile = args.map_file
     if args.schema_name:
         args.dataname = args.schema_name
     if args.schema_file:
         if os.path.isfile(schemafile) and args.schema_file != schemafile:
             if args.verbose:
-                print "WARNING: using", args.schema_file, "but", schemafile, " is also present."
+                print(f"WARNING: using {args.schema_file} but {schemafile} is also present.")
         schemafile = args.schema_file
     return (data, header, kind, schemafile, mapfile)
 
@@ -506,7 +506,8 @@ def format_schema_prolog(f, args):
     s = """{
     "name" : """ + "\"" + args.dataname + """",
     "attrs" : ["""
-    print >> f, s
+    with open(f, "w") as f:
+        print(s)
 
 def format_join(f, j, col_heads):
     jname =  j[0]
@@ -521,7 +522,8 @@ def format_join(f, j, col_heads):
             s += ", "
         s += "\"" + i + "\""
     s += "], \"index\" : {} }"
-    print >>f, s,
+    with open(f, "w") as f:
+        print(s)
 
 default_joins = [
     ("comp_job_time", "component_id", "job_id", "Time"),
@@ -541,7 +543,8 @@ def format_schema_epilog(f, args, col_heads):
     s="\n"
     s += """  ]
 }"""
-    print >>f, s
+    with open(f, "w") as f:
+        print(f"{s},")
 
 def is_index(n, args):
     if n in ["Time", "component_id", "job_id", "component_id.value", "job_id.value", "ProducerName", "anonymized_host_ProducerName"]:
@@ -570,13 +573,16 @@ def format_schema_element(f, args, name, mtype, first):
     if is_index(name, args):
         s += ",\t\"index\" : {} "
     s += " }"
-    print >>f, s,
+    with open(f, "w") as f:
+        print(f"{s},")
 
 def format_map_prolog(f):
-    print >> f, "["
+    with open(f, "w") as f:
+        print(f"[")
 
 def format_map_epilog(f):
-    print >>f, "\n]"
+    with open(f, "w") as f:
+        print(f"\n]")
 
 def format_map_element(f, k, metric, first):
     # accepts k as in or array of ints
@@ -589,14 +595,15 @@ def format_map_element(f, k, metric, first):
     else:
         colspec = "\"list\" : [" + str(k).strip("[]") +  "]"
     s += "\t{ \"target\" : \"" + metric + "\", \"source\" : { " + colspec + " }}"
-    print >> f, s,
+    with open(f, "w") as f:
+        print(f"{s},")
 
 def generate_map_new(col_heads, col_kinds, arr, udata, mapout, sout, mapvec):
     """ generate map conforming to schema and input file. This skips type checking."""
     with open(mapout, "w") as f:
         format_map_prolog(f)
         if len(mapvec) != len(col_heads):
-            print "metrics do not match map"
+            print("Metrics do not match map")
             sys.exit(1)
         kmax = len(mapvec)
         k = 0
@@ -661,7 +668,7 @@ def get_metric_index(met, heads, arr, udata):
 def generate_map_old(col_heads, col_kinds, arr, udata, mapout, sout, mapvec, strip_udata):
     """loop over metrics in schema and if present in col_heads, use them"""
     if len(mapvec) != len(col_heads):
-        print "metrics do not match map"
+        print("Metrics do not match map")
         sys.exit(1)
     with open(mapout, "w") as f:
         format_map_prolog(f)
@@ -679,10 +686,10 @@ def generate_map_old(col_heads, col_kinds, arr, udata, mapout, sout, mapvec, str
                 format_map_element(f, q, sout[k], first)
                 first = False
             else:
-                print "warning: schema element", sout[k], "not found in csv"
-                print "u=", udata
-                print "a=", arr
-                print col_heads
+                print(f"Warning: schema element {sout[k]} not found in csv")
+                print(f"u={udata}")
+                print(f"a={arr}")
+                print(f"{col_heads}")
                 # sos records are allowed to have empty fields at present
             k += 1
         format_map_epilog(f)
@@ -737,8 +744,8 @@ def get_filter(args):
         else:
             exclude = blacklist
     if args.verbose:
-        print "exclude=", exclude
-        print "include=", include
+        print(f"exclude={exclude}")
+        print(f"include={include}")
     return (include, exclude)
 
 def is_excluded(include, exclude, n, udata):
@@ -762,7 +769,7 @@ def is_excluded(include, exclude, n, udata):
 def generate_schema(col_heads, col_kinds, arr, udata, args, schemaout, mapout):
     if args.schema_file:
         if args.verbose:
-            print "schema output suppressed by --schema-file"
+            print("Schema output suppressed by --schema-file")
         old_schema = parse_schema(args.schema_file)
         (include, exclude) = ([], [])
     else:
@@ -791,7 +798,7 @@ def generate_schema(col_heads, col_kinds, arr, udata, args, schemaout, mapout):
                 if amax == 0:
                     if is_excluded(include, exclude, col_heads[h], udata):
                         if args.verbose:
-                            print "excluding", col_heads[h]
+                            print("excluding {col_heads[h]}")
                         h += 1
                         k += 1
                         mapvec.append(0)
@@ -886,16 +893,16 @@ def generate_schema(col_heads, col_kinds, arr, udata, args, schemaout, mapout):
      
         if not old_schema:
             if args.verbose:
-                print "rename to", schemaout
+                print(f"rename to {schemaout}")
             os.rename(schematmp, schemaout)
             schematmp = None
             new_schema = parse_schema(schemaout)
             if args.verbose:
-                print "map:", mapout
+                print(f"map: {mapout}")
             generate_map_new(metvec, col_kinds, arr, udata, mapout, new_schema, mapvec)
         else:
             if args.verbose:
-                print "mapold:", mapout
+                print(f"mapold: {mapout}")
             generate_map_old(metvec, col_kinds, arr, udata, mapout, old_schema, mapvec, args.strip_udata)
     except Exception as e:
         traceback.print_exc()
@@ -941,45 +948,45 @@ if __name__ == "__main__":
     # args.dataname will be derived by later code as the default schema name
 
     if args.verbose:
-        print args
+        print(args)
 
     (data, header, kind, schemaout, mapout) = get_filenames(args.data, args)
 
     if not os.path.isfile(data):
         if args.verbose:
-            print "WARNING: input data", data, "does not exist"
+            print(f"WARNING: input data {data} does not exist")
             if data != args.data:
-                print "  name derived from", args.data
+                print(f"  name derived from {args.data}")
         if args.guess:
-            print "ERROR: cannot guess types without data file present", data
+            print(f"ERROR: cannot guess types without data file present {data}")
             sys.exit(1)
     else:
         if args.guess:
             if os.path.getsize(data) == 0:
-                print "input data", data, "empty. Cannot guess."
+                print(f"input data {data} empty. Cannot guess.")
                 sys.exit(1)
     if not os.path.isfile(header):
         if args.verbose:
-            print "Header not present", header
+            print(f"Header not present {header}")
         if internal_header(data):
             header = data
             if args.verbose:
-                print "Found header in data file", data
+                print(f"Found header in data file {data}")
         else:
-            print "Data does not include header line or file is missing", data
+            print(f"Data does not include header line or file is missing {data}")
             sys.exit(1)
     if os.path.isfile(kind) and (args.guess or args.assume):
         if args.verbose:
-            print "Cowardly refusing to guess when there is kind input. Using kinds.", kind
+            print(f"Cowardly refusing to guess when there is kind input. Using kinds {kind}")
         args.guess = False
         args.assume = False
     if not os.path.isfile(kind) and not (args.guess or args.assume):
-        print "Cannot find", kind, "and not told --guess or --assume."
+        print(f"Cannot find {kind} and not told --guess or --assume.")
         sys.exit(1)
     if not (args.guess or args.assume):
         kf = kind_format(kind)
         if kf is None:
-            print "Invalid kind file format in", kind
+            print(f"Invalid kind file format in {kind}")
             sys.exit(1)
         (arr, udata) = kf
     else:
@@ -988,10 +995,10 @@ if __name__ == "__main__":
         if args.assume:
             assume_type = validate_assume(args.assume)
             if args.verbose:
-                print "Assuming data columns are type", assume_type
+                print(f"Assuming data columns are type {assume_type}")
     if args.alias_file:
         if not os.path.isfile(args.alias_file):
-            print "Error: --alias-file given is not found:", args.alias_file
+            print(f"Error: --alias-file given is not found: {args.alias_file}")
             sys.exit(1)
 
     subs = parse_aliases(args.alias_file)

--- a/ldms/scripts/ldms-csv-export-sos
+++ b/ldms/scripts/ldms-csv-export-sos
@@ -523,7 +523,7 @@ def format_join(f, j, col_heads):
         s += "\"" + i + "\""
     s += "], \"index\" : {} }"
     with open(f, "w") as f:
-        print(s)
+        print(f"{s},")
 
 default_joins = [
     ("comp_job_time", "component_id", "job_id", "Time"),
@@ -544,7 +544,7 @@ def format_schema_epilog(f, args, col_heads):
     s += """  ]
 }"""
     with open(f, "w") as f:
-        print(f"{s},")
+        print(s)
 
 def is_index(n, args):
     if n in ["Time", "component_id", "job_id", "component_id.value", "job_id.value", "ProducerName", "anonymized_host_ProducerName"]:

--- a/ldms/scripts/ldms-csv-export-sos
+++ b/ldms/scripts/ldms-csv-export-sos
@@ -66,7 +66,7 @@ ldms_type_sos_map = { "char" : "uint16",
                       "timestamp" : "timestamp"
     }
 
-match_elements = lambda p, s: [i for (q, i) in zip(s, range(len(s))) if p == q]
+match_elements = lambda p, s: [i for (q, i) in zip(s, list(range(len(s)))) if p == q]
 
 def fileopener(fn):
     """return the correct open function for the filename (default or gzip.open)"""
@@ -205,7 +205,7 @@ def value_type(v):
     if len(v) == 0:
             return "u64"
     try:
-        x = long(v)
+        x = int(v)
         if x < 0:
             if x < -9223372036854775808:
                 # cannot happen on s64 data, so must be
@@ -506,8 +506,7 @@ def format_schema_prolog(f, args):
     s = """{
     "name" : """ + "\"" + args.dataname + """",
     "attrs" : ["""
-    with open(f, "w") as f:
-        print(s)
+    print(s, file=f)
 
 def format_join(f, j, col_heads):
     jname =  j[0]
@@ -522,8 +521,7 @@ def format_join(f, j, col_heads):
             s += ", "
         s += "\"" + i + "\""
     s += "], \"index\" : {} }"
-    with open(f, "w") as f:
-        print(f"{s},")
+    print(s, end=' ', file=f)
 
 default_joins = [
     ("comp_job_time", "component_id", "job_id", "Time"),
@@ -543,8 +541,7 @@ def format_schema_epilog(f, args, col_heads):
     s="\n"
     s += """  ]
 }"""
-    with open(f, "w") as f:
-        print(s)
+    print(s, file=f)
 
 def is_index(n, args):
     if n in ["Time", "component_id", "job_id", "component_id.value", "job_id.value", "ProducerName", "anonymized_host_ProducerName"]:
@@ -573,16 +570,13 @@ def format_schema_element(f, args, name, mtype, first):
     if is_index(name, args):
         s += ",\t\"index\" : {} "
     s += " }"
-    with open(f, "w") as f:
-        print(f"{s},")
+    print(s, end=' ', file=f)
 
 def format_map_prolog(f):
-    with open(f, "w") as f:
-        print(f"[")
+    print("[", file=f)
 
 def format_map_epilog(f):
-    with open(f, "w") as f:
-        print(f"\n]")
+    print("\n]", file=f)
 
 def format_map_element(f, k, metric, first):
     # accepts k as in or array of ints
@@ -595,8 +589,7 @@ def format_map_element(f, k, metric, first):
     else:
         colspec = "\"list\" : [" + str(k).strip("[]") +  "]"
     s += "\t{ \"target\" : \"" + metric + "\", \"source\" : { " + colspec + " }}"
-    with open(f, "w") as f:
-        print(f"{s},")
+    print(s, end=' ', file=f)
 
 def generate_map_new(col_heads, col_kinds, arr, udata, mapout, sout, mapvec):
     """ generate map conforming to schema and input file. This skips type checking."""

--- a/ldms/scripts/ldms_local_opa2test.sh.in
+++ b/ldms/scripts/ldms_local_opa2test.sh.in
@@ -4,7 +4,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 
-export PYTHONPATH=${prefix}/lib/python2.7/site-packages
+export PYTHONPATH=@pythondir@
 . $libdir/ovis-lib-configvars.sh
 . $libdir/ovis-ldms-configvars.sh
 # Manually redefine portbase to avoid collisions.

--- a/ldms/scripts/ovis-roll-over.py
+++ b/ldms/scripts/ovis-roll-over.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 from __future__ import print_function
 import shlex
 from subprocess import Popen, PIPE
@@ -38,7 +38,7 @@ if __name__ == "__main__":
 
     # Check if auth file exists
     if not os.path.isfile(args.cfg_auth_file):
-        print("The secret file specified, '{0}', does not exist.".format(args.cfg_auth_file))
+        print(f"The secret file specified, {args.cfg_auth_file}, does not exist.")
         sys.exit(1)
 
     # Tell the running daemon to start storing data to a new path
@@ -57,9 +57,9 @@ if __name__ == "__main__":
     (out, err) = p.communicate(input="config name=store_sos path={0}\nquit".format(next_path))
     if out is not None and len(out) > 0:
         print("Failure attempting communicate with the ldmsd daemon:")
-        print(out)
+        print(f"{out}")
         sys.exit(2)
-    print("LDMSD now storing into {0}".format(next_path))
+    print(f"LDMSD now storing into {next_path}")
 
     # If a yesterday link exists, destroy that tree and link yesterday to today
     yesterlink = args.src_path + "/" + args.prev_link
@@ -74,7 +74,7 @@ if __name__ == "__main__":
         except Exception as e:
             print("Failed to remove old data.")
             print("The error is:")
-            print(e)
+            print(f"{e}")
 
     #
     # Update the 'Today' link to point to the next_path
@@ -87,12 +87,12 @@ if __name__ == "__main__":
     os.symlink(next_path, today)
     os.symlink(yesterpath, yesterlink)
 
-    print("{0} now pointing to {1}".format(today, next_path))
-    print("{0} now pointing to {1}".format(yesterlink, yesterpath))
+    print(f"{today} now pointing to {next_path}")
+    print(f"{yesterlink} now pointing to {yesterpath}")
 
     # Move the contents of the previous directory to archive storage
     #   copy the container files to the destination directory
-    print("copying {0} to {1}...".format(yesterpath, args.dst_path), end='')
+    print(f"copying {yesterpath} to {args.dst_path}... ")
     shutil.copytree(yesterpath, args.dst_path+"/"+os.path.basename(yesterpath))
     print("done")
     sys.exit(0)

--- a/ldms/scripts/ovis-roll-over.py
+++ b/ldms/scripts/ovis-roll-over.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from __future__ import print_function
 import shlex
 from subprocess import Popen, PIPE
 import shutil

--- a/ldms/src/sampler/filesingle/ldms-sensors-config
+++ b/ldms/src/sampler/filesingle/ldms-sensors-config
@@ -96,6 +96,7 @@ def main():
     last_file = None
     last_file_type = None
     last_group = None
+
     for line in lines:
         line = line.strip()
         if len(line) < 5:

--- a/ldms/src/sampler/filesingle/ldms-sensors-config
+++ b/ldms/src/sampler/filesingle/ldms-sensors-config
@@ -1,7 +1,12 @@
-#! /usr/bin/env python2
-# $0: sensors_bin_path
+#! /usr/bin/env python3
 # Run sensors under strace to discover where sensor files
 # live on the current system and generate a draft file.
+
+import argparse
+import os
+import subprocess
+import tempfile
+
 import warnings
 import sys
 import os.path
@@ -9,7 +14,7 @@ import tempfile
 import subprocess
 import argparse
 
-def fixlabel(s, nodash=False):
+def fix_label(s, nodash=False):
     if s[-2:] == "\\n":
         s = s[:-2]
     s = s.replace(" ", "_")
@@ -17,249 +22,224 @@ def fixlabel(s, nodash=False):
         s = s.replace("-", "_")
     return s
 
-ignore_types = [
+IGNORE_TYPES = [
     "crit",
     "alarm",
     "hyst",
 ]
 
-def main():
-    opts = argparse.ArgumentParser(
-            description="Generate filesingle metric list")
-    opts.add_argument("--sensors", metavar="SENSORS-PATH",
-            default="/usr/bin/sensors",
-            help="Full path to lm_sensor 'sensors' program")
-    opts.add_argument("--lscpu", metavar="LSCPU-PATH", default="/usr/bin/lscpu",
-            help="Full path to 'lscpu' program")
-    opts.add_argument("--nodash", default=False, action='store_true',
-            help="enable replacing - with _ in names.")
-    opts.add_argument("--test-lscpu", metavar="TEST-INPUT", required=False,
-            help="path to strace result file for parser testing")
-    opts.add_argument("--test-sensors", metavar="TEST-INPUT", required=False,
-            help="path to strace result file for parser testing")
 
-    args = opts.parse_args()
-    if args.test_sensors != None:
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate filesingle metric list")
+    parser.add_argument("--sensors", metavar="SENSORS-PATH",
+                        default="/usr/bin/sensors",
+                        help="Full path to lm_sensor 'sensors' program"
+                       )
+    parser.add_argument("--lscpu", metavar="LSCPU-PATH", default="/usr/bin/lscpu",
+                        help="Full path to 'lscpu' program"
+                       )
+    parser.add_argument("--nodash", default=False, action='store_true',
+                        help="enable replacing - with _ in names."
+                       )
+    parser.add_argument("--test-lscpu", metavar="TEST-INPUT", required=False,
+                        help="path to strace result file for parser testing"
+                       )
+    parser.add_argument("--test-sensors", metavar="TEST-INPUT", required=False,
+                        help="path to strace result file for parser testing"
+                       )
+
+    args = parser.parse_args()
+
+    if args.test_sensors:
         if not os.path.isfile(args.test_sensors):
-            print "missing", args.test_sensors, ". specify a trace log."
-            return 1
+            print(f"Missing {args.test_sensors}. Specify a trace log.")
+            exit(1)
     else:
         if not os.path.isfile(args.sensors):
-            print "missing", args.sensors, ". Need --sensors=<progpath>"
-            return 1
-    if args.test_lscpu != None:
+            print(f"Missing {args.sensors}. Need --sensors=<progpath>")
+            exit(1)
+
+    if args.test_lscpu:
         if not os.path.isfile(args.test_lscpu):
-            print "missing", args.test_lscpu, ". specify a trace log."
-            return 1
+            print(f"Missing {args.test_lscpu}. Specify a trace log.")
+            exit(1)
     else:
         if not os.path.isfile(args.lscpu):
-            print "missing", args.lscpu, ". Need --lscpu=<progpath>"
-            return 1
+            print(f"Missing {args.lscpu}. Need --lscpu=<progpath>")
+            exit(1)
 
-    sensorsbin = args.sensors
-    lscpubin = args.lscpu
+    sensors_bin = args.sensors
+    lscpu_bin = args.lscpu
     nodash = args.nodash
 
-    # build and parse sensors trace
-    tf = tempfile.mktemp(dir="/tmp", suffix=".trace", prefix="ldms-config-sensors.")
-    if args.test_sensors != None:
-        tf = args.test_sensors
+    # Build and parse sensors trace
+    trace_file = tempfile.mktemp(dir="/tmp", suffix=".trace", prefix="ldms-config-sensors.")
+    if args.test_sensors:
+        trace_file = args.test_sensors
     else:
-        cmd = "script -c 'strace -e trace=openat,open,read " + \
-                sensorsbin + " -u' " + tf + " > /dev/null"
+        cmd = f"script -c 'strace -e trace=openat,open,read {sensors_bin} -u' {trace_file} > /dev/null"
         trval = subprocess.call(cmd, shell=True)
         if trval != 0:
-            print "Unable to collect sensors config output"
-            return 1
-    f = open(tf)
-    lines = f.readlines()
-    f.close()
-    if args.test_sensors == None:
-        os.unlink(tf)
-    lastopen = None
-    lastread = None
-    lastfile = None
-    lastfiletype = None
-    lastgroup = None
-    devices = dict(); # nested dict
-    # devices[devpath][item]["label"]
-    # devices[devpath][item]["inputfile"]
-    # devices[devpath]["name"]
-    # where devpath is like /sys/class/hwmon/hwmon0
-    # item is like temp1
-    # and we compose metric names as:
-    # ".".join([devices[devpath]["name"], devices[devpath][item]["label"]])
-    for lf in lines:
-        l = lf.strip()
-        if len(l) < 5:
-            continue
-        if "openat(" == l[:7]:
-            ## print "OPENAT", l
-            tmp = l.split(',')[1].strip().strip('"')
-            if tmp[:11] == '/sys/class/':
-                lastfile = tmp
-                if tmp[-5:] == "/name":
-                    lastdevice = os.path.dirname(tmp)
-                    ## print "DEVICE", lastdevice
-                    devices[lastdevice] = dict()
-                    # devices[lastdevice]["namefile"] = tmp
-                    devices[lastdevice]["items"] = []
-                    lastfiletype = "name"
-                else:
-                    suff = tmp.split('_')[-1]
-                    lastfiletype = suff
-                ## print "lastfiletype", lastfiletype, tmp
-            else:
-                lastfile = None
-                lastfiletype = None
-                lastdevice = None
-            continue
-        if "open(" == l[:5]:
-            ## print "OPEN", l
-            tmp = l.split(',')[0].split("(")[1].strip().strip('"')
-            if tmp[:11] == '/sys/class/':
-                lastfile = tmp
-                if tmp[-5:] == "/name":
-                    lastdevice = os.path.dirname(tmp)
-                    ## print "DEVICE", lastdevice
-                    devices[lastdevice] = dict()
-                    # devices[lastdevice]["namefile"] = tmp
-                    devices[lastdevice]["items"] = []
-                    lastfiletype = "name"
-                else:
-                    suff = tmp.split('_')[-1]
-                    lastfiletype = suff
-                ## print "lastfiletype", lastfiletype, tmp
-            else:
-                lastfile = None
-                lastfiletype = None
-                lastdevice = None
-            continue
-        if "read(" == l[:5]:
-            ## print "READ", l
-            tmp = l.split(',')[1].strip().strip('"')
-            if len(tmp) == 0:
-                continue
-            if lastfiletype is None:
-                ## print "skip: no lastfiletype"
-                continue
-            if lastfiletype == "name":
-                devices[lastdevice]['name'] = fixlabel(tmp)
-                ## print "dev name", tmp
-                continue
-            if lastfiletype == "label":
-                lastdevice = os.path.dirname(lastfile)
-                bn = os.path.basename(lastfile)
-                split = bn.rfind("_")
-                item = bn[:split]
-                if not "group" in devices[lastdevice]:
-                    devices[lastdevice]["group"] = lastgroup
-                if not item in devices[lastdevice]["items"]:
-                    devices[lastdevice]["items"].append(item)
-                    devices[lastdevice][item] = dict()
-                    devices[lastdevice][item]["label"] = fixlabel(tmp)
-                ## print "dev LABEL", item, tmp
-                continue
-            if lastfiletype == "input" or lastfiletype == "average":
-                lastdevice = os.path.dirname(lastfile)
-                bn = os.path.basename(lastfile)
-                split = bn.rfind("_")
-                item = bn[:split]
-                if not "group" in devices[lastdevice]:
-                    devices[lastdevice]["group"] = lastgroup
-                if not item in devices[lastdevice]["items"]:
-                    devices[lastdevice]["items"].append(item)
-                    devices[lastdevice]["group"] = lastgroup
-                    devices[lastdevice][item] = dict()
-                    devices[lastdevice][item]["label"] = fixlabel(item)
-                devices[lastdevice][item]["inputfile"] = lastfile
-                ## print "dev FILE", item, tmp
-                continue
-            if lastfiletype in ignore_types:
-                continue
-            continue
-        if l.find(":") == -1:
-            lastgroup = l
+            print("Unable to collect sensors config output")
+            exit(1)
+    
+    devices = { }
+    with open(trace_file) as file:
+        lines = f.readlines()
 
-    for k,d in devices.iteritems():
-        if len(d["items"]) > 0:
-            for i in d["items"]:
-                ilbl = fixlabel(".".join([d["group"], d[i]["label"] ]), nodash)
-                print ilbl, d[i]["inputfile"], "S64 -1"
+    if not args.test_sensors:
+        os.unlink(trace_file)
 
-    devices = dict()
-    # build and parse lscpu trace
-    if args.test_lscpu != None:
-        atf = args.test_lscpu
+#review    lastopen = None
+#review    lastread = None
+    last_file = None
+    last_file_type = None
+    last_group = None
+    
+    for line in lines:
+        line = line.strip()
+        if len(line) < 5:
+            continue
+        if line.startswith("openat("):
+            temp = line.split(',')[1].strip().strip('"')
+            if temp.startswith('/sys/class/'):
+                last_file = temp
+                if temp.endswith("/name"):
+                    last_device = os.path.dirname(temp)
+                    devices[last_device] = {"items": []}
+                    last_file_type = "name"
+                else:
+                    suffix = temp.split('_')[-1]
+                    last_file_type = suffix
+            else:
+                last_file = None
+                last_file_type = None
+                last_device = None
+            continue
+        if line.startswith("open("):
+            temp = line.split(',')[0].split("(")[1].strip().strip('"')
+            if temp.startswith('/sys/class/'):
+                last_file = temp
+                if temp.endswith("/name"):
+                    last_device = os.path.dirname(temp)
+                    devices[last_device] = {"items": []}
+                    last_file_type = "name"
+                else:
+                    suffix = temp.split('_')[-1]
+                    last_file_type = suffix
+            else:
+                last_file = None
+                last_file_type = None
+                last_device = None
+            continue
+        if line.startswith("read("):
+            temp = line.split(',')[1].strip().strip('"')
+            if not temp:
+                continue
+            if last_file_type is None:
+                continue
+            if last_file_type == "name":
+                devices[last_device]['name'] = fix_label(temp)
+                continue
+            if last_file_type == "label":
+                last_device = os.path.dirname(last_file)
+                base_name = os.path.basename(last_file)
+                split_index = base_name.rfind("_")
+                item = base_name[:split_index]
+                if "group" not in devices[last_device]:
+                    devices[last_device]["group"] = last_group
+                if item not in devices[last_device]["items"]:
+                    devices[last_device]["items"].append(item)
+                    devices[last_device][item] = {}
+                    devices[last_device][item]["label"] = fix_label(temp)
+                continue
+            if last_file_type in ["input", "average"]:
+                last_device = os.path.dirname(last_file)
+                base_name = os.path.basename(last_file)
+                split_index = base_name.rfind("_")
+                item = base_name[:split_index]
+                if "group" not in devices[last_device]:
+                    devices[last_device]["group"] = last_group
+                if item not in devices[last_device]["items"]:
+                    devices[last_device]["items"].append(item)
+                    devices[last_device]["group"] = last_group
+                    devices[last_device][item] = {}
+                    devices[last_device][item]["label"] = fix_label(item)
+                devices[last_device][item]["inputfile"] = last_file
+                continue
+            if last_file_type in IGNORE_TYPES:
+                continue
+            continue
+        if ":" not in line:
+            last_group = line
+
+    for device, data in devices.items():
+        if data["items"]:
+            for item in data["items"]:
+                item_label = fix_label(".".join([data["group"], data[item]["label"] ]), nodash)
+                print(f"{item_label} {data[item]['inputfile']} S64 -1")
+
+    devices = {}
+    # Build and parse lscpu trace
+    if args.test_lscpu:
+        lscpu_trace_file = args.test_lscpu
     else:
-        tf = tempfile.mktemp(dir="/tmp", suffix=".trace",
-                prefix="ldms-config-sensors.")
-        atf = tf + "a"
-        cmd = "script -c 'strace -e trace=open,openat " + \
-            lscpubin + "' " + tf + "> /dev/null; grep cpuinfo_max_freq " + \
-            tf + " > " + atf
+        trace_file = tempfile.mktemp(dir="/tmp", suffix=".trace", prefix="ldms-config-sensors.")
+        lscpu_trace_file = trace_file + "a"
+        cmd = f"script -c 'strace -e trace=open,openat {lscpu_bin}' {trace_file} > /dev/null; grep cpuinfo_max_freq {trace_file} > {lscpu_trace_file}"
         trval = subprocess.call(cmd, shell=True)
         if trval != 0:
-            print "#Unable to collect lscpu config output"
-            return 1
-    f = open(atf)
-    lines = f.readlines()
-    f.close()
-    if args.test_lscpu == None:
-        os.unlink(tf)
-        os.unlink(atf)
-    for lf in lines:
-        l = lf.strip()
-        if len(l) < 5:
+            print("#Unable to collect lscpu config output")
+            exit(1)
+
+    with open(lscpu_trace_file) as file:
+        lines = file.readlines()
+
+    if not args.test_lscpu:
+        os.unlink(trace_file)
+        os.unlink(lscpu_trace_file)
+
+    for line in lines:
+        line = line.strip()
+        if len(line) < 5:
             continue
-        if "openat(" == l[:7]:
-            ## print "OPENAT", l
-            tmp = l.split('"')[1]
-            metfile = tmp.replace("max_fr", "cur_fr")
-            parts = tmp.split("/")
+        if line.startswith("openat("):
+            temp = line.split('"')[1]
+            met_file = temp.replace("max_fr", "cur_fr")
+            parts = temp.split("/")
             device = parts[-3]
             item = "cur_freq"
-            if not device in devices:
-                devices[device] = dict()
-            if not "items" in devices[device]:
-                devices[device]["items"] = []
-                devices[device]["group"] = device
+            if device not in devices:
+                devices[device] = {"items": [], "group": device}
             devices[device]["items"].append(item)
-            devices[device][item] = dict()
-            devices[device][item]["label"] = "cur_freq"
-            devices[device][item]["inputfile"] = metfile
-        elif "open(" == l[:5]:
-            ## print "OPEN", l
-            tmp = l.split('"')[1]
-            metfile = tmp.replace("max_fr", "cur_fr")
-            parts = tmp.split("/")
+            devices[device][item] = {"label": "cur_freq", "inputfile": met_file}
+        elif line.startswith("open("):
+            temp = line.split('"')[1]
+            met_file = temp.replace("max_fr", "cur_fr")
+            parts = temp.split("/")
             device = parts[-3]
             item = "cur_freq"
-            if not device in devices:
-                devices[device] = dict()
-            if not "items" in devices[device]:
-                devices[device]["items"] = []
-                devices[device]["group"] = device
+            if device not in devices:
+                devices[device] = {"items": [], "group": device}
             devices[device]["items"].append(item)
-            devices[device][item] = dict()
-            devices[device][item]["label"] = "cur_freq"
-            devices[device][item]["inputfile"] = metfile
+            devices[device][item] = {"label": "cur_freq", "inputfile": met_file}
         else:
-            print "unexpected line from lscpu trace:" + l
+            print(f"Unexpected line from lscpu trace: {line}")
 
-    # cpu temps reported in millicentigrade
-    # intel power averages in microwatts, apparently
-    # cpu freq reported in milliHz
-    llist=[]
-    for k,d in devices.iteritems():
-        if len(d["items"]) > 0:
-            for i in d["items"]:
-                ilbl = fixlabel(".".join([d["group"], d[i]["label"] ]), nodash)
-                ln = ilbl + " " + d[i]["inputfile"] + " " + "S64 -1"
-                llist.append(ln)
-    for i in sorted(llist):
-        print i
+    # CPU temps reported in millicentigrade
+    # Intel power averages in microwatts
+    # CPU freq reported in millihertz
+    output_lines = []
+    for device, data in devices.items():
+        if data["items"]:
+            for item in data["items"]:
+                item_label = fix_label(".".join([data["group"], data[item]["label"] ]), nodash)
+                output_line = f"{item_label} {data[item]['inputfile']} S64 -1"
+                output_lines.append(output_line)
+
+    for line in sorted(output_lines):
+        print(line)
 
 if __name__ == "__main__":
     main()
-

--- a/ldms/src/sampler/filesingle/ldms-sensors-config
+++ b/ldms/src/sampler/filesingle/ldms-sensors-config
@@ -83,6 +83,7 @@ def main():
         if trval != 0:
             print("Unable to collect sensors config output")
             exit(1)
+
     devices = { }
     with open(trace_file) as file:
         lines = f.readlines()

--- a/ldms/src/sampler/filesingle/ldms-sensors-config
+++ b/ldms/src/sampler/filesingle/ldms-sensors-config
@@ -83,7 +83,6 @@ def main():
         if trval != 0:
             print("Unable to collect sensors config output")
             exit(1)
-    
     devices = { }
     with open(trace_file) as file:
         lines = f.readlines()

--- a/ldms/src/sampler/filesingle/ldms-sensors-config
+++ b/ldms/src/sampler/filesingle/ldms-sensors-config
@@ -1,18 +1,14 @@
 #! /usr/bin/env python3
+# usage: $0: sensors_bin_path
 # Run sensors under strace to discover where sensor files
 # live on the current system and generate a draft file.
-
-import argparse
-import os
-import subprocess
-import tempfile
-
 import warnings
 import sys
 import os.path
 import tempfile
 import subprocess
 import argparse
+import os
 
 def fix_label(s, nodash=False):
     if s[-2:] == "\\n":
@@ -86,7 +82,7 @@ def main():
 
     devices = { }
     with open(trace_file) as file:
-        lines = f.readlines()
+        lines = file.readlines()
 
     if not args.test_sensors:
         os.unlink(trace_file)
@@ -147,9 +143,9 @@ def main():
                 base_name = os.path.basename(last_file)
                 split_index = base_name.rfind("_")
                 item = base_name[:split_index]
-                if "group" not in devices[last_device]:
+                if not "group" in devices[last_device]:
                     devices[last_device]["group"] = last_group
-                if item not in devices[last_device]["items"]:
+                if not item in devices[last_device]["items"]:
                     devices[last_device]["items"].append(item)
                     devices[last_device][item] = {}
                     devices[last_device][item]["label"] = fix_label(temp)
@@ -159,9 +155,9 @@ def main():
                 base_name = os.path.basename(last_file)
                 split_index = base_name.rfind("_")
                 item = base_name[:split_index]
-                if "group" not in devices[last_device]:
+                if not "group" in devices[last_device]:
                     devices[last_device]["group"] = last_group
-                if item not in devices[last_device]["items"]:
+                if not item in devices[last_device]["items"]:
                     devices[last_device]["items"].append(item)
                     devices[last_device]["group"] = last_group
                     devices[last_device][item] = {}
@@ -171,13 +167,15 @@ def main():
             if last_file_type in IGNORE_TYPES:
                 continue
             continue
-        if ":" not in line:
+        # exclude   lines with "xxxxx:" and "sdf: bar" but allow : in mlx device names.
+        if ": " not in line and line.strip()[-1] != ':':
             last_group = line
 
     for device, data in devices.items():
         if data["items"]:
             for item in data["items"]:
-                item_label = fix_label(".".join([data["group"], data[item]["label"] ]), nodash)
+                xg = data["group"] if data["group"] else "NOGROUP"
+                item_label = fix_label(".".join([xg, data[item]["label"] ]), nodash)
                 print(f"{item_label} {data[item]['inputfile']} S64 -1")
 
     devices = {}

--- a/ldms/src/sampler/filesingle/ldms-sensors-config
+++ b/ldms/src/sampler/filesingle/ldms-sensors-config
@@ -96,7 +96,6 @@ def main():
     last_file = None
     last_file_type = None
     last_group = None
-    
     for line in lines:
         line = line.strip()
         if len(line) < 5:
@@ -192,7 +191,6 @@ def main():
         if trval != 0:
             print("#Unable to collect lscpu config output")
             exit(1)
-
     with open(lscpu_trace_file) as file:
         lines = file.readlines()
 

--- a/ldms/src/sampler/shm/mpi_profiler/mpi_profiler.c
+++ b/ldms/src/sampler/shm/mpi_profiler/mpi_profiler.c
@@ -313,8 +313,9 @@ void post_Pcontrol_call(const int flag)
 	}
 }
 
-void *ldms_shm_periodic_update()
+void *ldms_shm_periodic_update(void *ignored)
 {
+	(void)ignored;
 	if(log_level_info())
 		printf("INFO: ldms_shm_updater_thread (%d): starting!\n\r",
 				profiler->rankid);

--- a/ldms/src/sampler/shm/mpi_profiler/wrap/wrap.py
+++ b/ldms/src/sampler/shm/mpi_profiler/wrap/wrap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 #################################################################################################
 # Copyright (c) 2010, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory
@@ -105,7 +105,6 @@ wrapper_includes = '''
 #include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "userheader.h"
 
 #ifndef _EXTERN_C_
 #ifdef __cplusplus
@@ -497,7 +496,7 @@ class Declaration:
         return self.argsNoEllipsis()[index].name
 
     def fortranFormals(self):
-        formals = map(Param.fortranFormal, self.argsNoEllipsis())
+        formals = list(map(Param.fortranFormal, self.argsNoEllipsis()))
         if self.name == "MPI_Init": formals = []    # Special case for init: no args in fortran
 
         ierr = []

--- a/ldms/src/sampler/shm/mpi_profiler/wrap/wrap.py
+++ b/ldms/src/sampler/shm/mpi_profiler/wrap/wrap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #################################################################################################
 # Copyright (c) 2010, Lawrence Livermore National Security, LLC.
 # Produced at the Lawrence Livermore National Laboratory
@@ -30,7 +30,7 @@
 # WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #################################################################################################
-from __future__ import print_function
+
 usage_string = \
 '''Usage: wrap.py [-fgd] [-i pmpi_init] [-c mpicc_name] [-o file] wrapper.w [...]
  Python script for creating PMPI wrappers. Roughly follows the syntax of
@@ -105,6 +105,7 @@ wrapper_includes = '''
 #include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "userheader.h"
 
 #ifndef _EXTERN_C_
 #ifdef __cplusplus
@@ -237,7 +238,7 @@ def joinlines(list, sep="\n"):
         return ""
 
 # Possible types of Tokens in input.
-LBRACE, RBRACE, TEXT, IDENTIFIER = range(4)
+LBRACE, RBRACE, TEXT, IDENTIFIER = list(range(4))
 
 class Token:
     """Represents tokens; generated from input by lexer and fed to parse()."""
@@ -481,7 +482,7 @@ class Declaration:
         return [arg.cType() for arg in self.args]
 
     def argsNoEllipsis(self):
-        return filter(lambda arg: arg.name != "...", self.args)
+        return [arg for arg in self.args if arg.name != "..."]
 
     def returnsErrorCode(self):
         """This is a special case for MPI_Wtime and MPI_Wtick.
@@ -578,7 +579,7 @@ def enumerate_mpi_declarations(mpicc, includes):
                 raise ValueError("Malformed declaration in header: '%s'" % line)
 
             arg_string = line[lparen+1:rparen]
-            arg_list = list(map(lambda s: s.strip(), arg_string.split(",")))
+            arg_list = list([s.strip() for s in arg_string.split(",")])
 
             # Handle functions that take no args specially
             if arg_list == ['void']:
@@ -659,7 +660,7 @@ def write_fortran_binding(out, decl, delegate_name, binding, stmts=None):
     out.write(decl.fortranPrototype(binding, default_modifiers))
     out.write(" { \n")
     if stmts:
-        out.write(joinlines(map(lambda s: "    " + s, stmts)))
+        out.write(joinlines(["    " + s for s in stmts]))
     if decl.returnsErrorCode():
         # regular MPI fortran functions use an error code
         out.write("    %s(%s);\n" % (delegate_name, ", ".join(decl.fortranArgNames())))
@@ -1092,7 +1093,7 @@ class Chunk:
 
     def iwrite(self, file, level, text):
         """Write indented text."""
-        for x in xrange(level):
+        for x in range(level):
             file.write("  ")
         file.write(text)
 

--- a/ldms/src/sampler/shm/shm_sampler.c
+++ b/ldms/src/sampler/shm/shm_sampler.c
@@ -366,9 +366,9 @@ static int create_base_for_box(ldms_shm_box_t *box, const char* schema_name,
 	box->base->job_end_idx = initial_base_config->job_end_idx;
 	box->base->job_id_idx = initial_base_config->job_id_idx;
 	box->base->job_start_idx = initial_base_config->job_start_idx;
-	box->base->uid = initial_base_config->uid;
-	box->base->gid = initial_base_config->gid;
-	box->base->perm = initial_base_config->perm;
+	box->base->auth.uid = initial_base_config->auth.uid;
+	box->base->auth.gid = initial_base_config->auth.gid;
+	box->base->auth.perm = initial_base_config->auth.perm;
 
 	box->base->producer_name = strdup(initial_base_config->producer_name);
 	box->base->schema_name = strdup(schema_name);
@@ -439,14 +439,14 @@ static void handle_ldms_set_delete_issue(ldms_shm_box_t* box)
 								ldms_shm_metric_set_counter)
 								+ 1;
 		int num_delimiter_chars = 1;
-		int instance_name_len = strlen(box->base->instance_name)
+		size_t instance_name_len = strlen(box->base->instance_name)
 				+ num_delimiter_chars
 				+ ldms_shm_metric_set_counter_len + 1;
 
 		char* instance_name = calloc(instance_name_len, sizeof(char));
 		if(!instance_name) {
 			ovis_log(mylog, OVIS_LERROR,
-					"failed to allocate memory of size=%d (%d + %d + %d + 1) for instance %s\n",
+					"failed to allocate memory of size=%zu (%zu + %d + %d + 1) for instance %s\n",
 					instance_name_len,
 					strlen(box->base->instance_name),
 					num_delimiter_chars,
@@ -482,7 +482,7 @@ static int create_metric_set(ldms_shm_box_t *box, ldms_shm_set_t shm_set,
 	if(!box->base->schema) {
 		ovis_log(mylog, OVIS_LERROR,
 				"%s: The schema '%s' could not be created, errno=%d.\n",
-				__FILE__, box->base, errno);
+				__FILE__, box->base->schema_name, errno);
 		rc = errno;
 		return rc;
 	}


### PR DESCRIPTION
@bschwal this removes python2 from OVIS-4
```
bash-4.4$ grep -r "/usr/bin/env python2" rpmbuild/BUILD/    
rpmbuild/BUILD/ovis-ldms-4.4.3/ldms/src/sampler/shm/mpi_profiler/wrap/wrap.py:#!/usr/bin/env python2  
rpmbuild/BUILD/ovis-ldms-4.4.3/ldms/src/sampler/filesingle/ldms-sensors-config:#! /usr/bin/env python2  
rpmbuild/BUILD/ovis-ldms-4.4.3/ldms/scripts/ldms-csv-export-sos:#! /usr/bin/env python2  
rpmbuild/BUILD/ovis-ldms-4.4.3/ldms/scripts/ovis-roll-over.py:#!/usr/bin/env python2  
rpmbuild/BUILD/ovis-ldms-4.4.3/ldms/scripts/ldms-csv-anonymize:#! /usr/bin/env python2
```

I still need to do some testing to ensure I didn't introduce any bad syntax. Evan and I plan on testing  this early this week.  If you have a chance, please review.