### PR TITLE
Fix decomp operations (b4.4. branch)

### DIFF
--- a/ldms/src/decomp/static/decomp_static.c
+++ b/ldms/src/decomp/static/decomp_static.c
@@ -1773,7 +1773,7 @@ static int decomp_static_decompose(ldmsd_strgp_t strgp, ldms_set_t set,
 						group_idx);
 				if (count != cfg_row->group_count)
 					ldmsd_log(LDMSD_LWARNING,
-						"strgp '%s': insufficent rows in "
+						"strgp '%s': insufficient rows in "
 						"cache to satisfy functional operator '%s' "
 						"on column '%s'.\n",
 						strgp->obj.name, cfg_col->op_name,

--- a/ldms/src/decomp/static/decomp_static.c
+++ b/ldms/src/decomp/static/decomp_static.c
@@ -1789,15 +1789,16 @@ static int decomp_static_decompose(ldmsd_strgp_t strgp, ldms_set_t set,
 						cfg_row->row_limit,
 						strgp->row_cache,
 						group_idx);
-				if (count != cfg_row->group_count)
-					ldmsd_log(LDMSD_LWARNING,
-						"strgp '%s': insufficient rows in "
-						"cache to satisfy functional operator '%s' "
-						"on column '%s'.\n",
-                                                strgp->obj.name,
-                                                ldmsd_decomp_op_to_string(cfg_col->op),
-						cfg_col->dst);
 				cfg_col = &cfg_row->cols[j];
+				if (cfg_col->op != LDMSD_DECOMP_OP_NONE
+                                    && count < cfg_row->row_limit)
+					ldmsd_log(LDMSD_LDEBUG,
+                                                  "strgp '%s': insufficient rows (%d of %d) in "
+                                                  "cache to satisfy functional operator '%s' "
+                                                  "on column '%s'.\n",
+                                                  strgp->obj.name, count, cfg_row->row_limit,
+                                                  ldmsd_decomp_op_to_string(cfg_col->op),
+                                                  cfg_col->dst);
 				rc = op_table[cfg_col->op](&row_list, dup_row, j);
 			}
 			ldmsd_row_cache_idx_free(group_idx);

--- a/ldms/src/decomp/static/decomp_static.c
+++ b/ldms/src/decomp/static/decomp_static.c
@@ -286,14 +286,6 @@ decomp_static_release_decomp(ldmsd_strgp_t strgp)
 	}
 }
 
-static int init_row_cache(ldmsd_strgp_t strgp, int row_limit)
-{
-	strgp->row_cache = ldmsd_row_cache_create(strgp, row_limit);
-	if (strgp->row_cache)
-		return 0;
-	return 1;
-}
-
 static int get_col_no(decomp_static_row_cfg_t cfg_row, const char *name)
 {
 	int i;
@@ -509,8 +501,8 @@ static int handle_group(
 		}
 	}
 
-	rc = init_row_cache(strgp, cfg_row->row_limit);
-	if (rc)
+	strgp->row_cache = ldmsd_row_cache_create(strgp, cfg_row->row_limit);
+	if (!strgp->row_cache)
 		goto enomem;
 	return 0;
 enomem:

--- a/ldms/src/decomp/static/decomp_static.c
+++ b/ldms/src/decomp/static/decomp_static.c
@@ -1792,13 +1792,13 @@ static int decomp_static_decompose(ldmsd_strgp_t strgp, ldms_set_t set,
 			dup_row = row_cache_dup(cfg_row, mid_rbn, row);
 
 			/* Apply functional operators to columns */
+                        struct ldmsd_row_list_s tmp_row_list;
+                        int count;
+                        count = ldmsd_row_cache_make_list(&tmp_row_list,
+                                                          cfg_row->row_limit,
+                                                          strgp->row_cache,
+                                                          group_idx);
 			for (j = 0; j < row->col_count; j++) {
-				struct ldmsd_row_list_s row_list;
-				int count = ldmsd_row_cache_make_list(
-						&row_list,
-						cfg_row->row_limit,
-						strgp->row_cache,
-						group_idx);
 				cfg_col = &cfg_row->cols[j];
 				if (cfg_col->op != LDMSD_DECOMP_OP_NONE
                                     && count < cfg_row->row_limit)
@@ -1809,7 +1809,7 @@ static int decomp_static_decompose(ldmsd_strgp_t strgp, ldms_set_t set,
                                                   strgp->obj.name, count, cfg_row->row_limit,
                                                   ldmsd_decomp_op_to_string(cfg_col->op),
                                                   cfg_col->dst);
-				rc = op_table[cfg_col->op](&row_list, dup_row, j);
+				rc = op_table[cfg_col->op](&tmp_row_list, dup_row, j);
 			}
 			ldmsd_row_cache_idx_free(group_idx);
 			row = dup_row;

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -433,7 +433,6 @@ typedef struct ldmsd_row_group_s {
 
 typedef struct ldmsd_row_cache_s {
 	ldmsd_strgp_t strgp;
-	int group_key_count;
 	int row_limit;
 	struct rbt group_tree;	/* Tree of ldmsd_row_group_t */
 	pthread_mutex_t lock;

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -288,7 +288,6 @@ struct ldmsd_stat {
 typedef struct ldmsd_prdcr_set {
 	char *inst_name;
 	char *schema_name;
-	char *producer_name;
 	ldmsd_prdcr_t prdcr;
 	ldms_set_t set;
 	int push_flags;

--- a/ldms/src/ldmsd/ldmsd_row_cache.c
+++ b/ldms/src/ldmsd/ldmsd_row_cache.c
@@ -41,6 +41,7 @@ static int tree_comparator(void *a, const void *b)
 	ldmsd_row_cache_idx_t key_a = (ldmsd_row_cache_idx_t)a;
 	ldmsd_row_cache_idx_t key_b = (ldmsd_row_cache_idx_t)b;
 	ldmsd_row_cache_key_t rowk_a, rowk_b;
+        int rc;
         assert(key_a->key_count == key_b->key_count);
 	for (i = 0; i < key_a->key_count; i++) {
 		rowk_a = key_a->keys[i];
@@ -56,10 +57,13 @@ static int tree_comparator(void *a, const void *b)
 				return -1;
 			if (rowk_a->mval->v_ts.usec > rowk_b->mval->v_ts.usec)
 				return 1;
-			return 0;
+                        continue;
 		case LDMS_V_CHAR_ARRAY:
-			return strncmp(rowk_a->mval->a_char, rowk_b->mval->a_char,
-				       rowk_a->count);
+			rc = strncmp(rowk_a->mval->a_char, rowk_b->mval->a_char,
+                                     rowk_a->count);
+                        if (rc != 0)
+                                return rc;
+                        continue;
 		case LDMS_V_CHAR:
 			if (rowk_a->mval->v_char == rowk_b->mval->v_char)
 				continue;

--- a/ldms/src/ldmsd/ldmsd_row_cache.c
+++ b/ldms/src/ldmsd/ldmsd_row_cache.c
@@ -41,9 +41,11 @@ static int tree_comparator(void *a, const void *b)
 	ldmsd_row_cache_idx_t key_a = (ldmsd_row_cache_idx_t)a;
 	ldmsd_row_cache_idx_t key_b = (ldmsd_row_cache_idx_t)b;
 	ldmsd_row_cache_key_t rowk_a, rowk_b;
+        assert(key_a->key_count == key_b->key_count);
 	for (i = 0; i < key_a->key_count; i++) {
 		rowk_a = key_a->keys[i];
 		rowk_b = key_b->keys[i];
+                assert(rowk_a->type == rowk_b->type);
 		switch (rowk_a->type) {
 		case LDMS_V_TIMESTAMP:
 			if (rowk_a->mval->v_ts.sec < rowk_b->mval->v_ts.sec)


### PR DESCRIPTION
There are multiple fixes and improvements in this PR.

The bug that instigated this work is fixed in the commit titled "ldmsd_row_cache: fix tree_comparator() function".

Also notable is the fix for the timestamp calculations in commit "decomp_static: correct timestamp calculations".
