### PR TITLE
Fix `ldmsd_controller` completion without ldmsd connection

### DIFF
--- a/ldms/python/ldmsd/ldmsd_communicator.py
+++ b/ldms/python/ldmsd/ldmsd_communicator.py
@@ -226,6 +226,24 @@ LDMSD_CTRL_CMD_MAP = {'usage': {'req_attr': [], 'opt_attr': ['name']},
                       'prdcr_listen_status': {'req_attr': [], 'opt_attr': []},
                       }
 
+def get_cmd_attr_list(cmd_verb):
+    """Return the dictionary of command attributes
+
+    If there are no required/optional attributes, the value of the
+    'req'/'opt' key is None. Otherwise, the value is a list of attribute
+    names.
+
+    @return: {'req': [], 'opt': []}
+    """
+    attr_dict = {'req': [], 'opt': []}
+    if 'req_attr' in LDMSD_CTRL_CMD_MAP[cmd_verb]:
+        if len(LDMSD_CTRL_CMD_MAP[cmd_verb]['req_attr']) > 0:
+            attr_dict['req'] = LDMSD_CTRL_CMD_MAP[cmd_verb]['req_attr']
+    if 'opt_attr' in LDMSD_CTRL_CMD_MAP[cmd_verb]:
+        if len(LDMSD_CTRL_CMD_MAP[cmd_verb]['opt_attr']) > 0:
+            attr_dict['opt'] = LDMSD_CTRL_CMD_MAP[cmd_verb]['opt_attr']
+    return attr_dict
+
 def fmt_status(msg):
     """
     Format communicator status response string into json object
@@ -972,19 +990,12 @@ class Communicator(object):
         """Return the dictionary of command attributes
 
         If there are no required/optional attributes, the value of the
-        'req'/'opt' key is None. Otherweise, the value is a list of attribute
+        'req'/'opt' key is None. Otherwise, the value is a list of attribute
         names.
 
         @return: {'req': [], 'opt': []}
         """
-        attr_dict = {'req': [], 'opt': []}
-        if 'req_attr' in LDMSD_CTRL_CMD_MAP[cmd_verb]:
-            if len(LDMSD_CTRL_CMD_MAP[cmd_verb]['req_attr']) > 0:
-                attr_dict['req'] = LDMSD_CTRL_CMD_MAP[cmd_verb]['req_attr']
-        if 'opt_attr' in LDMSD_CTRL_CMD_MAP[cmd_verb]:
-            if len(LDMSD_CTRL_CMD_MAP[cmd_verb]['opt_attr']) > 0:
-                attr_dict['opt'] = LDMSD_CTRL_CMD_MAP[cmd_verb]['opt_attr']
-        return attr_dict
+        return get_cmd_attr_list(cmd_verb)
 
     def reconnect(self, timeout=0):
         if self.ldms:

--- a/ldms/python/ldmsd/ldmsd_controller
+++ b/ldms/python/ldmsd/ldmsd_controller
@@ -64,7 +64,7 @@ from datetime import datetime
 
 from ldmsd import ldmsd_util
 from ldmsd.ldmsd_communicator import LDMSD_Request, LDMSD_Req_Attr
-from ldmsd.ldmsd_communicator import Communicator, fmt_status
+from ldmsd.ldmsd_communicator import Communicator, fmt_status, get_cmd_attr_list
 import errno
 import math
 
@@ -116,13 +116,14 @@ class LdmsdCmdParser(cmd.Cmd):
             cmd.Cmd.__init__(self)
 
     def __complete_attr_list(self, verb, text):
-        req_opt_attr = self.comm.get_cmd_attr_list(verb)
+        req_opt_attr = get_cmd_attr_list(verb)
         attr_list = []
         if req_opt_attr['req'] is not None:
             attr_list = req_opt_attr['req']
         if req_opt_attr['opt'] is not None:
             attr_list += req_opt_attr['opt']
-        return ["{0}=".format(attr) for attr in attr_list if attr.startswith(text)]
+        ret = ["{0}=".format(attr) for attr in attr_list if attr.startswith(text)]
+        return ret
 
     def emptyline(self):
         pass
@@ -135,7 +136,7 @@ class LdmsdCmdParser(cmd.Cmd):
         return True
 
     def __check_command_args(self, verb, args):
-        req_opt_attr = self.comm.get_cmd_attr_list(verb)
+        req_opt_attr = get_cmd_attr_list(verb)
         if set(req_opt_attr['req']) <= set(args):
             return 0
         else:
@@ -210,7 +211,7 @@ class LdmsdCmdParser(cmd.Cmd):
     def handle_args(self, verb, _args):
         if _args and not self.__check_command_syntax(_args):
             print("Syntax error, there are attributes for which no value is given.")
-        req_opt_attr = self.comm.get_cmd_attr_list(verb)
+        req_opt_attr = get_cmd_attr_list(verb)
 
         if not self.comm:
             print("Error: no LDMS connection")


### PR DESCRIPTION
When there is no `ldmsd` connection, `ldmsd_controller` command parameter completion does not work. This patch fixes the issue.