### PR TITLE
Fix null reference in ldms_xprt.c

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2665,8 +2665,8 @@ static void handle_rendezvous_lookup(zap_ep_t zep, zap_event_t ev,
 
 	if (lset) {
 		rc = EEXIST;
-		lset = NULL;	/* So error path won't try to delete it */
 		ref_put(&lset->ref, "__ldms_find_local_set");
+		lset = NULL;	/* So error path won't try to delete it */
 		/* unmap ev->map, it is not used */
 		zap_unmap(ev->map);
 		goto callback;


### PR DESCRIPTION
Move ref_put before assigning local set to NULL to avoid referencing a NULL address. Resolves segfault.