### PR TITLE
Fix LDMS rail max_mgs

### DIFF
--- a/ldms/src/core/ldms_rail.c
+++ b/ldms/src/core/ldms_rail.c
@@ -1102,7 +1102,8 @@ static int __rail_send(ldms_t _r, char *msg_buf, size_t msg_len)
 static size_t __rail_msg_max(ldms_t _r)
 {
 	ldms_rail_t r = (ldms_rail_t)_r;
-	return r->max_msg;
+	return	r->max_msg - (sizeof(struct ldms_request_hdr) +
+			sizeof(struct ldms_send_cmd_param));
 }
 
 /* interposer */


### PR DESCRIPTION
rail->max_msg() shall return the maximum length of data the application can send. Thus, it is underlying zap max_msg less the size of LDMS message header.