### PR TITLE
fix device group detection for mellanox in filesingle in b4.4 on CTS2 machines

### DIFF
--- a/ldms/src/sampler/filesingle/ldms-sensors-config
+++ b/ldms/src/sampler/filesingle/ldms-sensors-config
@@ -1,5 +1,4 @@
 #! /usr/bin/env python2
-# $0: sensors_bin_path
 # Run sensors under strace to discover where sensor files
 # live on the current system and generate a draft file.
 import warnings
@@ -178,8 +177,9 @@ def main():
             if lastfiletype in ignore_types:
                 continue
             continue
-        if l.find(":") == -1:
-            lastgroup = l
+        # exclude   lines with "xxxxx:" and "sdf: bar" but allow : in mlx device names.
+        if ": " not in line and line[-1] != ':':
+            last_group = line
 
     for k,d in devices.iteritems():
         if len(d["items"]) > 0:
@@ -262,4 +262,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
mellanox device headings in the output of the 'sensors -u' command may include a colon embedded in the device name. Prior to this fix, the last_group variable would become unassigned for mlx devices, causing output failure.

also removes a trailing line and incorrect usage comment line.