### PR TITLE
Interpose rail update callback to inject rail handle during update

### DIFF
--- a/ldms/src/core/ldms.c
+++ b/ldms/src/core/ldms.c
@@ -773,10 +773,20 @@ int __ldms_xprt_update(ldms_t x, struct ldms_set *set, ldms_update_cb_t cb, void
 	return rc;
 }
 
+/* Implementation is in ldms_rail.c */
+ldms_t __ldms_xprt_to_rail(ldms_t x);
 int ldms_xprt_update(struct ldms_set *set, ldms_update_cb_t cb, void *arg)
 {
-	ldms_t x = set->xprt;
-	return x->ops.update(x, set, cb, arg);
+	/*
+	 * We convert the transport handle to a rail handle using
+	 * __ldms_xprt_to_rail() and pass it to x->ops.update().
+	 * This ensures that the update operation will be handled
+	 * by the __rail_update() function, which allows us to
+	 * interpose the rail update callback and deliver the rail handle
+	 * when the update completes.
+	 */
+	ldms_t r = __ldms_xprt_to_rail(set->xprt);
+	return r->ops.update(r, set, cb, arg);
 }
 
 void __ldms_set_on_xprt_term(ldms_set_t set, ldms_t xprt)

--- a/ldms/src/core/ldms_rail.c
+++ b/ldms/src/core/ldms_rail.c
@@ -1271,9 +1271,9 @@ struct ldms_rail_update_ctxt_s {
 
 void __rail_update_cb(ldms_t x, ldms_set_t s, int flags, void *arg)
 {
-	ldms_rail_t r = ldms_xprt_ctxt_get(x);
+	struct ldms_rail_ep_s *rep = ldms_xprt_ctxt_get(x);
 	ldms_rail_update_ctxt_t uc = arg;
-	uc->app_cb((ldms_t)r, s, flags, uc->cb_arg);
+	uc->app_cb((ldms_t)rep->rail, s, flags, uc->cb_arg);
 	if (!(flags & LDMS_UPD_F_MORE)) {
 		free(uc);
 	}
@@ -1292,7 +1292,7 @@ static int __rail_update(ldms_t _r, struct ldms_set *set,
 	uc->r = r;
 	uc->app_cb = cb;
 	uc->cb_arg = arg;
-	rc = ldms_xprt_update(set, __rail_update_cb, uc);
+	rc = set->xprt->ops.update(set->xprt, set, __rail_update_cb, uc);
 	if (rc) {
 		/* synchronously error, clean up the context */
 		free(uc);


### PR DESCRIPTION
Ensure that the update operation is handled by `__rail_update()`, allowing the rail handle to be delivered upon update completion