### PR TITLE
samplers: API CHANGE - Remove sampler get_set() function

### DIFF
--- a/ldms/src/contrib/sampler/daos/daos.c
+++ b/ldms/src/contrib/sampler/daos/daos.c
@@ -226,11 +226,6 @@ static void term(struct ldmsd_plugin *self)
 		ovis_log_destroy(mylog);
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static const char *usage(struct ldmsd_plugin *self)
 {
 	dao_log(OVIS_LDEBUG, "usage() called\n");
@@ -245,7 +240,6 @@ static struct ldmsd_sampler daos_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler.c
+++ b/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler.c
@@ -506,12 +506,6 @@ exit:
 	return rc;
 }
 
-
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return g_set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	int rc = 0;
@@ -578,7 +572,6 @@ static struct ldmsd_sampler g_geopm_sampler_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/contrib/sampler/gpu_metrics_sampler/gpu_metrics_ldms_sampler.c
+++ b/ldms/src/contrib/sampler/gpu_metrics_sampler/gpu_metrics_ldms_sampler.c
@@ -277,15 +277,6 @@ static int config(struct ldmsd_plugin *self,
 }
 
 /**
- * LDMS call this function to obtain the current set of metrics.
- * @param self this plugin instance.
- * @return current set of metrics.
- */
-static ldms_set_t get_set(struct ldmsd_sampler *self) {
-    return set;
-}
-
-/**
  * LDMS calls this function to sample GPU metrics and store them in the metrics set.
  * @param self
  * @return 0 if successful; otherwise returns EINVAL.
@@ -357,7 +348,6 @@ static struct ldmsd_sampler gpu_metrics_plugin = {
                 .config = config,   // constructor
                 .usage = usage,
         },
-        .get_set = get_set,
         .sample = sample,
 };
 

--- a/ldms/src/contrib/sampler/ipmireader/ipmireader.c
+++ b/ldms/src/contrib/sampler/ipmireader/ipmireader.c
@@ -429,11 +429,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	int metric_no;
@@ -542,7 +537,6 @@ static struct ldmsd_sampler ipmireader_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/contrib/sampler/ipmireader/ipmisensors.c
+++ b/ldms/src/contrib/sampler/ipmireader/ipmisensors.c
@@ -305,11 +305,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	int metric_no;
@@ -400,7 +395,6 @@ static struct ldmsd_sampler ipmisensors_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/contrib/sampler/tutorial/tutorial_sampler.c
+++ b/ldms/src/contrib/sampler/tutorial/tutorial_sampler.c
@@ -196,11 +196,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	int metric_no;
@@ -266,7 +261,6 @@ static struct ldmsd_sampler tutorial_sampler_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/contrib/sampler/variorum_sampler/variorum_sampler.c
+++ b/ldms/src/contrib/sampler/variorum_sampler/variorum_sampler.c
@@ -195,11 +195,6 @@ static int sample(struct ldmsd_sampler *self)
 
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-        return set;
-}
-
 static void term(struct ldmsd_plugin *self)
 {
         int metric;
@@ -238,7 +233,6 @@ static struct ldmsd_sampler variorum_sampler_plugin = {
             .config = config,
             .usage= usage,
         },
-        .get_set = get_set,
         .sample = sample,
 };
 

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -905,7 +905,6 @@ struct ldmsd_plugin {
 
 struct ldmsd_sampler {
 	struct ldmsd_plugin base;
-	ldms_set_t (*get_set)(struct ldmsd_sampler *self);
 	int (*sample)(struct ldmsd_sampler *self);
 };
 

--- a/ldms/src/ldmsd/ldmsd.h
+++ b/ldms/src/ldmsd/ldmsd.h
@@ -897,7 +897,6 @@ struct ldmsd_plugin {
 		LDMSD_PLUGIN_STORE
 	} type;
 	struct ldmsd_plugin_cfg *pi;
-	enum ldmsd_plugin_type (*get_type)(struct ldmsd_plugin *self);
 	int (*config)(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct attr_value_list *avl);
 	void (*term)(struct ldmsd_plugin *self);
 	const char *(*usage)(struct ldmsd_plugin *self);

--- a/ldms/src/sampler/appinfo.c
+++ b/ldms/src/sampler/appinfo.c
@@ -376,14 +376,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl,
 }
 
 /**
- * Sampler metric set accessor (required).
- **/
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
-/**
  * Sample data. In the appinfo sampler, we need to find in the shared
  * memory the next process data structure that is ready for sampling,
  * copy it into the metric set, and mark it as sampled.
@@ -488,7 +480,6 @@ static struct ldmsd_sampler appinfo_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/aries_mmr/aries_linkstatus.c
+++ b/ldms/src/sampler/aries_mmr/aries_linkstatus.c
@@ -202,11 +202,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 	return EINVAL;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	int rc, row, col;
@@ -321,7 +316,6 @@ static struct ldmsd_sampler aries_linkstatus_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/aries_mmr/aries_mmr.c
+++ b/ldms/src/sampler/aries_mmr/aries_mmr.c
@@ -521,13 +521,6 @@ out:
 
 }
 
-
-
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static void term(struct ldmsd_plugin *self)
 {
 
@@ -590,7 +583,6 @@ static struct ldmsd_sampler aries_mmr_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/aries_mmr/aries_mmr_configurable.c
+++ b/ldms/src/sampler/aries_mmr/aries_mmr_configurable.c
@@ -945,12 +945,6 @@ out:
 
 }
 
-
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static void term(struct ldmsd_plugin *self)
 {
 	int i;
@@ -975,7 +969,6 @@ static struct ldmsd_sampler aries_mmr_configurable_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/aries_mmr/aries_nic_mmr.c
+++ b/ldms/src/sampler/aries_mmr/aries_nic_mmr.c
@@ -517,13 +517,6 @@ out:
 
 }
 
-
-
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static void term(struct ldmsd_plugin *self)
 {
 
@@ -588,7 +581,6 @@ static struct ldmsd_sampler aries_nic_mmr_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/aries_mmr/aries_rtr_mmr.c
+++ b/ldms/src/sampler/aries_mmr/aries_rtr_mmr.c
@@ -515,13 +515,6 @@ out:
 
 }
 
-
-
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static void term(struct ldmsd_plugin *self)
 {
 
@@ -586,7 +579,6 @@ static struct ldmsd_sampler aries_rtr_mmr_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/blob_stream/blob_stream_writer.c
+++ b/ldms/src/sampler/blob_stream/blob_stream_writer.c
@@ -643,11 +643,6 @@ static const char *usage(struct ldmsd_plugin *self)
 		;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	return 0;
@@ -661,7 +656,6 @@ static struct ldmsd_sampler blob_stream_writer = {
 			.config = config,
 			.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample
 };
 

--- a/ldms/src/sampler/clock/clock.c
+++ b/ldms/src/sampler/clock/clock.c
@@ -179,11 +179,6 @@ err:
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	union ldms_value v;
@@ -221,7 +216,6 @@ static struct ldmsd_sampler clock_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/coretemp/coretemp.c
+++ b/ldms/src/sampler/coretemp/coretemp.c
@@ -251,11 +251,6 @@ static ldms_set_t set;
 static ovis_log_t mylog;
 static base_data_t base;
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int create_metric_set(base_data_t base)
 {
 	int rc;
@@ -430,7 +425,6 @@ static struct ldmsd_sampler coretemp_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/cray_system_sampler/cray_aries_r_sampler.c
+++ b/ldms/src/sampler/cray_system_sampler/cray_aries_r_sampler.c
@@ -85,11 +85,6 @@ static int off_hsn = 0;
 
 static base_data_t base;
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int create_metric_set(base_data_t base)
 {
 	int rc, i;
@@ -361,7 +356,6 @@ static struct ldmsd_sampler cray_aries_r_sampler_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/cray_system_sampler/cray_gemini_r_sampler.c
+++ b/ldms/src/sampler/cray_system_sampler/cray_gemini_r_sampler.c
@@ -86,11 +86,6 @@ static int off_hsn = 0;
 
 static base_data_t base;
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int create_metric_set(base_data_t base)
 {
 
@@ -370,7 +365,6 @@ static struct ldmsd_sampler cray_gemini_r_sampler_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/cray_system_sampler/dvs_sampler.c
+++ b/ldms/src/sampler/cray_system_sampler/dvs_sampler.c
@@ -431,11 +431,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 dvs_mount_t find_dvs(const char *dir)
 {
 	struct rbn *rbn = rbt_find(&mount_tree, dir);
@@ -729,7 +724,6 @@ static struct ldmsd_sampler dvs_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
+++ b/ldms/src/sampler/dcgm_sampler/dcgm_sampler.c
@@ -645,11 +645,6 @@ static void term(struct ldmsd_plugin *self)
 
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static const char *usage(struct ldmsd_plugin *self)
 {
         ovis_log(mylog, OVIS_LDEBUG, "usage() called\n");
@@ -694,7 +689,6 @@ static struct ldmsd_sampler nvidia_dcgm_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/dstat/dstat.c
+++ b/ldms/src/sampler/dstat/dstat.c
@@ -519,11 +519,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	int rc = 0;
@@ -590,7 +585,6 @@ static struct ldmsd_sampler dstat_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/examples/array_example/all_example.c
+++ b/ldms/src/sampler/examples/array_example/all_example.c
@@ -265,11 +265,6 @@ static int sample(struct ldmsd_sampler *self)
 	return 0;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static void term(struct ldmsd_plugin *self)
 {
 	if (base)
@@ -295,7 +290,6 @@ static struct ldmsd_sampler all_example_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/examples/array_example/array_example.c
+++ b/ldms/src/sampler/examples/array_example/array_example.c
@@ -272,11 +272,6 @@ static int sample(struct ldmsd_sampler *self)
 	return 0;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static void term(struct ldmsd_plugin *self)
 {
 	if (base)
@@ -306,7 +301,6 @@ static struct ldmsd_sampler array_example_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/examples/list_sampler/list_sampler.c
+++ b/ldms/src/sampler/examples/list_sampler/list_sampler.c
@@ -227,11 +227,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static
 void value_setter(ldms_mval_t mval, enum ldms_value_type typ, int item)
 {
@@ -402,7 +397,6 @@ static struct ldmsd_sampler __plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/examples/record_sampler/record_sampler.c
+++ b/ldms/src/sampler/examples/record_sampler/record_sampler.c
@@ -232,11 +232,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static
 void value_setter(ldms_mval_t mval, enum ldms_value_type typ, int item)
 {
@@ -396,7 +391,6 @@ static struct ldmsd_sampler __plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/examples/synthetic/synthetic.c
+++ b/ldms/src/sampler/examples/synthetic/synthetic.c
@@ -268,11 +268,6 @@ err:
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	union ldms_value v;
@@ -342,7 +337,6 @@ static struct ldmsd_sampler synthetic_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/examples/test_sampler/test_sampler.c
+++ b/ldms/src/sampler/examples/test_sampler/test_sampler.c
@@ -1721,11 +1721,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 	return 0;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	assert(0 == "not implemented");
-}
-
 static int __gen_list_len(int min_len, int max_len)
 {
 	int llen = rand();
@@ -2013,7 +2008,6 @@ static struct ldmsd_sampler test_sampler_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/filesingle/filesingle.c
+++ b/ldms/src/sampler/filesingle/filesingle.c
@@ -288,11 +288,6 @@ err:
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	int rc;
@@ -387,7 +382,6 @@ static struct ldmsd_sampler filesingle_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/fptrans/fptrans.c
+++ b/ldms/src/sampler/fptrans/fptrans.c
@@ -210,11 +210,6 @@ err:
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	union ldms_value v;
@@ -251,7 +246,6 @@ static struct ldmsd_sampler fptrans_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/generic_sampler.c
+++ b/ldms/src/sampler/generic_sampler.c
@@ -321,11 +321,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 	return create_metric_set(value, prod_name);
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static void term(struct ldmsd_plugin *self)
 {
 	if (schema)
@@ -421,7 +416,6 @@ static struct ldmsd_sampler gs_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/grptest.c
+++ b/ldms/src/sampler/grptest.c
@@ -223,11 +223,6 @@ err:
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return grp;
-}
-
 static void __set_sample(ldms_set_t set)
 {
 	uint32_t counter;
@@ -275,7 +270,6 @@ static struct ldmsd_sampler meminfo_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/hello_stream/hello_sampler.c
+++ b/ldms/src/sampler/hello_stream/hello_sampler.c
@@ -85,11 +85,6 @@ static const char *usage(struct ldmsd_plugin *self)
 		"                   Defaults to 'hello'\n";
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	return 0;
@@ -146,7 +141,6 @@ static struct ldmsd_sampler hello_sampler = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample
 };
 

--- a/ldms/src/sampler/hweventpapi/hweventpapi.c
+++ b/ldms/src/sampler/hweventpapi/hweventpapi.c
@@ -935,11 +935,6 @@ out:
 	return EINVAL;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler * self)
-{
-	return set;
-}
-
 /*
  * This function called by the create_event_sets to create and add papi events
  * Input: event set
@@ -1423,7 +1418,6 @@ static struct ldmsd_sampler papi_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/ibm_occ/ibm_occ.c
+++ b/ldms/src/sampler/ibm_occ/ibm_occ.c
@@ -246,11 +246,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	int rc, metric_no, fd;
@@ -348,7 +343,6 @@ static struct ldmsd_sampler ibm_occ_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/ibmad_records_sampler/ibmad_records_sampler.c
+++ b/ldms/src/sampler/ibmad_records_sampler/ibmad_records_sampler.c
@@ -849,11 +849,6 @@ static void term(struct ldmsd_plugin *self)
         sampler_base = NULL;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static const char *usage(struct ldmsd_plugin *self)
 {
         ovis_log(mylog, OVIS_LDEBUG, "usage() called\n");
@@ -870,7 +865,6 @@ static struct ldmsd_sampler ibmad_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
+++ b/ldms/src/sampler/ibmad_sampler/ibmad_sampler.c
@@ -770,11 +770,6 @@ static void term(struct ldmsd_plugin *self)
 		ovis_log_destroy(mylog);
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static const char *usage(struct ldmsd_plugin *self)
 {
         ovis_log(mylog, OVIS_LDEBUG, "usage() called\n");
@@ -789,7 +784,6 @@ static struct ldmsd_sampler ibmad_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/ibnet/ibnet_plugin.c
+++ b/ldms/src/sampler/ibnet/ibnet_plugin.c
@@ -121,11 +121,6 @@ static void term_ibnet(struct ldmsd_plugin *self)
 	pthread_mutex_unlock(&only_lock);
 }
 
-static ldms_set_t get_set_ibnet(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static const char *usage_ibnet(struct ldmsd_plugin *self)
 {
 	ovis_log(mylog, OVIS_LDEBUG, SAMP " usage() called\n");
@@ -142,7 +137,6 @@ static struct ldmsd_sampler ibnet_plugin = {
 		.config = config_ibnet,
 		.usage = usage_ibnet,
 	},
-	.get_set = get_set_ibnet,
 	.sample = sample_ibnet,
 };
 

--- a/ldms/src/sampler/job_info/jobinfo.c
+++ b/ldms/src/sampler/job_info/jobinfo.c
@@ -432,12 +432,6 @@ config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct attr_value
 	return 0;
 }
 
-static ldms_set_t
-get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int
 sample(struct ldmsd_sampler *self)
 {
@@ -465,7 +459,6 @@ static struct ldmsd_sampler job_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/json/json_stream_sampler.c
+++ b/ldms/src/sampler/json/json_stream_sampler.c
@@ -1103,12 +1103,6 @@ static int sample(struct ldmsd_sampler *self)
 	return 0;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	/* no opt */
-	return NULL;
-}
-
 static struct ldmsd_sampler json_plugin = {
 	.base = {
 		.name = SAMP,
@@ -1117,7 +1111,6 @@ static struct ldmsd_sampler json_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/kgnilnd/kgnilnd.c
+++ b/ldms/src/sampler/kgnilnd/kgnilnd.c
@@ -81,11 +81,6 @@ static int metric_offset = 0;
 static int nmetrics = 0;
 static base_data_t base;
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 
 static char *replace_space(char *s)
 {
@@ -346,7 +341,6 @@ static struct ldmsd_sampler kgnilnd_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/ldms_jobid.c
+++ b/ldms/src/sampler/ldms_jobid.c
@@ -554,11 +554,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 	return 0;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	if (!set) {
@@ -636,7 +631,6 @@ static struct ldmsd_sampler jobid_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/llnl/edac.c
+++ b/ldms/src/sampler/llnl/edac.c
@@ -361,11 +361,6 @@ err:
 
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	// If there was an error before, don't send multiple errors, just return
@@ -456,7 +451,6 @@ static struct ldmsd_sampler edac_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/lnet_stats/lnet_stats.c
+++ b/ldms/src/sampler/lnet_stats/lnet_stats.c
@@ -321,11 +321,6 @@ err:
 	return 0;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	int i;
@@ -372,7 +367,6 @@ static struct ldmsd_sampler lnet_stats_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/loadavg/loadavg.c
+++ b/ldms/src/sampler/loadavg/loadavg.c
@@ -181,11 +181,6 @@ static const char *make_schema_name() {
 	return der_schema;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int create_metric_set(base_data_t base)
 {
 	ldms_schema_t schema;
@@ -451,7 +446,6 @@ static struct ldmsd_sampler loadavg_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/lustre/lustre2_client.c
+++ b/ldms/src/sampler/lustre/lustre2_client.c
@@ -434,11 +434,6 @@ BASE_CONFIG_DESC
 ;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	if (!set)
@@ -466,7 +461,6 @@ static struct ldmsd_sampler lustre_client_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/lustre/lustre2_mds.c
+++ b/ldms/src/sampler/lustre/lustre2_mds.c
@@ -295,11 +295,6 @@ BASE_CONFIG_DESC
 ;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	if (!set)
@@ -325,7 +320,6 @@ static struct ldmsd_sampler lustre_mds_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/lustre/lustre2_oss.c
+++ b/ldms/src/sampler/lustre/lustre2_oss.c
@@ -377,11 +377,6 @@ BASE_CONFIG_DESC
 ;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	if (!set)
@@ -407,7 +402,6 @@ static struct ldmsd_sampler lustre_oss_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/lustre_client/lustre_client.c
+++ b/ldms/src/sampler/lustre_client/lustre_client.c
@@ -292,11 +292,6 @@ static void term(struct ldmsd_plugin *self)
 		ovis_log_destroy(lustre_client_log);
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static const char *usage(struct ldmsd_plugin *self)
 {
         ovis_log(lustre_client_log, OVIS_LDEBUG, "usage() called\n");
@@ -311,7 +306,6 @@ static struct ldmsd_sampler llite_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/lustre_mdc/lustre_mdc.c
+++ b/ldms/src/sampler/lustre_mdc/lustre_mdc.c
@@ -284,11 +284,6 @@ static void term(struct ldmsd_plugin *self)
 		ovis_log_destroy(lustre_mdc_log);
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static const char *usage(struct ldmsd_plugin *self)
 {
 	ovis_log(lustre_mdc_log, OVIS_LDEBUG, "usage() called\n");
@@ -303,7 +298,6 @@ static struct ldmsd_sampler mdc_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/lustre_mdt/lustre_mdt.c
+++ b/ldms/src/sampler/lustre_mdt/lustre_mdt.c
@@ -253,11 +253,6 @@ static void term(struct ldmsd_plugin *self)
 		ovis_log_destroy(luster_mdt_log);
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static const char *usage(struct ldmsd_plugin *self)
 {
 	ovis_log(luster_mdt_log, OVIS_LDEBUG, SAMP" usage() called\n");
@@ -272,7 +267,6 @@ static struct ldmsd_sampler mdt_job_stats_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/lustre_ost/lustre_ost.c
+++ b/ldms/src/sampler/lustre_ost/lustre_ost.c
@@ -252,11 +252,6 @@ static void term(struct ldmsd_plugin *self)
 		ovis_log_destroy(lustre_ost_log);
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static const char *usage(struct ldmsd_plugin *self)
 {
         ovis_log(lustre_ost_log, OVIS_LDEBUG, "usage() called\n");
@@ -271,7 +266,6 @@ static struct ldmsd_sampler ost_job_stats_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/meminfo/meminfo.c
+++ b/ldms/src/sampler/meminfo/meminfo.c
@@ -203,11 +203,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	int rc;
@@ -265,7 +260,6 @@ static struct ldmsd_sampler meminfo_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/msr_interlagos/msr_interlagos.c
+++ b/ldms/src/sampler/msr_interlagos/msr_interlagos.c
@@ -1707,11 +1707,6 @@ static int sample(struct ldmsd_sampler *self)
 	return 0;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static void term(struct ldmsd_plugin *self)
 {
 	int i;
@@ -1752,7 +1747,6 @@ static struct ldmsd_sampler msr_interlagos_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/opa2/opa2.c
+++ b/ldms/src/sampler/opa2/opa2.c
@@ -502,11 +502,6 @@ static int SAPI(config)(struct ldmsd_plugin *self, struct attr_value_list *kwl, 
 	return 0;
 }
 
-static ldms_set_t SAPI(get_set)(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static int SAPI(sample)(struct ldmsd_sampler *self)
 {
 	int dec_val;
@@ -570,7 +565,6 @@ static struct ldmsd_sampler SAPI(plugin) = {
 		.config = SAPI(config),
 		.usage = SAPI(usage),
 	},
-	.get_set = SAPI(get_set),
 	.sample = SAPI(sample),
 };
 

--- a/ldms/src/sampler/papi/papi_sampler.c
+++ b/ldms/src/sampler/papi/papi_sampler.c
@@ -330,11 +330,6 @@ static const char *usage(struct ldmsd_plugin *self)
 		"     job_expiry    Number of seconds to retain sets for completed jobs. Defaults to 60s\n";
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static void sample_job(job_data_t job)
 {
 	long long values[64];
@@ -957,7 +952,6 @@ static struct ldmsd_sampler papi_sampler = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample
 };
 

--- a/ldms/src/sampler/perfevent/perfevent.c
+++ b/ldms/src/sampler/perfevent/perfevent.c
@@ -484,11 +484,6 @@ err2:
 	return 0;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	int rc;
@@ -589,7 +584,6 @@ static struct ldmsd_sampler pe_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/procdiskstats/procdiskstats.c
+++ b/ldms/src/sampler/procdiskstats/procdiskstats.c
@@ -463,11 +463,6 @@ out:
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static void term(struct ldmsd_plugin *self)
 {
 	if (mf)
@@ -504,7 +499,6 @@ static struct ldmsd_sampler procdiskstats_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/procinterrupts/procinterrupts.c
+++ b/ldms/src/sampler/procinterrupts/procinterrupts.c
@@ -74,12 +74,6 @@ static base_data_t base;
 
 static ovis_log_t mylog;
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
-
 static int getNProcs(char buf[]){
 	int nproc = 0;
 	char* pch;
@@ -302,7 +296,6 @@ static struct ldmsd_sampler procinterrupts_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/procnet/procnet.c
+++ b/ldms/src/sampler/procnet/procnet.c
@@ -109,11 +109,6 @@ struct kw {
 	int (*action)(struct attr_value_list *kwl, struct attr_value_list *avl, void *arg);
 };
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static void procnet_reset()
 {
 	if (mf)
@@ -488,7 +483,6 @@ static struct ldmsd_sampler procnet_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/procnetdev/procnetdev.c
+++ b/ldms/src/sampler/procnetdev/procnetdev.c
@@ -95,11 +95,6 @@ struct kw {
 	int (*action)(struct attr_value_list *kwl, struct attr_value_list *avl, void *arg);
 };
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int create_metric_set(base_data_t base)
 {
 	int rc;
@@ -371,7 +366,6 @@ static struct ldmsd_sampler procnetdev_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/procnetdev2/procnetdev2.c
+++ b/ldms/src/sampler/procnetdev2/procnetdev2.c
@@ -133,13 +133,6 @@ static base_data_t base;
 
 static ovis_log_t mylog;
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-        if (base)
-                return base->set;
-	return NULL;
-}
-
 static int create_metric_set(base_data_t base)
 {
 	ldms_schema_t schema;
@@ -436,7 +429,6 @@ static struct ldmsd_sampler procnetdev2_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/procnfs/procnfs.c
+++ b/ldms/src/sampler/procnfs/procnfs.c
@@ -124,11 +124,6 @@ static FILE *mf;
 static int metric_offset;
 static base_data_t base;
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int create_metric_set(base_data_t base)
 {
 	ldms_schema_t schema;
@@ -351,7 +346,6 @@ static struct ldmsd_sampler procnfs_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/procstat/procstat.c
+++ b/ldms/src/sampler/procstat/procstat.c
@@ -147,12 +147,6 @@ struct sampler_data {
 };
 // global instance, to become per instance later.
 
-
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return g.set;
-}
-
 /* records data, accounting for vagaries of cpu reporting in /proc/stat.
 On initial call of a sample, cpu_count, should have -1
 and it will be the size of the total stats row after that.
@@ -773,7 +767,6 @@ static struct ldmsd_sampler procstat_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/procstat2/procstat2.c
+++ b/ldms/src/sampler/procstat2/procstat2.c
@@ -464,11 +464,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 struct stat_row_ent {
 	const char *prefix;
 	enum stat_row type;
@@ -705,7 +700,6 @@ static struct ldmsd_sampler procstat2_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/rapl/rapl.c
+++ b/ldms/src/sampler/rapl/rapl.c
@@ -233,11 +233,6 @@ err:
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	int i;
@@ -308,7 +303,6 @@ static struct ldmsd_sampler rapl_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/rdc_sampler/rdc_plugin.c
+++ b/ldms/src/sampler/rdc_sampler/rdc_plugin.c
@@ -129,11 +129,6 @@ static void term() {
 	rdcinfo_delete(inst);
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static const char *usage(struct ldmsd_plugin *self) {
 	(void)self;
 	if (!usage_str)
@@ -149,7 +144,6 @@ static struct ldmsd_sampler plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/sampler_atasmart/sampler_atasmart.c
+++ b/ldms/src/sampler/sampler_atasmart/sampler_atasmart.c
@@ -358,11 +358,6 @@ err:
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 int atasmart_set_metric(SkDisk *d, SkSmartAttributeParsedData *a,
 				void *userdata)
 {
@@ -475,7 +470,6 @@ static struct ldmsd_sampler sampler_atasmart_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/shm/shm_sampler.c
+++ b/ldms/src/sampler/shm/shm_sampler.c
@@ -890,12 +890,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl,
 	return 0;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	ovis_log(mylog, OVIS_LINFO, "get_set called mistakenly\n");
-	return NULL;
-}
-
 static void check_box_activation(ldms_shm_box_t *box)
 {
 	if(!ldms_shm_set_is_active(box->shm_set)) {
@@ -1034,7 +1028,6 @@ static struct ldmsd_sampler shm_plugin = {
 			.config = config,
 			.usage = usage,
 		},
-		.get_set = get_set,
 		.sample = sample,
 };
 

--- a/ldms/src/sampler/slingshot_info/slingshot_info.c
+++ b/ldms/src/sampler/slingshot_info/slingshot_info.c
@@ -416,11 +416,6 @@ static void term(struct ldmsd_plugin *self)
         sampler_base = NULL;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static const char *usage(struct ldmsd_plugin *self)
 {
         ovis_log(mylog, OVIS_LDEBUG, "usage() called\n");
@@ -440,7 +435,6 @@ struct ldmsd_plugin *get_plugin()
                         .config = config,
                         .usage = usage,
                 },
-                .get_set = get_set,
                 .sample = sample,
         };
 

--- a/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
+++ b/ldms/src/sampler/slingshot_metrics/slingshot_metrics.c
@@ -620,11 +620,6 @@ static void term(struct ldmsd_plugin *self)
         ovis_log(mylog, OVIS_LDEBUG, "term() called\n");
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static const char *usage(struct ldmsd_plugin *self)
 {
         ovis_log(mylog, OVIS_LDEBUG, " usage() called\n");
@@ -644,7 +639,6 @@ struct ldmsd_plugin *get_plugin()
                         .config = config,
                         .usage = usage,
                 },
-                .get_set = get_set,
                 .sample = sample,
         };
 

--- a/ldms/src/sampler/slurm/slurm_sampler.c
+++ b/ldms/src/sampler/slurm/slurm_sampler.c
@@ -455,11 +455,6 @@ static const char *usage(struct ldmsd_plugin *self)
                 "     task_count    Set the length of the max number of tasks per job. Default set based on CPU\n";
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	return 0;
@@ -996,7 +991,6 @@ static struct ldmsd_sampler slurm_sampler = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample
 };
 

--- a/ldms/src/sampler/slurm/slurm_sampler2.c
+++ b/ldms/src/sampler/slurm/slurm_sampler2.c
@@ -1216,12 +1216,6 @@ static int sample(struct ldmsd_sampler *self)
 	return 0;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	/* no opt */
-	return NULL;
-}
-
 static struct ldmsd_sampler slurm2_plugin = {
 	.base = {
 		.name = SAMP,
@@ -1230,7 +1224,6 @@ static struct ldmsd_sampler slurm2_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/switchx.c
+++ b/ldms/src/sampler/switchx.c
@@ -409,11 +409,6 @@ static int sx_config(struct ldmsd_plugin *self, struct attr_value_list *kwl, str
 	return 0;
 }
 
-static ldms_set_t sx_get_set(struct ldmsd_sampler *self)
-{
-	return sx_ldms_sets[1].sx_set;
-}
-
 static int sx_sample_set(int port)
 {
 	int rc;
@@ -510,7 +505,6 @@ static struct ldmsd_sampler switchx_plugin = {
 		.config = sx_config,
 		.usage = usage,
 	},
-	.get_set = sx_get_set,
 	.sample = sx_sample,
 };
 

--- a/ldms/src/sampler/switchx_eth.c
+++ b/ldms/src/sampler/switchx_eth.c
@@ -353,11 +353,6 @@ static int sx_config(struct ldmsd_plugin *self, struct attr_value_list *kwl, str
 	return rc;
 }
 
-static ldms_set_t sx_get_set(struct ldmsd_sampler *self)
-{
-	return sx_ldms_sets[1].sx_set;
-}
-
 static int sx_sample_set(int log_port)
 {
 	int rc;
@@ -521,7 +516,6 @@ static struct ldmsd_sampler switchx_plugin = {
 		.config = sx_config,
 		.usage = usage,
 	},
-	.get_set = sx_get_set,
 	.sample = sx_sample,
 };
 

--- a/ldms/src/sampler/sysclassib/sysclassib.c
+++ b/ldms/src/sampler/sysclassib/sysclassib.c
@@ -605,11 +605,6 @@ err:
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 /**
  * Utility function for updating a single metric in a port.
  */
@@ -755,7 +750,6 @@ static struct ldmsd_sampler sysclassib_plugin = {
 		.config = config,
 		.usage = usage
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/syspapi/syspapi_sampler.c
+++ b/ldms/src/sampler/syspapi/syspapi_sampler.c
@@ -597,12 +597,6 @@ config(struct ldmsd_plugin *self, struct attr_value_list *kwl,
 	return rc;
 }
 
-static ldms_set_t
-get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int
 sample(struct ldmsd_sampler *self)
 {
@@ -740,7 +734,6 @@ static struct ldmsd_sampler syspapi_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/timer_base.c
+++ b/ldms/src/sampler/timer_base.c
@@ -101,12 +101,6 @@ uint64_t tv_to_u64(struct timeval tv)
 	return x;
 }
 
-ldms_set_t timer_base_get_set(struct ldmsd_sampler *self)
-{
-	struct timer_base *tb = (void*)self;
-	return tb->set;
-}
-
 int timer_base_create_metric_set(struct timer_base *tb)
 {
 	int rc = 0;
@@ -334,7 +328,6 @@ void timer_base_init(struct timer_base *tb)
 	tb->base.base.term = timer_base_term;
 	tb->base.base.config = __config;
 	tb->base.base.usage = timer_base_usage;
-	tb->base.get_set = timer_base_get_set;
 	tb->base.sample = timer_base_sample;
 	tb->state = TBS_INIT;
 	TAILQ_INIT(&tb->timer_list);

--- a/ldms/src/sampler/tsampler/timer_base.c
+++ b/ldms/src/sampler/tsampler/timer_base.c
@@ -101,12 +101,6 @@ uint64_t tv_to_u64(struct timeval tv)
 	return x;
 }
 
-ldms_set_t timer_base_get_set(struct ldmsd_sampler *self)
-{
-	struct timer_base *tb = (void*)self;
-	return tb->set;
-}
-
 int timer_base_create_metric_set(struct timer_base *tb)
 {
 	int rc = 0;
@@ -334,7 +328,6 @@ void timer_base_init(struct timer_base *tb)
 	tb->base.base.term = timer_base_term;
 	tb->base.base.config = __config;
 	tb->base.base.usage = timer_base_usage;
-	tb->base.get_set = timer_base_get_set;
 	tb->base.sample = timer_base_sample;
 	tb->state = TBS_INIT;
 	TAILQ_INIT(&tb->timer_list);

--- a/ldms/src/sampler/tsampler/timer_base.h
+++ b/ldms/src/sampler/tsampler/timer_base.h
@@ -87,8 +87,6 @@ int timer_base_config(struct ldmsd_plugin *self, struct attr_value_list *kwl,
 
 int timer_base_create_set(struct timer_base *tb);
 
-ldms_set_t timer_base_get_set(struct ldmsd_sampler *self);
-
 void timer_base_term(struct ldmsd_plugin *self);
 
 int timer_base_sample(struct ldmsd_sampler *self);

--- a/ldms/src/sampler/tx2mon/tx2mon.c
+++ b/ldms/src/sampler/tx2mon/tx2mon.c
@@ -624,11 +624,6 @@ static int sample(struct ldmsd_sampler *self)
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return sc;
-}
-
 static struct ldmsd_sampler tx2mon_plugin = {
 	.base = {
 		.name = SAMP,
@@ -637,7 +632,6 @@ static struct ldmsd_sampler tx2mon_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/variable/variable.c
+++ b/ldms/src/sampler/variable/variable.c
@@ -293,11 +293,6 @@ static int config(struct ldmsd_plugin *self, struct attr_value_list *kwl, struct
 	return 0;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	int rc;
@@ -371,7 +366,6 @@ static struct ldmsd_sampler variable_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/vmstat/vmstat.c
+++ b/ldms/src/sampler/vmstat/vmstat.c
@@ -77,10 +77,6 @@ static base_data_t base;
 
 static ovis_log_t mylog;
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
 #define LBUFSZ 256
 static int create_metric_set(base_data_t base)
 {
@@ -252,7 +248,6 @@ static struct ldmsd_sampler vmstat_plugin = {
 		.config = config,
 		.usage = usage
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 

--- a/ldms/src/sampler/zfs_leafvdevs/zfs_leafvdevs.c
+++ b/ldms/src/sampler/zfs_leafvdevs/zfs_leafvdevs.c
@@ -238,11 +238,6 @@ static void term(struct ldmsd_plugin *self)
 	sampler_base = NULL;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static const char *usage(struct ldmsd_plugin *self)
 {
 	ovis_log(mylog, OVIS_LDEBUG, SAMP " usage() called\n");
@@ -260,7 +255,6 @@ struct ldmsd_plugin *get_plugin()
 			 .config = config,
 			 .usage = usage,
 			 },
-		.get_set = get_set,
 		.sample = sample,
 	};
 

--- a/ldms/src/sampler/zfs_topvdevs/zfs_topvdevs.c
+++ b/ldms/src/sampler/zfs_topvdevs/zfs_topvdevs.c
@@ -245,11 +245,6 @@ static void term(struct ldmsd_plugin *self)
 
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static const char *usage(struct ldmsd_plugin *self)
 {
 	ovis_log(mylog, OVIS_LDEBUG, SAMP " usage() called\n");
@@ -267,7 +262,6 @@ struct ldmsd_plugin *get_plugin()
 			 .config = config,
 			 .usage = usage,
 			 },
-		.get_set = get_set,
 		.sample = sample,
 	};
 

--- a/ldms/src/sampler/zfs_zpool/zfs_zpool.c
+++ b/ldms/src/sampler/zfs_zpool/zfs_zpool.c
@@ -262,11 +262,6 @@ static void term(struct ldmsd_plugin *self)
 	sampler_base = NULL;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return NULL;
-}
-
 static const char *usage(struct ldmsd_plugin *self)
 {
 	ovis_log(mylog, OVIS_LDEBUG, SAMP " usage() called\n");
@@ -284,7 +279,6 @@ struct ldmsd_plugin *get_plugin()
 			 .config = config,
 			 .usage = usage,
 			 },
-		.get_set = get_set,
 		.sample = sample,
 	};
 	mylog = ovis_log_register("sampler."SAMP, "Message for the " SAMP " plugin");

--- a/ldms/src/third-plugins/my_plugin/src/my_plugin.c
+++ b/ldms/src/third-plugins/my_plugin/src/my_plugin.c
@@ -144,11 +144,6 @@ err:
 	return rc;
 }
 
-static ldms_set_t get_set(struct ldmsd_sampler *self)
-{
-	return set;
-}
-
 static int sample(struct ldmsd_sampler *self)
 {
 	union ldms_value v;
@@ -184,7 +179,6 @@ static struct ldmsd_sampler clock_plugin = {
 		.config = config,
 		.usage = usage,
 	},
-	.get_set = get_set,
 	.sample = sample,
 };
 


### PR DESCRIPTION
The get_set() function has been unused for a long time. Remove it.

Also remove the unused method "get_type()".