### PR TITLE
Fix incorrect remote hostname and port produced by ldms_xprt_names()

### DIFF
--- a/ldms/src/core/ldms_xprt.c
+++ b/ldms/src/core/ldms_xprt.c
@@ -2185,7 +2185,7 @@ int ldms_xprt_names(ldms_t x, char *lcl_name, size_t lcl_name_sz,
 	}
 
 	if (rem_name || rem_port) {
-		(void)getnameinfo(&lcl, xlen, rem_name, rem_name_sz,
+		(void)getnameinfo(&rmt, xlen, rem_name, rem_name_sz,
 					rem_port, rem_port_sz, flags);
 	}
 	return 0;


### PR DESCRIPTION
Previosly, ldms_xprt_names() incorrectly passed the local address to getnameinfo() to obtain the remote hostname and port. This resulted in incorrect output.