### PR TITLE
LDMS Rail fixes

### DIFF
--- a/ldms/python/ldms.pxd
+++ b/ldms/python/ldms.pxd
@@ -395,6 +395,7 @@ cdef extern from "ldms.h" nogil:
     ctypedef uint64_t pthread_t
     int ldms_xprt_get_threads(ldms_t x, pthread_t *out, int n)
     int ldms_xprt_is_rail(ldms_t x)
+    int ldms_xprt_is_remote_rail(ldms_t x)
     int ldms_xprt_rail_eps(ldms_t x)
     int ldms_xprt_rail_send_credit_get(ldms_t x, uint64_t *credits, int n)
 

--- a/ldms/python/ldms.pxd
+++ b/ldms/python/ldms.pxd
@@ -277,6 +277,7 @@ cdef extern from "ldms.h" nogil:
         EVENT_ERROR         "LDMS_XPRT_EVENT_ERROR"
         EVENT_DISCONNECTED  "LDMS_XPRT_EVENT_DISCONNECTED"
         EVENT_RECV          "LDMS_XPRT_EVENT_RECV"
+        EVENT_SET_DELETE    "LDMS_XPRT_EVENT_SET_DELETE"
         EVENT_SEND_COMPLETE "LDMS_XPRT_EVENT_SEND_COMPLETE"
         EVENT_SEND_CREDIT_DEPOSITED "LDMS_XPRT_EVENT_SEND_CREDIT_DEPOSITED"
         EVENT_LAST          "LDMS_XPRT_EVENT_LAST"
@@ -285,12 +286,16 @@ cdef extern from "ldms.h" nogil:
         LDMS_XPRT_EVENT_ERROR
         LDMS_XPRT_EVENT_DISCONNECTED
         LDMS_XPRT_EVENT_RECV
+        LDMS_XPRT_EVENT_SET_DELETE
         LDMS_XPRT_EVENT_SEND_COMPLETE
         LDMS_XPRT_EVENT_SEND_CREDIT_DEPOSITED
         LDMS_XPRT_EVENT_LAST
     cdef struct ldms_xprt_credit_event_data:
         uint64_t credit
         int      ep_idx
+    cdef struct ldms_xprt_set_delete_data:
+        void * set
+        const char *name
     cdef struct ldms_xprt_event:
         ldms_xprt_event_type type
         size_t data_len
@@ -298,6 +303,7 @@ cdef extern from "ldms.h" nogil:
         # know the names of the "fields" it can access in C code.
         char *data
         ldms_xprt_credit_event_data credit
+        ldms_xprt_set_delete_data set_delete
     ctypedef ldms_xprt_event *ldms_xprt_event_t
     ctypedef void (*ldms_event_cb_t)(ldms_t x, ldms_xprt_event_t e, void *cb_arg)
 

--- a/ldms/python/ldms.pyx
+++ b/ldms/python/ldms.pyx
@@ -3687,6 +3687,20 @@ cdef class Xprt(object):
         return ( LdmsAddr.from_sockaddr(PTR(&lcl)),
                  LdmsAddr.from_sockaddr(PTR(&rmt)) )
 
+    @property
+    def is_rail(self):
+        """True if this is a rail transport"""
+        cdef int rc
+        rc = ldms_xprt_is_rail(self.xprt)
+        return bool(rc)
+
+    @property
+    def is_remote_rail(self):
+        """True if the remote peer is a rail"""
+        cdef int rc
+        rc = ldms_xprt_is_remote_rail(self.xprt)
+        return bool(rc)
+
 
 cdef class _StreamSubCtxt(object):
     """For internal use"""

--- a/ldms/src/core/ldms_rail.c
+++ b/ldms/src/core/ldms_rail.c
@@ -704,6 +704,7 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
 	r->eps[m->idx].rate_credit.rate   = r->send_rate_limit;
 	r->eps[m->idx].rate_credit.ts.tv_sec  = 0;
 	r->eps[m->idx].rate_credit.ts.tv_nsec = 0;
+	r->eps[m->idx].remote_is_rail = 1;
 	ldms_xprt_ctxt_set(_x, &r->eps[m->idx], NULL);
 	pthread_mutex_unlock(&r->mutex);
 

--- a/ldms/src/core/ldms_rail.c
+++ b/ldms/src/core/ldms_rail.c
@@ -251,12 +251,6 @@ ldms_t ldms_xprt_rail_new(const char *xprt_name,
 	}
 	r->max_msg = zap_max_msg(zap);
 
-//	r->eps[0].ep = __ldms_xprt_new_with_auth(r->name, r->auth_name, r->auth_av_list);
-//	if (!r->eps[0].ep)
-//		goto err_1;
-//	ldms_xprt_ctxt_set(r->eps[0].ep, &r->eps[0], NULL);
-//	r->max_msg = r->eps[0].ep->max_msg;
-
 	/* The other endpoints will be created later in connect() or
 	 * __rail_zap_handle_conn_req() */
 
@@ -624,9 +618,6 @@ void __rail_zap_handle_conn_req(zap_ep_t zep, zap_event_t ev)
 			pthread_mutex_unlock(&__rail_mutex);
 			goto err_0;
 		}
-//		/* drop the unused first initial endpoint */
-//		ldms_xprt_put(r->eps[0].ep);
-//		r->eps[0].ep = NULL;
 
 		r->xtype = LDMS_XTYPE_PASSIVE_RAIL;
 		r->state = LDMS_RAIL_EP_ACCEPTING;

--- a/ldms/src/core/ldms_xprt.h
+++ b/ldms/src/core/ldms_xprt.h
@@ -434,6 +434,8 @@ struct ldms_xprt_ops_s {
 	void (*event_cb_set)(ldms_t x, ldms_event_cb_t cb ,void *cb_arg);
 
 	zap_ep_t (*get_zap_ep)(ldms_t x);
+
+	ldms_set_t (*set_by_name)(ldms_t x, const char *set_name);
 };
 
 struct ldms_xprt {


### PR DESCRIPTION
This pull request addresses the following issues:
- Add the _forgotten_ `set_by_name()` xprt operation. 
- The passive (accepted) legacy xprt was intentionally exposed to the application. It should be wrapped in rail object.
- Fix `set_delete` notification code path to support rail.